### PR TITLE
Record pre-execution failures in timeline and flow

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -449,56 +449,79 @@ impl ApiService for AppState {
             "Executing action"
         );
 
+        let request_ctx = cmd.clone();
+
         let exec = {
             let mut campaign = self.campaign.write().map_err(|_| {
                 error!("campaign lock poisoned while executing action");
                 ApiError::internal("campaign lock poisoned")
             })?;
 
-            let exec = campaign
-                .prepare_action(cmd, &self.armory)
-                .map_err(|err| match err {
-                    ExecuteActionError::InvalidInput(message) => {
-                        error!("execute_action invalid input: {}", message);
-                        ApiError {
-                            status: axum::http::StatusCode::BAD_REQUEST,
-                            body: api::ErrorResponse {
-                                error: message,
-                                details: None,
-                            },
+            let exec = match campaign.prepare_action(cmd, &self.armory) {
+                Ok(exec) => exec,
+                Err(err) => {
+                    let (record, ttp) =
+                        campaign.record_preparation_failure(&request_ctx, &self.armory, &err);
+                    drop(campaign);
+
+                    let _ = self.campaign_events.publish(CampaignEvent::TtpExecuted {
+                        cmd_id: record.id,
+                        action_id: record.ttp_id,
+                        target_id: record.target_id,
+                        exec_system_id: record.exec_system_id,
+                        ttp: Box::new(ttp),
+                        args: record.args,
+                        success: false,
+                        fail_reason: record.fail_reason,
+                        results: record.results,
+                        exit_code: -1,
+                    });
+
+                    let api_error = match err {
+                        ExecuteActionError::InvalidInput(message) => {
+                            error!("execute_action invalid input: {}", message);
+                            ApiError {
+                                status: axum::http::StatusCode::BAD_REQUEST,
+                                body: api::ErrorResponse {
+                                    error: message,
+                                    details: None,
+                                },
+                            }
                         }
-                    }
-                    ExecuteActionError::NotFound(message) => {
-                        error!("execute_action not found: {}", message);
-                        ApiError {
-                            status: axum::http::StatusCode::NOT_FOUND,
-                            body: api::ErrorResponse {
-                                error: message,
-                                details: None,
-                            },
+                        ExecuteActionError::NotFound(message) => {
+                            error!("execute_action not found: {}", message);
+                            ApiError {
+                                status: axum::http::StatusCode::NOT_FOUND,
+                                body: api::ErrorResponse {
+                                    error: message,
+                                    details: None,
+                                },
+                            }
                         }
-                    }
-                    ExecuteActionError::NoExecChannel(message) => {
-                        error!("execute_action no exec channel: {}", message);
-                        ApiError {
-                            status: axum::http::StatusCode::UNPROCESSABLE_ENTITY,
-                            body: api::ErrorResponse {
-                                error: message,
-                                details: None,
-                            },
+                        ExecuteActionError::NoExecChannel(message) => {
+                            error!("execute_action no exec channel: {}", message);
+                            ApiError {
+                                status: axum::http::StatusCode::UNPROCESSABLE_ENTITY,
+                                body: api::ErrorResponse {
+                                    error: message,
+                                    details: None,
+                                },
+                            }
                         }
-                    }
-                    ExecuteActionError::InvariantViolation(message) => {
-                        error!("execute_action invariant violation: {}", message);
-                        ApiError {
-                            status: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-                            body: api::ErrorResponse {
-                                error: message,
-                                details: None,
-                            },
+                        ExecuteActionError::InvariantViolation(message) => {
+                            error!("execute_action invariant violation: {}", message);
+                            ApiError {
+                                status: axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                                body: api::ErrorResponse {
+                                    error: message,
+                                    details: None,
+                                },
+                            }
                         }
-                    }
-                })?;
+                    };
+                    return Err(api_error);
+                }
+            };
             // Capture the decision under the operator's *actual* pre-action
             // conditions (zero reconstruction) for calibration. `prepare_action`
             // only grounded the command — no effects applied yet — so this is the

--- a/crates/campaign/src/campaign/execution.rs
+++ b/crates/campaign/src/campaign/execution.rs
@@ -552,6 +552,40 @@ impl Campaign {
         Ok(exec)
     }
 
+    /// Persist a failed execution attempt that never reached dispatch.
+    ///
+    /// Preparation can fail before an [`ExecTtp`] exists, so this records the
+    /// original request and returns a TTP description suitable for the
+    /// terminal campaign event published by the caller.
+    pub fn record_preparation_failure(
+        &mut self,
+        request: &ExecuteActionRequest,
+        armory: &Armory,
+        error: &ExecuteActionError,
+    ) -> (ExecutionRecord, Ttp) {
+        let cmd_id = generate_cmd_id();
+        let ttp = armory
+            .get_ttp(&request.action_id)
+            .cloned()
+            .unwrap_or_else(|| Ttp::new(&request.action_id, &request.action_id, ""));
+        let reason = match error {
+            ExecuteActionError::InvalidInput(reason)
+            | ExecuteActionError::NotFound(reason)
+            | ExecuteActionError::NoExecChannel(reason)
+            | ExecuteActionError::InvariantViolation(reason) => reason.clone(),
+        };
+        let record = ExecutionRecord::from_preparation_failure(
+            cmd_id,
+            request,
+            ttp.name.clone(),
+            ttp.tactic.clone(),
+            reason,
+        );
+
+        self.execution_records.push(record.clone());
+        (record, ttp)
+    }
+
     /// Internal pipeline: stages 2-6 of action preparation.
     ///
     /// Called by both `prepare_action` (normal attack steps) and

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -687,6 +687,95 @@ fn action_request(target_id: &str, exec_system_id: Option<&str>) -> ExecuteActio
 }
 
 #[test]
+fn record_preparation_failure_preserves_known_ttp_and_request_context() {
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+    let armory = Armory::from_ttps(vec![Ttp::new(
+        "test-ttp",
+        "Test Preparation Failure",
+        "Discovery",
+    )]);
+    let request = ExecuteActionRequest {
+        action_id: "test-ttp".to_string(),
+        target_id: "ns/default/pod/demo".to_string(),
+        exec_system_id: Some("custom-backend".to_string()),
+        procedure_id: Some("shell".to_string()),
+        args: HashMap::from([("Namespace".to_string(), "default".to_string())]),
+        reasoning: Some("verify unavailable channel".to_string()),
+    };
+    let error = ExecuteActionError::NoExecChannel("no route to target".to_string());
+
+    let (record, ttp) = campaign.record_preparation_failure(&request, &armory, &error);
+
+    assert!(record.id.starts_with("cmd-"));
+    assert_eq!(record.ttp_id, "test-ttp");
+    assert_eq!(record.ttp_name, "Test Preparation Failure");
+    assert_eq!(record.tactic, "Discovery");
+    assert_eq!(record.target_id, "ns/default/pod/demo");
+    assert_eq!(record.exec_system_id, "custom-backend");
+    assert_eq!(record.procedure_id, "shell");
+    assert_eq!(record.args, request.args);
+    assert_eq!(record.reasoning, "verify unavailable channel");
+    assert!(record.command.is_empty());
+    assert!(!record.success);
+    assert_eq!(record.exit_code, -1);
+    assert_eq!(record.results, vec!["no route to target"]);
+    assert_eq!(record.fail_reason, "no route to target");
+    assert_eq!(record.started_at_ms, record.completed_at_ms);
+    assert!(!record.is_cleanup);
+    assert_eq!(ttp.id, "test-ttp");
+    assert_eq!(ttp.name, "Test Preparation Failure");
+    assert_eq!(campaign.get_execution_records().len(), 1);
+    assert_eq!(campaign.get_execution_records()[0].id, record.id);
+    assert!(campaign.get_open_steps().is_empty());
+}
+
+#[test]
+fn record_preparation_failure_synthesizes_ttp_for_every_error_variant() {
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+    let armory = Armory::from_ttps(Vec::new());
+    let request = ExecuteActionRequest {
+        action_id: "unknown-ttp".to_string(),
+        target_id: "unknown-target".to_string(),
+        exec_system_id: None,
+        procedure_id: None,
+        args: HashMap::new(),
+        reasoning: None,
+    };
+    let errors = [
+        ExecuteActionError::InvalidInput("invalid input".to_string()),
+        ExecuteActionError::NotFound("not found".to_string()),
+        ExecuteActionError::NoExecChannel("no channel".to_string()),
+        ExecuteActionError::InvariantViolation("invariant violation".to_string()),
+    ];
+
+    for (index, error) in errors.iter().enumerate() {
+        let expected_reason = match error {
+            ExecuteActionError::InvalidInput(reason)
+            | ExecuteActionError::NotFound(reason)
+            | ExecuteActionError::NoExecChannel(reason)
+            | ExecuteActionError::InvariantViolation(reason) => reason,
+        };
+        let (record, ttp) = campaign.record_preparation_failure(&request, &armory, error);
+
+        assert_eq!(record.fail_reason, *expected_reason);
+        assert_eq!(record.results, vec![expected_reason.clone()]);
+        assert_eq!(record.ttp_id, "unknown-ttp");
+        assert_eq!(record.ttp_name, "unknown-ttp");
+        assert!(record.tactic.is_empty());
+        assert!(record.exec_system_id.is_empty());
+        assert!(record.procedure_id.is_empty());
+        assert!(!record.success);
+        assert_eq!(record.exit_code, -1);
+        assert_eq!(ttp.id, "unknown-ttp");
+        assert_eq!(ttp.name, "unknown-ttp");
+        assert!(ttp.tactic.is_empty());
+        assert_eq!(campaign.get_execution_records().len(), index + 1);
+    }
+
+    assert!(campaign.get_open_steps().is_empty());
+}
+
+#[test]
 fn prepare_action_auto_resolves_channel_from_graph() {
     let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
     let pod = Pod::new("demo", "default");

--- a/crates/campaign/src/execution_record.rs
+++ b/crates/campaign/src/execution_record.rs
@@ -4,6 +4,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use c2::{ExecTtp, TtpExecuted};
 use serde::{Deserialize, Serialize};
 
+use crate::ExecuteActionRequest;
+
 /// A single recorded execution — the grounded command, its arguments, and the
 /// raw results returned by the C2 backend.  This forms the append-only audit
 /// trail for a campaign session.
@@ -50,6 +52,41 @@ pub struct ExecutionRecord {
 }
 
 impl ExecutionRecord {
+    /// Build an audit record for an action that failed before it could be
+    /// grounded or dispatched to a C2 backend.
+    pub fn from_preparation_failure(
+        cmd_id: String,
+        request: &ExecuteActionRequest,
+        ttp_name: String,
+        tactic: String,
+        reason: String,
+    ) -> Self {
+        let now_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        Self {
+            id: cmd_id,
+            ttp_id: request.action_id.clone(),
+            ttp_name,
+            tactic,
+            target_id: request.target_id.clone(),
+            exec_system_id: request.exec_system_id.clone().unwrap_or_default(),
+            procedure_id: request.procedure_id.clone().unwrap_or_default(),
+            command: String::new(),
+            args: request.args.clone(),
+            success: false,
+            exit_code: -1,
+            results: vec![reason.clone()],
+            fail_reason: reason,
+            started_at_ms: now_ms,
+            completed_at_ms: now_ms,
+            is_cleanup: false,
+            reasoning: request.reasoning.clone().unwrap_or_default(),
+        }
+    }
+
     pub fn from_execution(cmd: &ExecTtp, event: &TtpExecuted) -> Self {
         let completed_at_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)


### PR DESCRIPTION
Persists failed execution records for all action-preparation errors, including requests that never resolve a dispatch channel. Publishes terminal TtpExecuted events while preserving existing HTTP status mapping and avoiding dispatched/open steps; unknown TTP IDs receive minimal metadata. Adds tests for request context, TTP fallback, failure variants, and record invariants. Validation: cargo build, focused tests, and app service tests pass; cargo test -p campaign has 363 passes and only the two pre-existing explicit-source routing failures.