### PR TITLE
Assimilate kubeconfig credentials into campaign actions

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -84,6 +84,38 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/eligible-auth-identities:
+    get:
+      summary: Get eligible Kubernetes authentication identities
+      description: Returns identities satisfying the action's authentication and RBAC requirements for the selected target.
+      operationId: getEligibleAuthIdentities
+      parameters:
+        - name: actionId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: targetId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Eligible identities
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/AuthIdentity'
+        '404':
+          description: Action or target not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /api/recommendations:
     get:
       summary: Rank recommended next actions
@@ -670,6 +702,11 @@ components:
           type: boolean
         isRunning:
           type: boolean
+        provenance:
+          type: array
+          items:
+            type: string
+            enum: [scenario, operator, action, inference]
 
     Edge:
       type: object
@@ -696,6 +733,11 @@ components:
         sessionId:
           type: string
           description: Backend ID of the active persistent session on this exec-channel edge, if any.
+        provenance:
+          type: array
+          items:
+            type: string
+            enum: [scenario, operator, action, inference]
 
     CampaignState:
       type: object
@@ -980,6 +1022,9 @@ components:
           type: string
         execSystemId:
           type: string
+        authIdentityId:
+          type: string
+          description: Entity ID of the ServiceAccount or active K8sCredential used for Kubernetes authentication.
         targetId:
           type: string
         procedureId:
@@ -996,6 +1041,20 @@ components:
             strongly encouraged when driving the campaign programmatically: it
             is stored on the resulting execution record so the timeline is
             self-explaining and auditable.
+
+    AuthIdentity:
+      type: object
+      required:
+        - id
+        - name
+        - kind
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        kind:
+          type: string
 
     K8sResource:
       type: object
@@ -1033,6 +1092,8 @@ components:
             $ref: '#/components/schemas/RBACPermission'
         accessLevel:
           type: string
+        activeKubeconfig:
+          type: boolean
         exists:
           type: array
           items:
@@ -1105,6 +1166,9 @@ components:
         exec_system_id:
           type: string
           description: ID of the system that ran the command; empty for direct builtin exec
+        auth_identity_id:
+          type: string
+          description: ID of the Kubernetes authentication identity selected for the action
         procedure_id:
           type: string
         command:

--- a/armory/TTPs/Discovery/check_kubeconfig_permissions.yaml
+++ b/armory/TTPs/Discovery/check_kubeconfig_permissions.yaml
@@ -1,0 +1,19 @@
+name: Check Kubeconfig Permissions
+description: Query the Kubernetes API for permissions granted to the active kubeconfig identity
+tactic: Discovery
+techniques: ["Permission Groups Discovery", "T1069.003"]
+parameters:
+  NS:
+    type: Namespace
+    description: Namespace in which namespaced permissions should be evaluated
+    default: default
+preconditions:
+  kind: K8sCredential
+  activeKubeconfig: true
+procedures:
+  - key: k8s-client
+    command: k8sSelfSubjectRulesReview(${NS})
+    isLocal: true
+effects:
+  - k8s.SelfSubjectRulesReview
+references: []

--- a/armory/TTPs/Discovery/get_namespaces.yaml
+++ b/armory/TTPs/Discovery/get_namespaces.yaml
@@ -1,0 +1,30 @@
+id: get-namespaces
+name: Get Namespaces via K8s API
+description: Get a list of namespaces from the Kubernetes API server
+tactic: Discovery
+techniques: ["Container and Resource Discovery", "T1613"]
+preconditions:
+  rbac:
+    - verb: list
+      resource: namespaces
+parameters:
+  TOKEN:
+    type: ServiceAccount
+    description: The ServiceAccount token used to authorize this request
+    optional: true
+    default: ""
+procedures:
+  - key: kubectl
+    command: kubectl get namespaces --token=${TOKEN} --output=json
+  - key: k8s-request
+    k8s_request:
+      api_server: ${API_SERVER}
+      api: /api/v1
+      resource: namespaces
+      cluster_scoped: true
+      query: limit=500
+      token: ${TOKEN}
+      ca_path: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+effects:
+  - k8s.namespaceList
+references: []

--- a/crates/api/src/api_handlers.rs
+++ b/crates/api/src/api_handlers.rs
@@ -4,7 +4,9 @@ use axum::extract::{Query, State};
 use chrono::{DateTime, Utc};
 use tracing::debug;
 
-use campaign::ttp_applicability::{resolve_target_context, ttp_applicable_for_target};
+use campaign::ttp_applicability::{
+    eligible_auth_identities, resolve_target_context, ttp_applicable_for_target,
+};
 
 use crate::sse::events_handler;
 use crate::state_conversions::{campaign_to_campaign_state, campaign_to_graph};
@@ -97,6 +99,14 @@ pub(crate) struct GetApplicableTtpsParams {
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
+pub(crate) struct GetEligibleAuthIdentitiesParams {
+    #[serde(rename = "actionId")]
+    pub(crate) action_id: String,
+    #[serde(rename = "targetId")]
+    pub(crate) target_id: String,
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
 pub(crate) struct GetRecommendationsParams {
     /// Optional: restrict recommendations to a single target entity.
     #[serde(rename = "targetId")]
@@ -111,6 +121,8 @@ pub(crate) struct ExecuteActionCmdPayload {
     pub(crate) action_id: String,
     #[serde(rename = "execSystemId")]
     pub(crate) exec_system_id: Option<String>,
+    #[serde(rename = "authIdentityId")]
+    pub(crate) auth_identity_id: Option<String>,
     #[serde(rename = "targetId")]
     pub(crate) target_id: String,
     #[serde(rename = "procedureId")]
@@ -203,6 +215,34 @@ pub(crate) async fn applicable_ttps_handler<S: ApiService>(
         .collect::<Vec<_>>();
 
     Ok(axum::Json(ttps))
+}
+
+pub(crate) async fn eligible_auth_identities_handler<S: ApiService>(
+    State(service): State<S>,
+    Query(params): Query<GetEligibleAuthIdentitiesParams>,
+) -> Result<axum::Json<Vec<campaign::AuthIdentitySummary>>, ApiError> {
+    let ttp = service
+        .get_armory(GetArmoryParams { tactic: None })
+        .await?
+        .into_iter()
+        .find(|ttp| ttp.id == params.action_id)
+        .ok_or_else(|| ApiError::not_found(format!("unknown action '{}'", params.action_id)))?;
+    let campaign = service.get_campaign().await?;
+    if !campaign
+        .get_entities()
+        .iter()
+        .any(|entity| entity.entity_id().0 == params.target_id)
+    {
+        return Err(ApiError::not_found(format!(
+            "unknown target '{}'",
+            params.target_id
+        )));
+    }
+    Ok(axum::Json(eligible_auth_identities(
+        &ttp,
+        &campaign,
+        &params.target_id,
+    )))
 }
 
 /// Rank applicable `(TTP × target)` actions by utility for the current campaign
@@ -436,6 +476,7 @@ pub(crate) async fn execute_action_handler<S: ApiService>(
         .execute_action(campaign::ExecuteActionRequest {
             action_id: cmd.action_id,
             exec_system_id: cmd.exec_system_id,
+            auth_identity_id: cmd.auth_identity_id,
             target_id: cmd.target_id,
             procedure_id: cmd.procedure_id,
             args: cmd.args.unwrap_or_default(),

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -36,6 +36,10 @@ pub fn router_with_sse<S: ApiService>(service: S) -> axum::Router {
             axum::routing::get(api_handlers::applicable_ttps_handler::<S>),
         )
         .route(
+            "/api/eligible-auth-identities",
+            axum::routing::get(api_handlers::eligible_auth_identities_handler::<S>),
+        )
+        .route(
             "/api/recommendations",
             axum::routing::get(api_handlers::recommendations_handler::<S>),
         )

--- a/crates/api/src/mcp.rs
+++ b/crates/api/src/mcp.rs
@@ -312,6 +312,10 @@ impl<S: ApiService> RanMcpHandler<S> {
         let reasoning = opt_str(args, "reasoning")
             .map(str::to_owned)
             .filter(|s| !s.trim().is_empty());
+        let auth_identity_id = opt_str(args, "auth_identity_id")
+            .or_else(|| opt_str(args, "authIdentityId"))
+            .map(str::to_owned)
+            .filter(|s| !s.trim().is_empty());
 
         let result = self
             .api
@@ -319,6 +323,7 @@ impl<S: ApiService> RanMcpHandler<S> {
                 action_id,
                 target_id,
                 exec_system_id,
+                auth_identity_id,
                 procedure_id,
                 args: extra_args,
                 reasoning,
@@ -660,6 +665,7 @@ fn tool_defs() -> Vec<Tool> {
                     "action_id": { "type": "string", "description": "TTP ID to execute" },
                     "target_id": { "type": "string", "description": "Entity ID to execute against" },
                     "exec_system_id": { "type": "string", "description": "ID of the system to run the command from (optional)" },
+                    "auth_identity_id": { "type": "string", "description": "Eligible ServiceAccount or active K8sCredential entity ID used for Kubernetes authentication (optional)" },
                     "procedure_id": { "type": "string", "description": "Specific procedure variant to use (optional)" },
                     "args": { "type": "object", "description": "TTP parameter overrides (key-value string pairs)", "additionalProperties": { "type": "string" } },
                     "reasoning": { "type": "string", "description": "STRONGLY ENCOURAGED. Your rationale for running this action at this point in the assessment: what you expect it to reveal or achieve, why this target, and how it follows from prior findings. Recorded on the execution record for audit and replay. Provide it on every call unless truly trivial." }

--- a/crates/api/src/state_conversions.rs
+++ b/crates/api/src/state_conversions.rs
@@ -34,6 +34,10 @@ pub(crate) fn campaign_to_campaign_state(campaign: &Campaign) -> CampaignState {
                 data.entry(k).or_insert(v);
             }
         }
+        data.insert(
+            "provenance".to_string(),
+            provenance_value(campaign.entity_provenance(&entity.entity_id())),
+        );
 
         entities.insert(id, data);
     }
@@ -55,6 +59,14 @@ pub(crate) fn campaign_to_campaign_state(campaign: &Campaign) -> CampaignState {
                 if let Some(ref sid) = r.session_id {
                     m.insert("sessionId".to_string(), Value::String(sid.clone()));
                 }
+                m.insert(
+                    "provenance".to_string(),
+                    provenance_value(campaign.relation_provenance(
+                        &r.name,
+                        &r.source_id,
+                        &r.target_id,
+                    )),
+                );
                 m
             })
             .collect(),
@@ -110,6 +122,11 @@ pub(crate) fn campaign_to_graph(campaign: &Campaign) -> Graph {
                     },
                     relation: None,
                     session_id: r.session_id.clone(),
+                    provenance: Some(provenance_strings(campaign.relation_provenance(
+                        &r.name,
+                        &r.source_id,
+                        &r.target_id,
+                    ))),
                 });
             }
         }
@@ -147,6 +164,10 @@ pub(crate) fn campaign_to_graph(campaign: &Campaign) -> Graph {
             _ => None,
         };
 
+        let mut entity_payload = serialize_campaign_entity_map(&entity);
+        if let Some(ref mut payload) = entity_payload {
+            prune_entity_payload_for_ui(entity.entity_kind(), payload);
+        }
         nodes.push(GraphNode {
             id: id.clone(),
             entity_id: id,
@@ -162,7 +183,10 @@ pub(crate) fn campaign_to_graph(campaign: &Campaign) -> Graph {
                 ),
                 _ => None,
             },
-            entity: serialize_campaign_entity_map(&entity),
+            entity: entity_payload,
+            provenance: Some(provenance_strings(
+                campaign.entity_provenance(&entity.entity_id()),
+            )),
         });
     }
 
@@ -243,7 +267,7 @@ fn prune_entity_payload_for_ui(kind: &str, data: &mut HashMap<String, Value>) {
         data.remove("accessLevel");
     }
 
-    if kind == "ServiceAccount" {
+    if kind == "ServiceAccount" || kind == "K8sCredential" {
         // Rename `entitlements` → `can` and convert each permission's snake_case
         // field names to the camelCase names the frontend EntitlementInfo component expects.
         if let Some(entitlements) = data.remove("entitlements") {
@@ -255,6 +279,37 @@ fn prune_entity_payload_for_ui(kind: &str, data: &mut HashMap<String, Value>) {
             }
         }
     }
+
+    if kind == "K8sCredential" {
+        data.remove("token");
+        data.remove("cert_data");
+        data.remove("key_data");
+        data.remove("ca_data");
+    }
+}
+
+fn provenance_strings(
+    origins: std::collections::BTreeSet<campaign::KnowledgeProvenance>,
+) -> Vec<String> {
+    origins
+        .into_iter()
+        .map(|origin| match origin {
+            campaign::KnowledgeProvenance::Scenario => "scenario",
+            campaign::KnowledgeProvenance::Operator => "operator",
+            campaign::KnowledgeProvenance::Action => "action",
+            campaign::KnowledgeProvenance::Inference => "inference",
+        })
+        .map(str::to_string)
+        .collect()
+}
+
+fn provenance_value(origins: std::collections::BTreeSet<campaign::KnowledgeProvenance>) -> Value {
+    Value::Array(
+        provenance_strings(origins)
+            .into_iter()
+            .map(Value::String)
+            .collect(),
+    )
 }
 
 /// Convert a serialized `Vec<RbacPermission>` (snake_case keys) into the
@@ -308,4 +363,83 @@ fn is_unknown_enum_value(value: &Value) -> bool {
 
 fn is_access_level_none(value: &Value) -> bool {
     matches!(value, Value::String(s) if s == "none")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use campaign::{
+        InitialClusterKnowledge, InitialKnowledge, InitialKubeconfigKnowledge, KnowledgeProvenance,
+    };
+    use ran_domain::{Entity, K8sCluster, K8sCredential, RbacPermission};
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn credential_payload_is_redacted_and_provenance_is_exposed() {
+        let cluster = K8sCluster::new("demo").with_server(Some("https://demo".into()));
+        let cluster_id = cluster.entity_id();
+        let mut credential = K8sCredential::new("https://demo").with_name("developer");
+        credential.token = Some("super-secret".into());
+        credential.key_data = Some("private-key".into());
+        credential.cert_data = Some("certificate".into());
+        credential.ca_data = Some("ca".into());
+        credential.has_token = true;
+        credential
+            .entitlements
+            .push(RbacPermission::new("list", "pods"));
+        let credential_id = credential.entity_id();
+        let origins = BTreeSet::from([KnowledgeProvenance::Scenario]);
+        let campaign = Campaign::bootstrap_with_knowledge(
+            "test",
+            InitialKnowledge {
+                clusters: vec![InitialClusterKnowledge {
+                    cluster,
+                    provenance: origins.clone(),
+                }],
+                kubeconfigs: vec![InitialKubeconfigKnowledge {
+                    credential,
+                    cluster_id,
+                    provenance: origins,
+                }],
+            },
+        );
+
+        let state = campaign_to_campaign_state(&campaign);
+        let payload = state.entities.get(&credential_id.0).unwrap();
+        assert_eq!(
+            payload.get("provenance"),
+            Some(&serde_json::json!(["scenario"]))
+        );
+        for secret in ["token", "key_data", "cert_data", "ca_data"] {
+            assert!(!payload.contains_key(secret));
+        }
+        assert_eq!(
+            payload.get("can"),
+            Some(&serde_json::json!([{
+                "verb": "list",
+                "resourceType": "pods",
+                "resourceName": null,
+                "apiGroup": null,
+                "scope": null,
+                "sourceRole": null
+            }]))
+        );
+
+        let graph = campaign_to_graph(&campaign);
+        let node = graph
+            .nodes
+            .iter()
+            .find(|node| node.id == credential_id.0)
+            .unwrap();
+        assert_eq!(
+            node.provenance.as_deref(),
+            Some(["scenario".to_string()].as_slice())
+        );
+        let entity = node.entity.as_ref().unwrap();
+        assert!(!entity.contains_key("token"));
+        assert!(graph.edges.iter().any(|edge| {
+            edge.name == "authenticates-to"
+                && edge.provenance.as_deref() == Some(["scenario".to_string()].as_slice())
+        }));
+    }
 }

--- a/crates/app/src/config.rs
+++ b/crates/app/src/config.rs
@@ -11,6 +11,8 @@ pub struct Config {
     pub namespaces: NamespaceFilter,
     pub scoring: ScoringConfig,
     pub plans: PlansConfig,
+    #[serde(rename = "seedKnowledge")]
+    pub seed_knowledge: Vec<SeedKnowledgeConfig>,
 }
 
 impl Config {
@@ -54,6 +56,39 @@ impl ScoringConfig {
             ..utility_ai::Profile::default()
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum SeedKnowledgeConfig {
+    Cluster(SeedClusterConfig),
+    Credential(SeedCredentialConfig),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeedClusterConfig {
+    pub id: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub server: Option<String>,
+    #[serde(default)]
+    pub context_name: Option<String>,
+    pub provenance: campaign::KnowledgeProvenance,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SeedCredentialConfig {
+    pub credential_type: String,
+    pub id: String,
+    pub path: PathBuf,
+    #[serde(default)]
+    pub context: Option<String>,
+    #[serde(default)]
+    pub cluster: Option<String>,
+    pub provenance: campaign::KnowledgeProvenance,
 }
 
 /// Controls which namespaces are visible during discovery.
@@ -108,8 +143,35 @@ pub fn load(path: Option<PathBuf>) -> Result<Config> {
         }
     };
 
-    let cfg: Config = serde_yaml::from_slice(&data)
+    let mut cfg: Config = serde_yaml::from_slice(&data)
         .map_err(|e| anyhow::anyhow!("failed to parse {}: {}", path.display(), e))?;
+
+    let base_dir = path.parent().unwrap_or_else(|| std::path::Path::new("."));
+    for seed in &mut cfg.seed_knowledge {
+        if let SeedKnowledgeConfig::Credential(credential) = seed {
+            if credential.credential_type != "kubeconfig" {
+                return Err(anyhow::anyhow!(
+                    "unsupported credentialType '{}' for seed '{}'",
+                    credential.credential_type,
+                    credential.id
+                ));
+            }
+            if credential.path.is_relative() {
+                credential.path = base_dir.join(&credential.path);
+            }
+        }
+    }
+
+    let mut ids = std::collections::HashSet::new();
+    for seed in &cfg.seed_knowledge {
+        let id = match seed {
+            SeedKnowledgeConfig::Cluster(cluster) => &cluster.id,
+            SeedKnowledgeConfig::Credential(credential) => &credential.id,
+        };
+        if !ids.insert(id.clone()) {
+            return Err(anyhow::anyhow!("duplicate seedKnowledge id '{}'", id));
+        }
+    }
 
     debug!(path = %path.display(), "config loaded");
     Ok(cfg)

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod config;
 
 use std::{
+    collections::BTreeSet,
     net::SocketAddr,
     path::PathBuf,
     sync::{Arc, Mutex, RwLock},
@@ -19,11 +20,12 @@ use api::{ApiError, ApiService, GetRunningPodsParams, K8sResource};
 use campaign::{
     spawn_c2_event_processor_with_external_parser, Campaign, CampaignEvent, CampaignEventBus,
     EntitySummary, ExecuteActionError, ExecuteActionRequest, ExecuteActionResult,
-    ExternalParseRequest, ExternalParseResponse, ExternalParser,
+    ExternalParseRequest, ExternalParseResponse, ExternalParser, InitialClusterKnowledge,
+    InitialKnowledge, InitialKubeconfigKnowledge, KnowledgeProvenance,
 };
-use config::NamespaceFilter;
-use k8s::{kubeconfig_path_or_err, target_cluster_from_kubeconfig, K8sService};
-use ran_domain::{K8sCluster, Pod, RelationSummary};
+use config::{NamespaceFilter, SeedKnowledgeConfig};
+use k8s::{kubeconfig_path_or_err, resolve_kubeconfig, Client, ResolvedKubeconfig};
+use ran_domain::{Entity, K8sCluster, K8sCredential, Pod, RelationSummary};
 
 // ---------------------------------------------------------------------------
 // AppState — the ApiService implementation
@@ -31,7 +33,7 @@ use ran_domain::{K8sCluster, Pod, RelationSummary};
 
 #[derive(Clone)]
 pub struct AppState {
-    k8s: K8sService,
+    k8s: Client,
     campaign: Arc<RwLock<Campaign>>,
     c2: C2Handle,
     armory: Armory,
@@ -50,7 +52,7 @@ pub struct AppState {
     /// Sidecar file (JSONL) persisting the decision log across restarts.
     decisions_sidecar: Option<PathBuf>,
     ran_name: String,
-    target_cluster: K8sCluster,
+    initial_knowledge: InitialKnowledge,
     campaign_events: CampaignEventBus,
     pod_watch: Arc<Mutex<Option<k8s::WatchHandle>>>,
     plan_executors:
@@ -62,7 +64,7 @@ pub struct AppState {
 impl AppState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        k8s: K8sService,
+        k8s: Client,
         campaign: Arc<RwLock<Campaign>>,
         c2: C2Handle,
         armory: Armory,
@@ -72,7 +74,7 @@ impl AppState {
         scoring_sidecar: Option<PathBuf>,
         scoring_tuning: bool,
         ran_name: String,
-        target_cluster: K8sCluster,
+        initial_knowledge: InitialKnowledge,
         campaign_events: CampaignEventBus,
         plans_dir: PathBuf,
     ) -> Self {
@@ -98,7 +100,7 @@ impl AppState {
             decision_log: Arc::new(RwLock::new(decision_log)),
             decisions_sidecar,
             ran_name,
-            target_cluster,
+            initial_knowledge,
             campaign_events,
             pod_watch: Arc::new(Mutex::new(None)),
             plan_executors: Arc::new(Mutex::new(std::collections::HashMap::new())),
@@ -359,7 +361,7 @@ impl ApiService for AppState {
             .campaign
             .write()
             .map_err(|_| ApiError::internal("campaign lock poisoned"))?;
-        campaign.reset(self.ran_name.clone(), self.target_cluster.clone());
+        campaign.reset_with_knowledge(self.ran_name.clone(), self.initial_knowledge.clone());
         let _ = self.campaign_events.publish(CampaignEvent::Reset);
         Ok(())
     }
@@ -1194,6 +1196,343 @@ fn is_loopback_url(url: &Url) -> bool {
     )
 }
 
+fn credential_from_resolved(
+    resolved: &ResolvedKubeconfig,
+    name: impl Into<String>,
+) -> K8sCredential {
+    let mut credential =
+        K8sCredential::new(resolved.server.clone().unwrap_or_default()).with_name(name);
+    credential.context_name = Some(resolved.context_name.clone());
+    credential.user_name = resolved.user_name.clone();
+    credential.auth_method = resolved.auth_method.clone();
+    credential.has_token = resolved.has_token;
+    credential.has_client_certificate = resolved.has_client_certificate;
+    credential.has_client_key = resolved.has_client_key;
+    credential.ca_data = resolved.ca_data.clone();
+    credential.token = resolved.token.clone();
+    credential.cert_data = resolved.cert_data.clone();
+    credential.key_data = resolved.key_data.clone();
+    credential
+}
+
+fn single_origin(origin: KnowledgeProvenance) -> BTreeSet<KnowledgeProvenance> {
+    BTreeSet::from([origin])
+}
+
+fn clusters_match(a: &K8sCluster, b: &K8sCluster) -> bool {
+    match (a.server.as_deref(), b.server.as_deref()) {
+        (Some(a), Some(b)) if !a.is_empty() && !b.is_empty() => a == b,
+        _ => a.name.eq_ignore_ascii_case(&b.name),
+    }
+}
+
+fn credentials_match(a: &K8sCredential, b: &K8sCredential) -> bool {
+    a.endpoint == b.endpoint && a.context_name == b.context_name && a.user_name == b.user_name
+}
+
+fn deduplicate_initial_clusters(
+    initial: &mut InitialKnowledge,
+) -> std::collections::HashMap<ran_domain::EntityId, ran_domain::EntityId> {
+    let mut deduplicated: Vec<InitialClusterKnowledge> = Vec::new();
+    let mut aliases = std::collections::HashMap::new();
+
+    for mut entry in std::mem::take(&mut initial.clusters) {
+        let original_id = entry.cluster.entity_id();
+        if let Some(existing) = deduplicated
+            .iter_mut()
+            .find(|existing| clusters_match(&existing.cluster, &entry.cluster))
+        {
+            if existing.cluster.server.is_none() {
+                existing.cluster.server = entry.cluster.server.take();
+            }
+            if existing.cluster.context_name.is_none() {
+                existing.cluster.context_name = entry.cluster.context_name.take();
+            }
+            existing.provenance.extend(entry.provenance);
+            aliases.insert(original_id, existing.cluster.entity_id());
+        } else {
+            aliases.insert(original_id.clone(), original_id);
+            deduplicated.push(entry);
+        }
+    }
+
+    initial.clusters = deduplicated;
+    for credential in &mut initial.kubeconfigs {
+        if let Some(preferred) = aliases.get(&credential.cluster_id) {
+            credential.cluster_id = preferred.clone();
+        }
+    }
+    aliases
+}
+
+fn build_initial_knowledge(
+    active: &ResolvedKubeconfig,
+    seeds: &[SeedKnowledgeConfig],
+) -> Result<InitialKnowledge> {
+    let mut initial = InitialKnowledge::default();
+    let mut cluster_aliases: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+
+    // Register declared cluster aliases first so credential entries are order-independent.
+    for seed in seeds {
+        let SeedKnowledgeConfig::Cluster(config) = seed else {
+            continue;
+        };
+        let cluster = K8sCluster::new(config.name.as_deref().unwrap_or(&config.id))
+            .with_id(&config.id)
+            .with_context_name(config.context_name.clone())
+            .with_server(config.server.clone());
+        if let Some(existing) = initial.clusters.iter().find(|entry| {
+            entry.cluster.entity_id() == cluster.entity_id()
+                && entry.cluster.server != cluster.server
+        }) {
+            anyhow::bail!(
+                "cluster seeds '{}' and '{}' resolve to the same entity with conflicting servers",
+                existing.cluster.entity_id(),
+                config.id
+            );
+        }
+        if let Some((idx, entry)) = initial
+            .clusters
+            .iter_mut()
+            .enumerate()
+            .find(|(_, entry)| clusters_match(&entry.cluster, &cluster))
+        {
+            entry.provenance.insert(config.provenance);
+            cluster_aliases.insert(config.id.clone(), idx);
+        } else {
+            cluster_aliases.insert(config.id.clone(), initial.clusters.len());
+            initial.clusters.push(InitialClusterKnowledge {
+                cluster,
+                provenance: single_origin(config.provenance),
+            });
+        }
+    }
+
+    let active_cluster = K8sCluster::new(&active.cluster_name)
+        .with_context_name(Some(active.context_name.clone()))
+        .with_server(active.server.clone());
+    let active_cluster_idx = if let Some((idx, existing)) = initial
+        .clusters
+        .iter_mut()
+        .enumerate()
+        .find(|(_, entry)| clusters_match(&entry.cluster, &active_cluster))
+    {
+        if existing.cluster.server.is_none() {
+            existing.cluster.server = active_cluster.server.clone();
+        }
+        if existing.cluster.context_name.is_none() {
+            existing.cluster.context_name = active_cluster.context_name.clone();
+        }
+        existing.provenance.insert(KnowledgeProvenance::Operator);
+        idx
+    } else {
+        let idx = initial.clusters.len();
+        initial.clusters.push(InitialClusterKnowledge {
+            cluster: active_cluster,
+            provenance: single_origin(KnowledgeProvenance::Operator),
+        });
+        idx
+    };
+
+    for seed in seeds {
+        let SeedKnowledgeConfig::Credential(config) = seed else {
+            continue;
+        };
+        let resolved = resolve_kubeconfig(&config.path, config.context.as_deref())?;
+        let resolved_cluster = K8sCluster::new(&resolved.cluster_name)
+            .with_context_name(Some(resolved.context_name.clone()))
+            .with_server(resolved.server.clone());
+
+        let cluster_idx = if let Some(alias) = config.cluster.as_deref() {
+            let idx = *cluster_aliases.get(alias).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "seed credential '{}' references unknown cluster '{}'",
+                    config.id,
+                    alias
+                )
+            })?;
+            let declared = &mut initial.clusters[idx];
+            if let (Some(expected), Some(actual)) = (
+                declared.cluster.server.as_deref(),
+                resolved.server.as_deref(),
+            ) {
+                if expected != actual {
+                    anyhow::bail!(
+                        "seed credential '{}' resolves to server '{}' but cluster '{}' declares '{}'",
+                        config.id,
+                        actual,
+                        alias,
+                        expected
+                    );
+                }
+            }
+            if declared.cluster.server.is_none() {
+                declared.cluster.server = resolved.server.clone();
+            }
+            if declared.cluster.context_name.is_none() {
+                declared.cluster.context_name = Some(resolved.context_name.clone());
+            }
+            declared.provenance.insert(config.provenance);
+            idx
+        } else if let Some((idx, entry)) = initial
+            .clusters
+            .iter_mut()
+            .enumerate()
+            .find(|(_, entry)| clusters_match(&entry.cluster, &resolved_cluster))
+        {
+            entry.provenance.insert(config.provenance);
+            idx
+        } else {
+            let idx = initial.clusters.len();
+            initial.clusters.push(InitialClusterKnowledge {
+                cluster: resolved_cluster,
+                provenance: single_origin(config.provenance),
+            });
+            idx
+        };
+
+        let credential = credential_from_resolved(&resolved, &config.id);
+        if let Some(existing) = initial
+            .kubeconfigs
+            .iter_mut()
+            .find(|entry| credentials_match(&entry.credential, &credential))
+        {
+            existing.provenance.insert(config.provenance);
+        } else {
+            initial.kubeconfigs.push(InitialKubeconfigKnowledge {
+                credential,
+                cluster_id: initial.clusters[cluster_idx].cluster.entity_id(),
+                provenance: single_origin(config.provenance),
+            });
+        }
+    }
+
+    let active_cluster_id = initial.clusters[active_cluster_idx].cluster.entity_id();
+    let cluster_aliases = deduplicate_initial_clusters(&mut initial);
+    let active_cluster_id = cluster_aliases
+        .get(&active_cluster_id)
+        .cloned()
+        .unwrap_or(active_cluster_id);
+
+    let active_name = active
+        .user_name
+        .as_deref()
+        .unwrap_or(&active.context_name)
+        .to_string();
+    let mut active_credential = credential_from_resolved(active, active_name);
+    active_credential.active = true;
+    if let Some(existing) = initial
+        .kubeconfigs
+        .iter_mut()
+        .find(|entry| credentials_match(&entry.credential, &active_credential))
+    {
+        existing.provenance.insert(KnowledgeProvenance::Operator);
+        existing.credential.active = true;
+    } else {
+        initial.kubeconfigs.push(InitialKubeconfigKnowledge {
+            credential: active_credential,
+            cluster_id: active_cluster_id,
+            provenance: single_origin(KnowledgeProvenance::Operator),
+        });
+    }
+
+    Ok(initial)
+}
+
+#[cfg(test)]
+mod initial_knowledge_tests {
+    use super::*;
+    use crate::config::{SeedClusterConfig, SeedCredentialConfig};
+
+    const KUBECONFIG: &str = r#"apiVersion: v1
+kind: Config
+clusters:
+- name: demo
+  cluster:
+    server: https://demo.example
+contexts:
+- name: demo-context
+  context:
+    cluster: demo
+    user: developer
+current-context: demo-context
+users:
+- name: developer
+  user:
+    token: secret
+"#;
+
+    #[test]
+    fn seeded_active_kubeconfig_deduplicates_and_merges_provenance() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config");
+        std::fs::write(&path, KUBECONFIG).unwrap();
+        let active = resolve_kubeconfig(&path, None).unwrap();
+        let seeds = vec![
+            SeedKnowledgeConfig::Cluster(SeedClusterConfig {
+                id: "target-cluster".into(),
+                name: None,
+                server: None,
+                context_name: None,
+                provenance: KnowledgeProvenance::Scenario,
+            }),
+            SeedKnowledgeConfig::Credential(SeedCredentialConfig {
+                credential_type: "kubeconfig".into(),
+                id: "developer-kubeconfig".into(),
+                path,
+                context: None,
+                cluster: Some("target-cluster".into()),
+                provenance: KnowledgeProvenance::Scenario,
+            }),
+        ];
+
+        let initial = build_initial_knowledge(&active, &seeds).unwrap();
+        assert_eq!(initial.clusters.len(), 1);
+        assert_eq!(
+            initial.clusters[0].cluster.id.as_deref(),
+            Some("target-cluster")
+        );
+        assert_eq!(initial.kubeconfigs.len(), 1);
+        assert!(initial.kubeconfigs[0].credential.active);
+        assert_eq!(
+            initial.kubeconfigs[0].credential.entity_name(),
+            "developer-kubeconfig"
+        );
+        assert_eq!(
+            initial.kubeconfigs[0].provenance,
+            BTreeSet::from([KnowledgeProvenance::Scenario, KnowledgeProvenance::Operator,])
+        );
+    }
+
+    #[test]
+    fn conflicting_declared_cluster_fails_initialization() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config");
+        std::fs::write(&path, KUBECONFIG).unwrap();
+        let active = resolve_kubeconfig(&path, None).unwrap();
+        let seeds = vec![
+            SeedKnowledgeConfig::Cluster(SeedClusterConfig {
+                id: "target".into(),
+                name: None,
+                server: Some("https://other.example".into()),
+                context_name: None,
+                provenance: KnowledgeProvenance::Scenario,
+            }),
+            SeedKnowledgeConfig::Credential(SeedCredentialConfig {
+                credential_type: "kubeconfig".into(),
+                id: "developer".into(),
+                path,
+                context: None,
+                cluster: Some("target".into()),
+                provenance: KnowledgeProvenance::Scenario,
+            }),
+        ];
+
+        assert!(build_initial_knowledge(&active, &seeds).is_err());
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Server bootstrap
 // ---------------------------------------------------------------------------
@@ -1224,6 +1563,8 @@ pub struct ServerConfig {
     /// Directory the web UI lists pre-defined plans from (`ran.yaml`'s
     /// `plans.dir`, defaulting to `plans` in the current working directory).
     pub plans_dir: PathBuf,
+    /// Scenario knowledge loaded from the existing ran.yaml configuration.
+    pub seed_knowledge: Vec<SeedKnowledgeConfig>,
 }
 
 /// Locate the scoring sidecar file (tuned-profile persistence) next to the
@@ -1272,8 +1613,9 @@ fn load_sidecar_profile(path: &std::path::Path) -> Option<utility_ai::Profile> {
 /// the app layer; the CLI calls this after argument parsing.
 pub async fn start(cfg: ServerConfig) -> Result<()> {
     let kubeconfig_path = kubeconfig_path_or_err(cfg.kubeconfig)?;
-    let k8s = K8sService::from_kubeconfig(Some(kubeconfig_path.clone())).await?;
-    let target_cluster = target_cluster_from_kubeconfig(Some(kubeconfig_path.clone()))?;
+    let active_kubeconfig = resolve_kubeconfig(kubeconfig_path.clone(), None)?;
+    let k8s = Client::from_resolved_kubeconfig(&active_kubeconfig).await?;
+    let initial_knowledge = build_initial_knowledge(&active_kubeconfig, &cfg.seed_knowledge)?;
     let (armory, user_armory_dir) = load_armory(cfg.armory_dir)?;
 
     // External script parsers live in armory/parsers/ (sibling to TTPs/).
@@ -1290,13 +1632,9 @@ pub async fn start(cfg: ServerConfig) -> Result<()> {
             }
         });
 
-    let campaign_cluster = K8sCluster::new(target_cluster.name)
-        .with_context_name(target_cluster.context_name)
-        .with_server(target_cluster.server);
-
-    let campaign = Arc::new(RwLock::new(Campaign::bootstrap(
+    let campaign = Arc::new(RwLock::new(Campaign::bootstrap_with_knowledge(
         "Ran",
-        campaign_cluster.clone(),
+        initial_knowledge.clone(),
     )));
 
     let (c2_handle, c2_events, c2_manager) = C2Manager::new(256, k8s.clone());
@@ -1330,7 +1668,7 @@ pub async fn start(cfg: ServerConfig) -> Result<()> {
         Some(sidecar),
         cfg.scoring.tuning_ui,
         "Ran".to_string(),
-        campaign_cluster,
+        initial_knowledge,
         campaign_events.clone(),
         cfg.plans_dir.clone(),
     );
@@ -1736,6 +2074,7 @@ pub struct TriggerConfig {
     pub armory_dir: Option<PathBuf>,
     /// Namespace visibility filter loaded from `ran.yaml`.
     pub namespace_filter: NamespaceFilter,
+    pub seed_knowledge: Vec<SeedKnowledgeConfig>,
     /// TTP ID to execute (from the armory).
     pub action_id: String,
     /// Target entity ID in the form `ns/<namespace>/pod/<name>`.
@@ -1753,8 +2092,9 @@ pub struct TriggerConfig {
 /// the full parser + analyzer + rules pipeline, then exits.
 pub async fn trigger(cfg: TriggerConfig) -> Result<()> {
     let kubeconfig_path = kubeconfig_path_or_err(cfg.kubeconfig)?;
-    let k8s = K8sService::from_kubeconfig(Some(kubeconfig_path.clone())).await?;
-    let target_cluster = target_cluster_from_kubeconfig(Some(kubeconfig_path.clone()))?;
+    let active_kubeconfig = resolve_kubeconfig(kubeconfig_path.clone(), None)?;
+    let k8s = Client::from_resolved_kubeconfig(&active_kubeconfig).await?;
+    let initial_knowledge = build_initial_knowledge(&active_kubeconfig, &cfg.seed_knowledge)?;
     let (armory, user_armory_dir) = load_armory(cfg.armory_dir)?;
 
     let external_parser: Option<Arc<dyn ExternalParser>> =
@@ -1765,11 +2105,10 @@ pub async fn trigger(cfg: TriggerConfig) -> Result<()> {
                 .then(|| Arc::new(ScriptParserRunner::new(parsers_dir)) as Arc<dyn ExternalParser>)
         });
 
-    let campaign_cluster = K8sCluster::new(target_cluster.name)
-        .with_context_name(target_cluster.context_name)
-        .with_server(target_cluster.server);
-
-    let campaign = Arc::new(RwLock::new(Campaign::bootstrap("Ran", campaign_cluster)));
+    let campaign = Arc::new(RwLock::new(Campaign::bootstrap_with_knowledge(
+        "Ran",
+        initial_knowledge,
+    )));
 
     let (c2_handle, c2_events, c2_manager) = C2Manager::new(256, k8s);
     let campaign_events = CampaignEventBus::new(256);
@@ -1815,6 +2154,7 @@ pub async fn trigger(cfg: TriggerConfig) -> Result<()> {
                     action_id: cfg.action_id.clone(),
                     target_id: pod_id.0.clone(),
                     exec_system_id: cfg.exec_system_id,
+                    auth_identity_id: None,
                     procedure_id: cfg.procedure_id,
                     args: cfg.args,
                     reasoning: Some("cli trigger".to_string()),

--- a/crates/app/tests/service.rs
+++ b/crates/app/tests/service.rs
@@ -1,7 +1,7 @@
 /// Integration tests for the `app` crate's service layer.
 ///
 /// Tests that do not touch Kubernetes can run anywhere.
-/// Tests that spin up a full `AppState` (including `K8sService`) are marked
+/// Tests that spin up a full `AppState` (including `k8s::Client`) are marked
 /// `#[ignore]` and require a valid kubeconfig at the default location.
 /// Run them with: `cargo test -p app -- --ignored`
 
@@ -41,6 +41,62 @@ fn config_load_returns_defaults_when_file_missing() {
     assert!(cfg.namespaces.included.is_empty());
 }
 
+#[test]
+fn config_loads_seed_knowledge_and_resolves_relative_path() {
+    let tmp = tempfile::tempdir().unwrap();
+    let config_path = tmp.path().join("ran.yaml");
+    std::fs::write(
+        &config_path,
+        r#"seedKnowledge:
+  - type: credential
+    credentialType: kubeconfig
+    id: developer
+    path: fixtures/developer.yaml
+    provenance: scenario
+"#,
+    )
+    .unwrap();
+
+    let config = app::config::load(Some(config_path)).unwrap();
+    let app::config::SeedKnowledgeConfig::Credential(seed) = &config.seed_knowledge[0] else {
+        panic!("expected credential seed")
+    };
+    assert_eq!(seed.path, tmp.path().join("fixtures/developer.yaml"));
+}
+
+#[test]
+fn config_rejects_duplicate_seed_ids_and_unknown_credential_types() {
+    let tmp = tempfile::tempdir().unwrap();
+    let duplicate_path = tmp.path().join("duplicate.yaml");
+    std::fs::write(
+        &duplicate_path,
+        r#"seedKnowledge:
+  - type: cluster
+    id: duplicate
+    provenance: scenario
+  - type: cluster
+    id: duplicate
+    provenance: scenario
+"#,
+    )
+    .unwrap();
+    assert!(app::config::load(Some(duplicate_path)).is_err());
+
+    let unsupported_path = tmp.path().join("unsupported.yaml");
+    std::fs::write(
+        &unsupported_path,
+        r#"seedKnowledge:
+  - type: credential
+    credentialType: token
+    id: token
+    path: token.yaml
+    provenance: scenario
+"#,
+    )
+    .unwrap();
+    assert!(app::config::load(Some(unsupported_path)).is_err());
+}
+
 // ---------------------------------------------------------------------------
 // Full service test — requires kubeconfig
 // ---------------------------------------------------------------------------
@@ -57,9 +113,9 @@ async fn app_state_get_and_reset_campaign_without_cli() {
     use std::sync::{Arc, RwLock};
 
     let kubeconfig = k8s::default_kubeconfig_path();
-    let k8s = k8s::K8sService::from_kubeconfig(Some(kubeconfig.clone()))
+    let k8s = k8s::Client::from_kubeconfig(Some(kubeconfig.clone()))
         .await
-        .expect("failed to create K8sService from default kubeconfig");
+        .expect("failed to create k8s client from default kubeconfig");
 
     let target_cluster = k8s::target_cluster_from_kubeconfig(Some(kubeconfig))
         .expect("failed to read target cluster from kubeconfig");
@@ -99,7 +155,15 @@ async fn app_state_get_and_reset_campaign_without_cli() {
         None,
         false,
         "Test".to_string(),
-        campaign_cluster,
+        campaign::InitialKnowledge {
+            clusters: vec![campaign::InitialClusterKnowledge {
+                cluster: campaign_cluster,
+                provenance: std::collections::BTreeSet::from([
+                    campaign::KnowledgeProvenance::Operator,
+                ]),
+            }],
+            kubeconfigs: Vec::new(),
+        },
         campaign_events,
         std::path::PathBuf::from("plans"),
     );

--- a/crates/c2/src/builtin.rs
+++ b/crates/c2/src/builtin.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use k8s::{K8sService, PodExecOutput};
+use k8s::{Client, PodExecOutput};
 use tracing::{debug, warn};
 
 use crate::types::{ExecTtp, TtpExecuted};
@@ -17,7 +17,7 @@ pub(crate) trait PodExecClient: Send + Sync {
 }
 
 #[async_trait]
-impl PodExecClient for K8sService {
+impl PodExecClient for Client {
     async fn exec_pod_command(
         &self,
         namespace: &str,
@@ -34,7 +34,7 @@ pub struct BuiltinC2 {
 }
 
 impl BuiltinC2 {
-    pub fn new(k8s: K8sService) -> Self {
+    pub fn new(k8s: Client) -> Self {
         Self {
             pod_exec_client: Arc::new(k8s),
         }
@@ -406,6 +406,7 @@ mod tests {
             target_id: target_id.to_string(),
             exec_chain: vec![target_id.to_string()],
             exec_system_id: exec_system_id.to_string(),
+            auth_identity_id: None,
             output_transform: None,
             is_cleanup: false,
             reasoning: String::new(),

--- a/crates/c2/src/executor.rs
+++ b/crates/c2/src/executor.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use k8s::K8sService;
+use k8s::{Client, PodExecOutput};
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tracing::{debug, warn};
 
@@ -61,7 +61,7 @@ pub struct C2Manager {
     cmd_rx: mpsc::Receiver<ExecTtp>,
     event_bus: C2EventBus,
     backends: Backends,
-    k8s: Option<K8sService>,
+    k8s: Option<Client>,
 }
 
 #[async_trait]
@@ -77,7 +77,7 @@ impl C2Backend for BuiltinC2 {
 }
 
 impl C2Manager {
-    pub fn new(buffer_size: usize, k8s: K8sService) -> (C2Handle, C2EventBus, Self) {
+    pub fn new(buffer_size: usize, k8s: Client) -> (C2Handle, C2EventBus, Self) {
         let (cmd_tx, cmd_rx) = mpsc::channel(buffer_size);
         let event_bus = C2EventBus::new(buffer_size);
 
@@ -145,6 +145,71 @@ impl C2Manager {
 
     async fn execute_command(&self, cmd: &ExecTtp) -> TtpExecuted {
         let trimmed = cmd.procedure.command.trim_start();
+
+        if let Some(namespace) = parse_kubeconfig_permission_command(trimmed) {
+            let Some(k8s) = self.k8s.as_ref() else {
+                let reason = "no K8s client configured".to_string();
+                return TtpExecuted {
+                    id: cmd.id.clone(),
+                    success: false,
+                    results: vec![reason.clone()],
+                    exit_code: 1,
+                    fail_reason: reason,
+                    session_connected: None,
+                };
+            };
+            return match k8s.self_subject_rules_review(namespace).await {
+                Ok(response) => TtpExecuted {
+                    id: cmd.id.clone(),
+                    success: true,
+                    results: vec![response],
+                    exit_code: 0,
+                    fail_reason: String::new(),
+                    session_connected: None,
+                },
+                Err(error) => {
+                    let reason = error.to_string();
+                    TtpExecuted {
+                        id: cmd.id.clone(),
+                        success: false,
+                        results: vec![reason.clone()],
+                        exit_code: 1,
+                        fail_reason: reason,
+                        session_connected: None,
+                    }
+                }
+            };
+        }
+
+        if cmd
+            .auth_identity_id
+            .as_deref()
+            .is_some_and(|identity| identity.starts_with("k8s/credential/"))
+        {
+            let Some(k8s) = self.k8s.as_ref() else {
+                return failed_result(cmd, "no active Kubernetes client configured");
+            };
+            let result = if let Some(request) = cmd.procedure.k8s_request.as_ref() {
+                k8s.execute_request(request)
+                    .await
+                    .map(|stdout| PodExecOutput {
+                        stdout,
+                        stderr: String::new(),
+                        exit_code: 0,
+                    })
+            } else if trimmed.contains("kubectl ") || trimmed.starts_with("kubectl") {
+                k8s.execute_kubectl_command(trimmed).await
+            } else {
+                return failed_result(
+                    cmd,
+                    "selected procedure does not support kubeconfig authentication",
+                );
+            };
+            return match result {
+                Ok(output) => command_output_result(cmd, output),
+                Err(error) => failed_result(cmd, &error.to_string()),
+            };
+        }
 
         if trimmed.starts_with("setTarget(") || trimmed == "noop" {
             if args_flag(&cmd.args, "Interactive") {
@@ -380,6 +445,56 @@ impl C2Manager {
     }
 }
 
+fn parse_kubeconfig_permission_command(command: &str) -> Option<&str> {
+    command
+        .trim()
+        .strip_prefix("k8sSelfSubjectRulesReview(")?
+        .strip_suffix(')')
+        .map(str::trim)
+        .filter(|namespace| !namespace.is_empty())
+}
+
+fn failed_result(cmd: &ExecTtp, reason: &str) -> TtpExecuted {
+    TtpExecuted {
+        id: cmd.id.clone(),
+        success: false,
+        results: vec![reason.to_string()],
+        exit_code: 1,
+        fail_reason: reason.to_string(),
+        session_connected: None,
+    }
+}
+
+fn command_output_result(cmd: &ExecTtp, output: k8s::PodExecOutput) -> TtpExecuted {
+    let mut results = Vec::new();
+    if !output.stdout.trim().is_empty() {
+        results.push(output.stdout.trim().to_string());
+    }
+    if !output.stderr.trim().is_empty() {
+        if results.is_empty() {
+            results.push(String::new());
+        }
+        results.push(output.stderr.trim().to_string());
+    }
+    TtpExecuted {
+        id: cmd.id.clone(),
+        success: output.exit_code == 0,
+        results,
+        exit_code: output.exit_code,
+        fail_reason: if output.exit_code == 0 {
+            String::new()
+        } else {
+            output
+                .stderr
+                .lines()
+                .last()
+                .unwrap_or("kubectl command failed")
+                .to_string()
+        },
+        session_connected: None,
+    }
+}
+
 /// Look up a boolean arg by name, case-insensitively. Returns true only for
 /// the exact string `"true"` (case-insensitive).
 fn args_flag(args: &HashMap<String, String>, key: &str) -> bool {
@@ -405,7 +520,7 @@ fn args_str(args: &HashMap<String, String>, key: &str) -> Option<String> {
 /// campaign can process it after TTP effects rather than as a separate event.
 async fn open_kubectl_exec_session(
     backends: Backends,
-    k8s: K8sService,
+    k8s: Client,
     backend_id: String,
     target_entity_id: String,
     container: Option<String>,
@@ -630,10 +745,27 @@ mod tests {
 
     use armory::{Procedure, Ttp};
 
+    use super::parse_kubeconfig_permission_command;
     use super::{C2Backend, C2Event, C2Manager, ExecTtp, TtpExecuted, BUILTIN_C2_ID};
 
     struct MockBackend {
         marker: String,
+    }
+
+    #[test]
+    fn parses_kubeconfig_permission_control_command() {
+        assert_eq!(
+            parse_kubeconfig_permission_command("k8sSelfSubjectRulesReview(dungeon)"),
+            Some("dungeon")
+        );
+        assert_eq!(
+            parse_kubeconfig_permission_command("k8sSelfSubjectRulesReview()"),
+            None
+        );
+        assert_eq!(
+            parse_kubeconfig_permission_command("kubectl get pods"),
+            None
+        );
     }
 
     #[async_trait::async_trait]
@@ -781,6 +913,7 @@ mod tests {
             target_id: "ns/default/pod/nginx".to_string(),
             exec_chain: vec!["ns/default/pod/nginx".to_string()],
             exec_system_id: exec_system_id.to_string(),
+            auth_identity_id: None,
             output_transform: None,
             is_cleanup: false,
             reasoning: String::new(),

--- a/crates/c2/src/shell_session.rs
+++ b/crates/c2/src/shell_session.rs
@@ -412,6 +412,7 @@ mod tests {
             target_id: "node/test-node".to_string(),
             exec_chain: vec!["node/test-node".to_string()],
             exec_system_id: exec_system_id.to_string(),
+            auth_identity_id: None,
             output_transform: None,
             is_cleanup: false,
             reasoning: String::new(),

--- a/crates/c2/src/types.rs
+++ b/crates/c2/src/types.rs
@@ -26,6 +26,10 @@ pub struct ExecTtp {
     /// local/C2-side commands.
     pub exec_chain: Vec<String>,
     pub exec_system_id: String,
+    /// Authentication identity selected for Kubernetes API/kubectl operations.
+    /// This is an entity ID only; credential material is never serialized here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_identity_id: Option<String>,
     /// Unix timestamp (milliseconds) when the command was dispatched.
     pub started_at_ms: u64,
     /// Output post-processing required before parsers run.

--- a/crates/campaign/Cargo.toml
+++ b/crates/campaign/Cargo.toml
@@ -8,6 +8,7 @@ armory  = { path = "../armory" }
 cortex  = { path = "../graph" }
 async-trait = "0.1"
 c2 = { path = "../c2" }
+k8s = { path = "../k8s" }
 ran-domain = { path = "../domain" }
 base64 = "0.22"
 serde = { workspace = true }

--- a/crates/campaign/src/analyzers.rs
+++ b/crates/campaign/src/analyzers.rs
@@ -1,8 +1,9 @@
 use ran_domain::{
-    BindsTo, Confidence, Contains, DaemonSet, Deployment, Entity, EntityId, GCPServiceAccount,
-    Grants, Job, K8sCluster, K8sCredential, K8sGateway, K8sHTTPRoute, K8sIngress, K8sNode, K8sRole,
-    K8sRoleBinding, K8sService, KubeletExecSink, KubeletExecSource, NameConfidence, Namespace,
-    Owns, Pod, PodExec, RbacPermission, RunsOn, ServiceAccount, StatefulSet, UnknownSystem, Uses,
+    AuthenticatesTo, BindsTo, Confidence, Contains, DaemonSet, Deployment, Entity, EntityId,
+    GCPServiceAccount, Grants, Job, K8sCluster, K8sCredential, K8sGateway, K8sHTTPRoute,
+    K8sIngress, K8sNode, K8sRole, K8sRoleBinding, K8sService, KubeletExecSink, KubeletExecSource,
+    NameConfidence, Namespace, Owns, Pod, PodExec, RbacPermission, RunsOn, ServiceAccount,
+    StatefulSet, UnknownSystem, Uses,
 };
 
 use crate::rules::InferenceRule;
@@ -1708,19 +1709,30 @@ impl InferenceRule for KubeconfigCredentialAnalyzer {
 
     fn infer(&self, campaign: &Campaign, update: &FactsUpdate) -> FactsUpdate {
         let mut inferred = FactsUpdate::default();
+        let relations = PendingView::new(campaign, update).relations();
 
         for entity in &update.new_entities {
             let Some(cred) = entity.as_any().downcast_ref::<K8sCredential>() else {
                 continue;
             };
+            let credential_id = cred.entity_id();
 
-            let cluster_name = if cred.endpoint.is_empty() {
-                "discovered".to_string()
-            } else {
-                cred.endpoint.clone()
-            };
+            // An existing credential may be re-emitted as a partial entity when
+            // new facts such as RBAC entitlements are learned. Its established
+            // authenticates-to edge is authoritative; do not derive another
+            // cluster from an incomplete update.
+            if relations.iter().any(|relation| {
+                relation.name == "authenticates-to" && relation.source_id == credential_id.0
+            }) {
+                continue;
+            }
 
-            let cluster = K8sCluster::new(&cluster_name).with_server(Some(cred.endpoint.clone()));
+            // Without an endpoint there is no stable cluster identity to infer.
+            if cred.endpoint.is_empty() {
+                continue;
+            }
+
+            let cluster = K8sCluster::new(&cred.endpoint).with_server(Some(cred.endpoint.clone()));
             let cluster_id = cluster.entity_id();
 
             if !campaign.entities.contains::<K8sCluster>(&cluster_id)
@@ -1730,6 +1742,16 @@ impl InferenceRule for KubeconfigCredentialAnalyzer {
                     .any(|e| e.entity_id() == cluster_id)
             {
                 inferred.new_entities.push(Box::new(cluster));
+            }
+            let already_related = campaign
+                .graph
+                .targets_of(&credential_id, "authenticates-to")
+                .contains(&&cluster_id);
+            if !already_related {
+                inferred.new_relations.push(Box::new(AuthenticatesTo::new(
+                    credential_id.0,
+                    cluster_id.0,
+                )));
             }
         }
 
@@ -2623,6 +2645,42 @@ mod tests {
                 .all(|e| e.entity_id() != cluster_id),
             "should not re-emit K8sCluster when already in campaign"
         );
+    }
+
+    #[test]
+    fn permission_update_does_not_infer_second_cluster_for_existing_credential() {
+        let mut campaign = test_campaign();
+        let cluster_id = campaign
+            .entities
+            .values::<K8sCluster>()
+            .next()
+            .expect("bootstrap cluster")
+            .entity_id();
+        let credential =
+            K8sCredential::new("https://10.96.0.1:6443").with_name("developer-kubeconfig");
+        let credential_id = credential.entity_id();
+        campaign.insert_entity(&credential);
+        campaign.insert_relation(&AuthenticatesTo::new(credential_id.0.clone(), cluster_id.0));
+
+        // SelfSubjectRulesReview emits a partial entity carrying only identity
+        // and newly learned entitlements.
+        let mut permission_update = K8sCredential::new("").with_name("developer-kubeconfig");
+        permission_update
+            .entitlements
+            .push(RbacPermission::new("list", "pods"));
+        let mut update = FactsUpdate::default();
+        update.new_entities.push(Box::new(permission_update));
+
+        let inferred = KubeconfigCredentialAnalyzer.infer(&campaign, &update);
+
+        assert!(inferred
+            .new_entities
+            .iter()
+            .all(|entity| entity.entity_kind() != "Cluster"));
+        assert!(inferred
+            .new_relations
+            .iter()
+            .all(|relation| relation.relation_name() != "authenticates-to"));
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/campaign/src/campaign/entity_refs.rs
+++ b/crates/campaign/src/campaign/entity_refs.rs
@@ -113,6 +113,10 @@ impl<'a> CampaignEntityRef<'a> {
 
     pub fn namespace(&self) -> Option<&str> {
         match self {
+            // A Namespace is its own namespace context. This matters when an
+            // action targets the namespace node itself (for example, listing
+            // pods in that namespace).
+            CampaignEntityRef::Namespace(e) => Some(&e.name),
             CampaignEntityRef::Pod(e) => e.meta.namespace.as_deref(),
             CampaignEntityRef::ServiceAccount(e) => e.meta.namespace.as_deref(),
             CampaignEntityRef::Secret(e) => e.meta.namespace.as_deref(),

--- a/crates/campaign/src/campaign/execution.rs
+++ b/crates/campaign/src/campaign/execution.rs
@@ -192,12 +192,11 @@ struct KubernetesRequestSpec {
     timeout_seconds: u64,
 }
 
-fn build_k8s_url(spec: &KubernetesRequestSpec) -> String {
-    let api_server = spec.api_server.trim_end_matches('/');
+fn build_k8s_resource_path(spec: &KubernetesRequestSpec) -> String {
     let api = spec.api.trim_matches('/');
     let resource = spec.resource.trim_matches('/');
 
-    let base = format!("{}/{}", api_server, api);
+    let base = format!("/{}", api);
 
     let resource_path = if spec.cluster_scoped.is_true() || spec.namespace.trim().is_empty() {
         format!("{}/{}", base, resource)
@@ -210,6 +209,39 @@ fn build_k8s_url(spec: &KubernetesRequestSpec) -> String {
     } else {
         format!("{}?{}", resource_path, spec.query.trim())
     }
+}
+
+fn build_k8s_url(spec: &KubernetesRequestSpec) -> String {
+    format!(
+        "{}{}",
+        spec.api_server.trim_end_matches('/'),
+        build_k8s_resource_path(spec)
+    )
+}
+
+/// Build a secret-free request line for native Kubernetes client executions.
+/// Structured requests do not have a shell command, but the execution record
+/// and flow drawer still need to show what was sent to the API server.
+fn describe_k8s_request(
+    procedure_id: &str,
+    request: JsonValue,
+) -> Result<String, ExecuteActionError> {
+    let spec: KubernetesRequestSpec = serde_json::from_value(request).map_err(|e| {
+        ExecuteActionError::InvalidInput(format!(
+            "invalid k8s_request in procedure '{}': {}",
+            procedure_id, e
+        ))
+    })?;
+    let method = if spec.method.trim().is_empty() {
+        "GET"
+    } else {
+        spec.method.trim()
+    };
+    Ok(format!(
+        "{} {}",
+        method.to_ascii_uppercase(),
+        build_k8s_resource_path(&spec)
+    ))
 }
 
 #[derive(Debug, Deserialize)]
@@ -688,6 +720,11 @@ impl Campaign {
         }
         ground_procedure_and_effects(&mut procedure, &mut ttp.effects, &mut args, &ttp.id);
         if use_kubeconfig {
+            if procedure.command.trim().is_empty() {
+                if let Some(request) = procedure.k8s_request.clone() {
+                    procedure.command = describe_k8s_request(&procedure.id, request)?;
+                }
+            }
             let supported = procedure.k8s_request.is_some()
                 || procedure.command.contains("kubectl ")
                 || procedure

--- a/crates/campaign/src/campaign/execution.rs
+++ b/crates/campaign/src/campaign/execution.rs
@@ -543,6 +543,7 @@ impl Campaign {
         let mut exec = self.prepare_action_with_ttp(
             request.target_id,
             request.exec_system_id,
+            request.auth_identity_id,
             request.procedure_id,
             ttp,
             args,
@@ -592,10 +593,12 @@ impl Campaign {
     /// `build_cleanup_actions` (synthesized cleanup TTPs).  Does NOT validate
     /// that the target entity is in the campaign — the caller is responsible
     /// for deciding whether to skip missing targets.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn prepare_action_with_ttp(
         &mut self,
         target_id: String,
         exec_system_id: Option<String>,
+        requested_auth_identity_id: Option<String>,
         procedure_id: Option<String>,
         mut ttp: Ttp,
         mut args: HashMap<String, String>,
@@ -607,6 +610,46 @@ impl Campaign {
                 args.insert(p.name.clone(), p.default.clone());
             }
         }
+
+        let eligible_identities =
+            crate::ttp_applicability::eligible_auth_identities(&ttp, self, &target_id);
+        let implicit_identity = args
+            .get("TOKEN")
+            .filter(|value| !value.trim().is_empty())
+            .filter(|value| {
+                eligible_identities
+                    .iter()
+                    .any(|identity| identity.id == **value)
+            })
+            .cloned()
+            .or_else(|| {
+                eligible_identities
+                    .iter()
+                    .find(|identity| identity.id == target_id)
+                    .map(|identity| identity.id.clone())
+            })
+            .or_else(|| {
+                (eligible_identities.len() == 1).then(|| eligible_identities[0].id.clone())
+            });
+        let auth_identity_id = requested_auth_identity_id
+            .filter(|identity| !identity.trim().is_empty())
+            .or(implicit_identity);
+        if let Some(identity_id) = auth_identity_id.as_deref() {
+            if !eligible_identities
+                .iter()
+                .any(|identity| identity.id == identity_id)
+            {
+                return Err(ExecuteActionError::InvalidInput(format!(
+                    "authentication identity '{}' is not eligible for action '{}'",
+                    identity_id, ttp.id
+                )));
+            }
+        }
+        let use_kubeconfig = auth_identity_id.as_deref().is_some_and(|identity_id| {
+            self.entities
+                .find::<ran_domain::K8sCredential>(&EntityId::new(identity_id))
+                .is_some_and(|credential| credential.active)
+        });
 
         // Stage 2: normalise the caller-supplied routing hint.
         let exec_hint = normalise_exec_hint(exec_system_id.as_deref(), &target_id);
@@ -640,8 +683,26 @@ impl Campaign {
 
         // Stage 5: ground the procedure command and effects.
         let mut procedure = self.select_procedure(&ttp, procedure_id.as_deref())?;
+        if use_kubeconfig {
+            args.insert("TOKEN".to_string(), String::new());
+        }
         ground_procedure_and_effects(&mut procedure, &mut ttp.effects, &mut args, &ttp.id);
-        materialize_k8s_request(&mut procedure, armory)?;
+        if use_kubeconfig {
+            let supported = procedure.k8s_request.is_some()
+                || procedure.command.contains("kubectl ")
+                || procedure
+                    .command
+                    .trim_start()
+                    .starts_with("k8sSelfSubjectRulesReview(");
+            if !supported {
+                return Err(ExecuteActionError::InvalidInput(format!(
+                    "procedure '{}' does not support kubeconfig authentication",
+                    procedure.id
+                )));
+            }
+        } else {
+            materialize_k8s_request(&mut procedure, armory)?;
+        }
         materialize_steps(&mut procedure, armory)?;
         materialize_abstract_http_request(&mut procedure, armory)?;
 
@@ -651,6 +712,7 @@ impl Campaign {
             &ttp.tactic,
             &mut procedure,
             &args,
+            auth_identity_id.as_deref(),
             exec_hint.as_deref(),
             lateral_src,
         )?;
@@ -672,6 +734,7 @@ impl Campaign {
             target_id: route.target_id,
             exec_chain: route.exec_chain,
             exec_system_id: route.backend_id,
+            auth_identity_id,
             started_at_ms: current_time_millis(),
             output_transform: route.output_transform,
             is_cleanup: false,
@@ -713,6 +776,7 @@ impl Campaign {
 
             match self.prepare_action_with_ttp(
                 record.target_id.clone(),
+                None,
                 None,
                 Some(cleanup_proc.id.clone()),
                 cleanup_ttp,
@@ -811,15 +875,32 @@ impl Campaign {
     /// 2. Lateral Movement tactic → [`route_lateral_movement`] (uses pre-resolved src).
     /// 3. Remote channel needed (tactic / procedure flag) → [`route_remote`].
     /// 4. Everything else → [`route_fallback`] (pod targets get in-cluster source).
+    #[allow(clippy::too_many_arguments)]
     fn route_exec_channel(
         &mut self,
         target_id: &str,
         tactic: &str,
         procedure: &mut Procedure,
         args: &HashMap<String, String>,
+        auth_identity_id: Option<&str>,
         exec_hint: Option<&str>,
         lateral_src: Option<ExecChannel>,
     ) -> Result<ExecRoute, ExecuteActionError> {
+        if auth_identity_id.is_some_and(|identity| identity.starts_with("k8s/credential/"))
+            && (procedure.k8s_request.is_some()
+                || procedure.command.contains("kubectl ")
+                || procedure
+                    .command
+                    .trim_start()
+                    .starts_with("k8sSelfSubjectRulesReview("))
+        {
+            return Ok(ExecRoute::direct(
+                BUILTIN_C2_ID.to_string(),
+                target_id.to_string(),
+                vec![],
+                None,
+            ));
+        }
         if is_local_control_command(&procedure.command) {
             tracing::info!(
                 target_id = %target_id,
@@ -1686,6 +1767,7 @@ impl Campaign {
         // Record the alias so apply_facts can transplant all relations.
         self.detect_pod_identity_merge(cmd, &mut updates);
 
+        updates.attribute_unattributed(crate::KnowledgeProvenance::Action);
         let rules = default_rules();
         updates = run_rules_fixpoint(self, &rules, updates);
 
@@ -1744,6 +1826,12 @@ impl Campaign {
     fn apply_facts(&mut self, updates: &FactsUpdate) {
         for entity in &updates.new_entities {
             self.insert_entity(entity.as_ref());
+            if let Some(origins) = updates.entity_provenance.get(&entity.entity_id()) {
+                for origin in origins {
+                    self.knowledge_provenance
+                        .add_entity(entity.entity_id(), *origin);
+                }
+            }
         }
 
         // Merge entity aliases: transplant graph edges and entity data.
@@ -1751,6 +1839,8 @@ impl Campaign {
         for (stale_id, preferred_id) in &updates.entity_aliases {
             // Graph: retarget all edges from stale → preferred.
             self.graph.merge_entities(preferred_id, stale_id);
+            self.knowledge_provenance
+                .merge_entity(stale_id, preferred_id);
             // Entity maps: merge runtime data (IPs, access level, binaries, etc.).
             // Dispatch to the correct merge function based on entity kind.
             if stale_id.0.starts_with("system/") {
@@ -1823,6 +1913,12 @@ impl Campaign {
                         // Insert edge to preferred node (graph PodSingleNode
                         // invariant removes the old runs-on automatically).
                         self.insert_relation_with_ids(&src, &preferred_node, rel.as_ref());
+                        self.apply_relation_provenance(
+                            updates,
+                            rel.as_ref(),
+                            &src,
+                            &preferred_node,
+                        );
                         continue;
                     }
                     // Same node — nothing to do (PodSingleNode invariant will
@@ -1837,6 +1933,28 @@ impl Campaign {
                 self.insert_relation(rel.as_ref());
             } else {
                 self.insert_relation_with_ids(&src, &tgt, rel.as_ref());
+            }
+            self.apply_relation_provenance(updates, rel.as_ref(), &src, &tgt);
+        }
+    }
+
+    fn apply_relation_provenance(
+        &mut self,
+        updates: &FactsUpdate,
+        relation: &dyn ran_domain::Relation,
+        source_id: &EntityId,
+        target_id: &EntityId,
+    ) {
+        let original_key = crate::RelationProvenanceKey::from_relation(relation);
+        if let Some(origins) = updates.relation_provenance.get(&original_key) {
+            let effective_key = crate::RelationProvenanceKey::new(
+                relation.relation_name(),
+                source_id.0.clone(),
+                target_id.0.clone(),
+            );
+            for origin in origins {
+                self.knowledge_provenance
+                    .add_relation(effective_key.clone(), *origin);
             }
         }
     }

--- a/crates/campaign/src/campaign/mod.rs
+++ b/crates/campaign/src/campaign/mod.rs
@@ -9,7 +9,7 @@ mod types;
 pub use entity_refs::{CampaignEntityRef, CampaignSystemEntityMut, CampaignSystemEntityRef};
 pub use entity_store::{EntityStore, EntityType};
 pub use execution::best_tool_readiness;
-pub use state::Campaign;
+pub use state::{Campaign, InitialClusterKnowledge, InitialKnowledge, InitialKubeconfigKnowledge};
 pub use types::{
     ExecChannel, ExecuteActionError, ExecuteActionRequest, ExecuteActionResult,
     ExecutedActionEvent, TtpExecutionProcessing,

--- a/crates/campaign/src/campaign/state.rs
+++ b/crates/campaign/src/campaign/state.rs
@@ -1,9 +1,9 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use cortex::KnowledgeGraph;
 use ran_domain::{
-    C2Server, Entity, EntityId, K8sCluster, K8sNode, Pod, PodExec, RelationSummary, SessionStatus,
-    UnknownSystem,
+    AuthenticatesTo, C2Server, Entity, EntityId, K8sCluster, K8sCredential, K8sNode, Pod, PodExec,
+    Relation, RelationSummary, SessionStatus, UnknownSystem,
 };
 use serde::{Deserialize, Serialize};
 
@@ -11,7 +11,10 @@ use c2::{ExecTtp, BUILTIN_C2_ID};
 
 use crate::execution_record::ExecutionRecord;
 use crate::external_parser::SystemFieldUpdates;
-use crate::{external_parser, ParseAudit};
+use crate::{
+    external_parser, KnowledgeProvenance, KnowledgeProvenanceStore, ParseAudit,
+    RelationProvenanceKey,
+};
 
 use super::{CampaignSystemEntityMut, CampaignSystemEntityRef, EntityStore, ExecChannel};
 
@@ -38,21 +41,85 @@ pub struct Campaign {
     /// that later routes over that session.
     #[serde(default)]
     pub session_traversals: HashMap<String, Vec<crate::traversal::TraversalHop>>,
+    #[serde(default)]
+    pub knowledge_provenance: KnowledgeProvenanceStore,
+}
+
+#[derive(Debug, Clone)]
+pub struct InitialClusterKnowledge {
+    pub cluster: K8sCluster,
+    pub provenance: BTreeSet<KnowledgeProvenance>,
+}
+
+#[derive(Debug, Clone)]
+pub struct InitialKubeconfigKnowledge {
+    pub credential: K8sCredential,
+    pub cluster_id: EntityId,
+    pub provenance: BTreeSet<KnowledgeProvenance>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct InitialKnowledge {
+    pub clusters: Vec<InitialClusterKnowledge>,
+    pub kubeconfigs: Vec<InitialKubeconfigKnowledge>,
 }
 
 impl Campaign {
     pub fn bootstrap(ran_name: impl Into<String>, target_cluster: K8sCluster) -> Self {
+        let mut origins = BTreeSet::new();
+        origins.insert(KnowledgeProvenance::Operator);
+        Self::bootstrap_with_knowledge(
+            ran_name,
+            InitialKnowledge {
+                clusters: vec![InitialClusterKnowledge {
+                    cluster: target_cluster,
+                    provenance: origins,
+                }],
+                kubeconfigs: Vec::new(),
+            },
+        )
+    }
+
+    pub fn bootstrap_with_knowledge(
+        ran_name: impl Into<String>,
+        initial: InitialKnowledge,
+    ) -> Self {
         let mut entities = EntityStore::default();
         let mut graph = KnowledgeGraph::new();
+        let mut knowledge_provenance = KnowledgeProvenanceStore::default();
 
         let c2 = C2Server::new(ran_name.into());
         let c2_id = c2.entity_id();
         entities.insert_typed(c2);
-        graph.ensure_node(c2_id);
+        graph.ensure_node(c2_id.clone());
+        knowledge_provenance.add_entity(c2_id, KnowledgeProvenance::Operator);
 
-        let cluster_id = target_cluster.entity_id();
-        entities.insert_typed(target_cluster);
-        graph.ensure_node(cluster_id);
+        for entry in initial.clusters {
+            let cluster_id = entry.cluster.entity_id();
+            entities.insert_typed(entry.cluster);
+            graph.ensure_node(cluster_id.clone());
+            for origin in entry.provenance {
+                knowledge_provenance.add_entity(cluster_id.clone(), origin);
+            }
+        }
+
+        for entry in initial.kubeconfigs {
+            let credential_id = entry.credential.entity_id();
+            entities.insert_typed(entry.credential);
+            graph.ensure_node(credential_id.clone());
+            let relation =
+                AuthenticatesTo::new(credential_id.0.clone(), entry.cluster_id.0.clone());
+            graph.insert_edge(
+                relation.source_id(),
+                relation.target_id(),
+                cortex::edge_data_for(relation.relation_name(), None, None),
+            );
+            for origin in entry.provenance {
+                knowledge_provenance.add_entity(credential_id.clone(), origin);
+                knowledge_provenance
+                    .add_relation(RelationProvenanceKey::from_relation(&relation), origin);
+            }
+        }
 
         Campaign {
             entities,
@@ -63,6 +130,7 @@ impl Campaign {
             file_contents: HashMap::new(),
             command_traversals: HashMap::new(),
             session_traversals: HashMap::new(),
+            knowledge_provenance,
         }
     }
 
@@ -78,6 +146,10 @@ impl Campaign {
         *self = Campaign::bootstrap(ran_name, target_cluster);
     }
 
+    pub fn reset_with_knowledge(&mut self, ran_name: impl Into<String>, initial: InitialKnowledge) {
+        *self = Campaign::bootstrap_with_knowledge(ran_name, initial);
+    }
+
     pub fn entity_count(&self) -> usize {
         self.entities.entity_count()
     }
@@ -88,6 +160,20 @@ impl Campaign {
 
     pub fn get_relations(&self) -> Vec<RelationSummary> {
         self.graph.to_relation_summaries()
+    }
+
+    pub fn entity_provenance(&self, id: &EntityId) -> BTreeSet<KnowledgeProvenance> {
+        self.knowledge_provenance.entity(id)
+    }
+
+    pub fn relation_provenance(
+        &self,
+        name: &str,
+        source_id: &str,
+        target_id: &str,
+    ) -> BTreeSet<KnowledgeProvenance> {
+        self.knowledge_provenance
+            .relation(&RelationProvenanceKey::new(name, source_id, target_id))
     }
 
     pub fn get_parse_audits(&self) -> &[ParseAudit] {
@@ -567,6 +653,7 @@ mod planner_helper_tests {
             file_contents: std::collections::HashMap::new(),
             command_traversals: std::collections::HashMap::new(),
             session_traversals: std::collections::HashMap::new(),
+            knowledge_provenance: KnowledgeProvenanceStore::default(),
         }
     }
 
@@ -582,5 +669,47 @@ mod planner_helper_tests {
     fn entity_has_relation_false_when_no_relation() {
         let c = minimal_campaign();
         assert!(!c.entity_has_relation("ns/default/pod/nginx-abc", "rce.can-exec"));
+    }
+
+    #[test]
+    fn bootstrap_with_kubeconfig_records_relation_and_provenance() {
+        let cluster = K8sCluster::new("demo").with_server(Some("https://demo".into()));
+        let cluster_id = cluster.entity_id();
+        let credential = K8sCredential::new("https://demo").with_name("developer");
+        let credential_id = credential.entity_id();
+        let origins =
+            BTreeSet::from([KnowledgeProvenance::Operator, KnowledgeProvenance::Scenario]);
+        let initial = InitialKnowledge {
+            clusters: vec![InitialClusterKnowledge {
+                cluster,
+                provenance: origins.clone(),
+            }],
+            kubeconfigs: vec![InitialKubeconfigKnowledge {
+                credential,
+                cluster_id: cluster_id.clone(),
+                provenance: origins.clone(),
+            }],
+        };
+        let mut campaign = Campaign::bootstrap_with_knowledge("test", initial.clone());
+
+        assert!(campaign.entities.contains::<K8sCredential>(&credential_id));
+        assert_eq!(
+            campaign
+                .graph
+                .targets_of(&credential_id, "authenticates-to"),
+            vec![&cluster_id]
+        );
+        assert_eq!(campaign.entity_provenance(&credential_id), origins);
+        assert!(campaign.execution_records.is_empty());
+        assert!(serde_json::to_string(&campaign).is_ok());
+
+        campaign.reset_with_knowledge("test", initial);
+        assert!(campaign.entities.contains::<K8sCredential>(&credential_id));
+        assert_eq!(
+            campaign
+                .graph
+                .targets_of(&credential_id, "authenticates-to"),
+            vec![&cluster_id]
+        );
     }
 }

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 use armory::{Armory, Procedure, Ttp, TtpParam};
 use c2::{ExecTtp, TtpExecuted, BUILTIN_C2_ID};
 use ran_domain::{
-    AccessLevel, C2Server, Container, ContainerEscape, Entity, EntityId, K8sCluster, K8sNode,
-    KubeletExecSink, OutputTransformKind, Pod, PodExec, RbacPermission, RceCanExec, RunsOn,
-    ServiceAccount, SessionInfo, SessionStatus, Uses,
+    AccessLevel, C2Server, Container, ContainerEscape, Entity, EntityId, K8sCluster, K8sCredential,
+    K8sNode, KubeletExecSink, OutputTransformKind, Pod, PodExec, RbacPermission, RceCanExec,
+    RunsOn, ServiceAccount, SessionInfo, SessionStatus, Uses,
 };
 
 use super::{Campaign, ExecChannel, ExecuteActionError, ExecuteActionRequest};
@@ -31,6 +31,7 @@ fn sample_exec_ttp(target_id: &str, effects: Vec<&str>) -> ExecTtp {
         target_id: target_id.to_string(),
         exec_chain: vec![target_id.to_string()],
         exec_system_id: String::new(),
+        auth_identity_id: None,
         started_at_ms: 0,
         output_transform: None,
         is_cleanup: false,
@@ -415,6 +416,7 @@ fn resolve_exec_channel_prefers_last_foothold_chain_for_follow_up() {
         tactic: "Discovery".to_string(),
         target_id: entry_id.clone(),
         exec_system_id: BUILTIN_C2_ID.to_string(),
+        auth_identity_id: None,
         procedure_id: "shell".to_string(),
         command: "id".to_string(),
         args: HashMap::new(),
@@ -519,6 +521,7 @@ fn resolve_exec_source_prefers_most_recently_used_pod() {
         tactic: "Execution".to_string(),
         target_id: id_a.clone(),
         exec_system_id: BUILTIN_C2_ID.to_string(),
+        auth_identity_id: None,
         procedure_id: "shell".to_string(),
         command: "id".to_string(),
         args: HashMap::new(),
@@ -538,6 +541,7 @@ fn resolve_exec_source_prefers_most_recently_used_pod() {
         tactic: "Discovery".to_string(),
         target_id: id_b.clone(),
         exec_system_id: BUILTIN_C2_ID.to_string(),
+        auth_identity_id: None,
         procedure_id: "shell".to_string(),
         command: "hostname".to_string(),
         args: HashMap::new(),
@@ -680,6 +684,7 @@ fn action_request(target_id: &str, exec_system_id: Option<&str>) -> ExecuteActio
         action_id: "test-ttp".to_string(),
         target_id: target_id.to_string(),
         exec_system_id: exec_system_id.map(str::to_string),
+        auth_identity_id: None,
         procedure_id: None,
         args: HashMap::new(),
         reasoning: None,
@@ -698,6 +703,7 @@ fn record_preparation_failure_preserves_known_ttp_and_request_context() {
         action_id: "test-ttp".to_string(),
         target_id: "ns/default/pod/demo".to_string(),
         exec_system_id: Some("custom-backend".to_string()),
+        auth_identity_id: Some("operator-kubeconfig".to_string()),
         procedure_id: Some("shell".to_string()),
         args: HashMap::from([("Namespace".to_string(), "default".to_string())]),
         reasoning: Some("verify unavailable channel".to_string()),
@@ -712,6 +718,10 @@ fn record_preparation_failure_preserves_known_ttp_and_request_context() {
     assert_eq!(record.tactic, "Discovery");
     assert_eq!(record.target_id, "ns/default/pod/demo");
     assert_eq!(record.exec_system_id, "custom-backend");
+    assert_eq!(
+        record.auth_identity_id.as_deref(),
+        Some("operator-kubeconfig")
+    );
     assert_eq!(record.procedure_id, "shell");
     assert_eq!(record.args, request.args);
     assert_eq!(record.reasoning, "verify unavailable channel");
@@ -737,6 +747,7 @@ fn record_preparation_failure_synthesizes_ttp_for_every_error_variant() {
         action_id: "unknown-ttp".to_string(),
         target_id: "unknown-target".to_string(),
         exec_system_id: None,
+        auth_identity_id: None,
         procedure_id: None,
         args: HashMap::new(),
         reasoning: None,
@@ -882,6 +893,7 @@ fn prepare_action_expands_object_headers_into_multiple_flags() {
                 action_id: "http-object-headers".to_string(),
                 target_id: target_id.clone(),
                 exec_system_id: None,
+                auth_identity_id: None,
                 procedure_id: Some("curl".to_string()),
                 args: HashMap::new(),
                 reasoning: None,
@@ -939,6 +951,7 @@ fn prepare_action_materializes_abstract_http_request_procedure() {
                 action_id: "http-abstract".to_string(),
                 target_id,
                 exec_system_id: None,
+                auth_identity_id: None,
                 procedure_id: Some("curl".to_string()),
                 args: HashMap::new(),
                 reasoning: None,
@@ -1000,6 +1013,7 @@ fn prepare_action_materializes_steps_fetch_with_headers_and_chmod() {
                 action_id: "steps-abstract".to_string(),
                 target_id,
                 exec_system_id: None,
+                auth_identity_id: None,
                 procedure_id: Some("curl".to_string()),
                 args: HashMap::new(),
                 reasoning: None,
@@ -1118,6 +1132,7 @@ fn prepare_action_lateral_effect_grounds_lowercase_src_with_explicit_source_enti
                 action_id: "lateral-test".to_string(),
                 target_id: target_id.clone(),
                 exec_system_id: Some(source_id.clone()),
+                auth_identity_id: None,
                 procedure_id: None,
                 args: HashMap::new(),
                 reasoning: None,
@@ -1155,6 +1170,7 @@ fn nmap_exec_ttp(target_id: &str) -> ExecTtp {
         target_id: target_id.to_string(),
         exec_chain: vec![target_id.to_string()],
         exec_system_id: target_id.to_string(),
+        auth_identity_id: None,
         started_at_ms: 0,
         output_transform: None,
         is_cleanup: false,
@@ -1445,6 +1461,7 @@ fn prepare_action_wraps_kubelet_sink_with_ran_ws_envelope() {
                 action_id: "test-kubelet-wrap".to_string(),
                 target_id: target_id.clone(),
                 exec_system_id: None,
+                auth_identity_id: None,
                 procedure_id: None,
                 args: HashMap::new(),
                 reasoning: None,
@@ -1515,6 +1532,7 @@ fn prepare_action_builds_kubelet_sink_command_when_outer_envelope_missing() {
                 action_id: "test-kubelet-fallback".to_string(),
                 target_id: target_id.clone(),
                 exec_system_id: None,
+                auth_identity_id: None,
                 procedure_id: None,
                 args: HashMap::new(),
                 reasoning: None,
@@ -1593,6 +1611,7 @@ fn prepare_action_with_caller_supplied_source_keeps_direct_execution_for_service
                 action_id: "read-token".to_string(),
                 target_id: sa_id.clone(),
                 exec_system_id: Some(entry_id.clone()),
+                auth_identity_id: None,
                 procedure_id: None,
                 args: HashMap::new(),
                 reasoning: None,
@@ -1645,6 +1664,7 @@ fn prepare_action_with_caller_supplied_source_keeps_direct_execution_for_node_ta
                 action_id: "node-proxy-check".to_string(),
                 target_id: node_id.clone(),
                 exec_system_id: Some(entry_id.clone()),
+                auth_identity_id: None,
                 procedure_id: None,
                 args,
                 reasoning: None,
@@ -1738,6 +1758,7 @@ fn prepare_action_local_command_fallback_uses_in_cluster_source_for_pod_target()
             ExecuteActionRequest {
                 action_id: "test-local-fallback".to_string(),
                 exec_system_id: None,
+                auth_identity_id: None,
                 target_id: redis_id,
                 procedure_id: None,
                 args: HashMap::new(),
@@ -2456,6 +2477,7 @@ fn src_mount_path_grounded_for_non_lateral_ttp() {
                 action_id: "scan-node".to_string(),
                 target_id: target_id.clone(),
                 exec_system_id: Some(exec_id.clone()),
+                auth_identity_id: None,
                 procedure_id: None,
                 args: HashMap::new(),
                 reasoning: None,
@@ -2491,6 +2513,7 @@ fn prepare_action_with_ttp_produces_same_result_as_prepare_action() {
     let exec = campaign
         .prepare_action_with_ttp(
             target_id.clone(),
+            None,
             None,
             None,
             ttp,
@@ -2550,6 +2573,7 @@ fn build_cleanup_actions_returns_one_action_for_ttp_with_cleanup() {
         tactic: "Execution".to_string(),
         target_id: pod_id.clone(),
         exec_system_id: BUILTIN_C2_ID.to_string(),
+        auth_identity_id: None,
         procedure_id: "ubuntu".to_string(),
         command: "apt-get install -y curl".to_string(),
         args: std::collections::HashMap::from([("PKG".to_string(), "curl".to_string())]),
@@ -2569,6 +2593,7 @@ fn build_cleanup_actions_returns_one_action_for_ttp_with_cleanup() {
         tactic: "Discovery".to_string(),
         target_id: pod_id.clone(),
         exec_system_id: BUILTIN_C2_ID.to_string(),
+        auth_identity_id: None,
         procedure_id: "shell".to_string(),
         command: "id".to_string(),
         args: std::collections::HashMap::new(),
@@ -2614,6 +2639,7 @@ fn build_cleanup_actions_preserves_original_args_in_cleanup_command() {
         tactic: "Execution".to_string(),
         target_id: pod_id.clone(),
         exec_system_id: BUILTIN_C2_ID.to_string(),
+        auth_identity_id: None,
         procedure_id: "ubuntu".to_string(),
         command: "apt-get install -y wget".to_string(),
         args: std::collections::HashMap::from([("PKG".to_string(), "wget".to_string())]),
@@ -2643,6 +2669,59 @@ fn build_cleanup_actions_preserves_original_args_in_cleanup_command() {
 // ---------------------------------------------------------------------------
 
 use super::execution::materialize_k8s_request;
+
+#[test]
+fn active_kubeconfig_keeps_structured_request_for_native_execution() {
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+    let target_id = campaign
+        .entities
+        .values::<K8sCluster>()
+        .next()
+        .expect("cluster")
+        .entity_id()
+        .0;
+    let mut credential = K8sCredential::new("https://cluster.example").with_name("operator");
+    credential.active = true;
+    let credential_id = credential.entity_id().0;
+    campaign.entities.insert_typed(credential);
+    let ttp = Ttp {
+        status: "enabled".to_string(),
+        procedures: vec![Procedure {
+            k8s_request: Some(serde_json::json!({
+                "api_server": "https://cluster.example",
+                "api": "/api/v1",
+                "resource": "namespaces",
+                "cluster_scoped": true
+            })),
+            ..Procedure::new("k8s-request", "")
+        }],
+        ..Ttp::new("get-namespaces", "Get Namespaces", "Discovery")
+    };
+    let armory = Armory::from_ttps(vec![ttp]);
+
+    let exec = campaign
+        .prepare_action(
+            ExecuteActionRequest {
+                action_id: "get-namespaces".to_string(),
+                exec_system_id: None,
+                auth_identity_id: Some(credential_id.clone()),
+                target_id,
+                procedure_id: Some("k8s-request".to_string()),
+                args: HashMap::new(),
+                reasoning: None,
+            },
+            &armory,
+        )
+        .expect("active kubeconfig should prepare native request");
+
+    assert_eq!(
+        exec.auth_identity_id.as_deref(),
+        Some(credential_id.as_str())
+    );
+    assert!(exec.procedure.k8s_request.is_some());
+    assert!(exec.exec_chain.is_empty());
+    assert_eq!(exec.exec_system_id, BUILTIN_C2_ID);
+}
 
 /// Minimal armory with a curl tool TTP for use in k8s_request and http_request tests.
 fn curl_armory() -> Armory {

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -4,8 +4,8 @@ use armory::{Armory, Procedure, Ttp, TtpParam};
 use c2::{ExecTtp, TtpExecuted, BUILTIN_C2_ID};
 use ran_domain::{
     AccessLevel, C2Server, Container, ContainerEscape, Entity, EntityId, K8sCluster, K8sCredential,
-    K8sNode, KubeletExecSink, OutputTransformKind, Pod, PodExec, RbacPermission, RceCanExec,
-    RunsOn, ServiceAccount, SessionInfo, SessionStatus, Uses,
+    K8sNode, KubeletExecSink, Namespace, OutputTransformKind, Pod, PodExec, RbacPermission,
+    RceCanExec, RunsOn, ServiceAccount, SessionInfo, SessionStatus, Uses,
 };
 
 use super::{Campaign, ExecChannel, ExecuteActionError, ExecuteActionRequest};
@@ -2719,8 +2719,77 @@ fn active_kubeconfig_keeps_structured_request_for_native_execution() {
         Some(credential_id.as_str())
     );
     assert!(exec.procedure.k8s_request.is_some());
+    assert_eq!(exec.procedure.command, "GET /api/v1/namespaces");
     assert!(exec.exec_chain.is_empty());
     assert_eq!(exec.exec_system_id, BUILTIN_C2_ID);
+}
+
+#[test]
+fn active_kubeconfig_request_uses_namespace_target_and_records_request_line() {
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+    let namespace = Namespace::new("dungeon");
+    let target_id = namespace.entity_id().0;
+    campaign.entities.insert_typed(namespace);
+    let mut credential = K8sCredential::new("https://cluster.example").with_name("operator");
+    credential.active = true;
+    let credential_id = credential.entity_id().0;
+    campaign.entities.insert_typed(credential);
+    let ttp = Ttp {
+        status: "enabled".to_string(),
+        params: vec![
+            TtpParam {
+                name: "NS".to_string(),
+                param_type: "Namespace".to_string(),
+                description: String::new(),
+                required: true,
+                default: "${NS}".to_string(),
+            },
+            TtpParam {
+                name: "ALL_NS".to_string(),
+                param_type: "bool".to_string(),
+                description: String::new(),
+                required: true,
+                default: "false".to_string(),
+            },
+        ],
+        procedures: vec![Procedure {
+            k8s_request: Some(serde_json::json!({
+                "api_server": "https://cluster.example",
+                "api": "/api/v1",
+                "resource": "pods",
+                "namespace": "${NS}",
+                "cluster_scoped": "${ALL_NS}",
+                "query": "limit=500"
+            })),
+            ..Procedure::new("k8s-request", "")
+        }],
+        ..Ttp::new("get-pods", "Get Pods", "Discovery")
+    };
+    let armory = Armory::from_ttps(vec![ttp]);
+
+    let exec = campaign
+        .prepare_action(
+            ExecuteActionRequest {
+                action_id: "get-pods".to_string(),
+                exec_system_id: None,
+                auth_identity_id: Some(credential_id),
+                target_id,
+                procedure_id: Some("k8s-request".to_string()),
+                args: HashMap::new(),
+                reasoning: None,
+            },
+            &armory,
+        )
+        .expect("namespaced native request should prepare");
+
+    assert_eq!(exec.args.get("NS").map(String::as_str), Some("dungeon"));
+    assert_eq!(
+        exec.procedure.command,
+        "GET /api/v1/namespaces/dungeon/pods?limit=500"
+    );
+    let request = exec.procedure.k8s_request.expect("structured request");
+    assert_eq!(request["namespace"], "dungeon");
+    assert_eq!(request["cluster_scoped"], "false");
 }
 
 /// Minimal armory with a curl tool TTP for use in k8s_request and http_request tests.

--- a/crates/campaign/src/campaign/types.rs
+++ b/crates/campaign/src/campaign/types.rs
@@ -9,6 +9,8 @@ use crate::{FactsUpdate, ParseAudit};
 pub struct ExecuteActionRequest {
     pub action_id: String,
     pub exec_system_id: Option<String>,
+    #[serde(default)]
+    pub auth_identity_id: Option<String>,
     pub target_id: String,
     pub procedure_id: Option<String>,
     pub args: HashMap<String, String>,

--- a/crates/campaign/src/effects.rs
+++ b/crates/campaign/src/effects.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 use indexmap::IndexSet;
 use ran_domain::{
@@ -8,6 +8,7 @@ use ran_domain::{
 };
 
 use crate::grounding::resolve_template;
+use crate::{KnowledgeProvenance, RelationProvenanceKey};
 
 type SimpleEffectHandler = fn(&HashMap<String, String>) -> Result<FactsUpdate, String>;
 /// Handler for relation-style effects such as `rce.can-exec(src, tgt)`.
@@ -34,15 +35,24 @@ pub struct FactsUpdate {
     /// Used when a placeholder entity (e.g. IP-derived pod name from a network
     /// scan) is later identified as an already-known named entity.
     pub entity_aliases: IndexSet<(EntityId, EntityId)>,
+    pub entity_provenance: HashMap<EntityId, BTreeSet<KnowledgeProvenance>>,
+    pub relation_provenance: HashMap<RelationProvenanceKey, BTreeSet<KnowledgeProvenance>>,
 }
 
 impl FactsUpdate {
     pub fn merge(&mut self, other: Self) {
+        let FactsUpdate {
+            new_entities,
+            new_relations,
+            entity_aliases,
+            entity_provenance,
+            relation_provenance,
+        } = other;
         // Build O(1)-lookup sets from existing entries so each item from `other`
         // is checked in O(1) rather than O(n), avoiding the previous O(n²) scan.
         let seen_entities: IndexSet<EntityId> =
             self.new_entities.iter().map(|e| e.entity_id()).collect();
-        for entity in other.new_entities {
+        for entity in new_entities {
             if !seen_entities.contains(&entity.entity_id()) {
                 self.new_entities.push(entity);
             }
@@ -59,7 +69,7 @@ impl FactsUpdate {
                 )
             })
             .collect();
-        for rel in other.new_relations {
+        for rel in new_relations {
             let key = (
                 rel.relation_name().to_string(),
                 rel.source_id().clone(),
@@ -71,7 +81,34 @@ impl FactsUpdate {
         }
 
         // IndexSet::insert handles dedup natively — no scan needed.
-        self.entity_aliases.extend(other.entity_aliases);
+        self.entity_aliases.extend(entity_aliases);
+        for (id, origins) in entity_provenance {
+            self.entity_provenance
+                .entry(id)
+                .or_default()
+                .extend(origins);
+        }
+        for (key, origins) in relation_provenance {
+            self.relation_provenance
+                .entry(key)
+                .or_default()
+                .extend(origins);
+        }
+    }
+
+    pub fn attribute_unattributed(&mut self, provenance: KnowledgeProvenance) {
+        for entity in &self.new_entities {
+            self.entity_provenance
+                .entry(entity.entity_id())
+                .or_default()
+                .insert(provenance);
+        }
+        for relation in &self.new_relations {
+            self.relation_provenance
+                .entry(RelationProvenanceKey::from_relation(relation.as_ref()))
+                .or_default()
+                .insert(provenance);
+        }
     }
 }
 
@@ -186,6 +223,7 @@ fn parse_k8s_pod(args: &HashMap<String, String>) -> Result<FactsUpdate, String> 
         new_entities: vec![Box::new(pod)],
         new_relations: Vec::new(),
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -220,6 +258,7 @@ fn parse_k8s_serviceaccount(args: &HashMap<String, String>) -> Result<FactsUpdat
         new_entities: vec![Box::new(sa)],
         new_relations: Vec::new(),
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -240,6 +279,7 @@ fn parse_k8s_role(args: &HashMap<String, String>) -> Result<FactsUpdate, String>
         new_entities: vec![Box::new(role)],
         new_relations: Vec::new(),
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -264,6 +304,7 @@ fn parse_k8s_rolebinding(args: &HashMap<String, String>) -> Result<FactsUpdate, 
         new_entities: vec![Box::new(binding)],
         new_relations: Vec::new(),
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -286,6 +327,7 @@ fn parse_k8s_cronjob(args: &HashMap<String, String>) -> Result<FactsUpdate, Stri
         new_entities: vec![Box::new(cj)],
         new_relations: Vec::new(),
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -759,6 +801,7 @@ fn parse_c2_session_relation(
         new_entities: Vec::new(),
         new_relations: vec![Box::new(rel)],
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -774,6 +817,7 @@ fn parse_k8s_can_exec_relation(
         new_entities: Vec::new(),
         new_relations: vec![Box::new(rel)],
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -789,6 +833,7 @@ fn parse_k8s_can_reach_relation(
         new_entities: Vec::new(),
         new_relations: vec![Box::new(rel)],
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -804,6 +849,7 @@ fn parse_runs_on_relation(
         new_entities: Vec::new(),
         new_relations: vec![Box::new(rel)],
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -842,6 +888,7 @@ fn parse_kubelet_exec_source_relation(
         new_entities: Vec::new(),
         new_relations: vec![Box::new(rel)],
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -865,6 +912,7 @@ fn parse_rce_can_exec_relation(
         new_entities: Vec::new(),
         new_relations: vec![Box::new(rel)],
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 
@@ -951,6 +999,7 @@ fn parse_container_escape_relation(
             Box::new(ContainerEscape::new(src, &node_entity_id).with_opt_envelope(envelope)),
         ],
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     })
 }
 

--- a/crates/campaign/src/execution_record.rs
+++ b/crates/campaign/src/execution_record.rs
@@ -23,6 +23,9 @@ pub struct ExecutionRecord {
     pub target_id: String,
     /// ID of the entity the command physically executed on (pod, node, or C2 entity).
     pub exec_system_id: String,
+    /// Kubernetes authentication identity selected for this action.
+    #[serde(default)]
+    pub auth_identity_id: Option<String>,
     /// ID of the procedure variant that was selected.
     pub procedure_id: String,
     /// The fully-grounded command string that was sent to the C2 backend.
@@ -73,6 +76,7 @@ impl ExecutionRecord {
             tactic,
             target_id: request.target_id.clone(),
             exec_system_id: request.exec_system_id.clone().unwrap_or_default(),
+            auth_identity_id: request.auth_identity_id.clone(),
             procedure_id: request.procedure_id.clone().unwrap_or_default(),
             command: String::new(),
             args: request.args.clone(),
@@ -100,6 +104,7 @@ impl ExecutionRecord {
             tactic: cmd.ttp.tactic.clone(),
             target_id: cmd.target_id.clone(),
             exec_system_id: cmd.exec_target().to_string(),
+            auth_identity_id: cmd.auth_identity_id.clone(),
             procedure_id: cmd.procedure.id.clone(),
             command: cmd.procedure.command.clone(),
             args: cmd.args.clone(),

--- a/crates/campaign/src/failure_analyzers.rs
+++ b/crates/campaign/src/failure_analyzers.rs
@@ -435,6 +435,7 @@ mod tests {
             target_id: "ns/default/pod/demo".to_string(),
             exec_chain: vec!["ns/default/pod/demo".to_string()],
             exec_system_id: String::new(),
+            auth_identity_id: None,
             started_at_ms: 0,
             output_transform: None,
             is_cleanup: false,

--- a/crates/campaign/src/grounding.rs
+++ b/crates/campaign/src/grounding.rs
@@ -572,7 +572,7 @@ pub fn detect_ungrounded_vars(cmd: &str) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ran_domain::{Entity, JwToken, K8sCluster, Pod, ServiceAccountToken};
+    use ran_domain::{Entity, JwToken, K8sCluster, Namespace, Pod, ServiceAccountToken};
 
     use crate::campaign::Campaign;
 
@@ -601,6 +601,19 @@ mod tests {
         ground_args_from_context(&mut args, &target_id, &campaign);
 
         assert_eq!(args["NS"], "staging");
+    }
+
+    #[test]
+    fn ground_args_fills_ns_from_namespace_target() {
+        let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+        let namespace = Namespace::new("dungeon");
+        let target_id = namespace.entity_id().0.clone();
+        campaign.entities.insert_typed(namespace);
+
+        let mut args = HashMap::from([("NS".to_string(), "${NS}".to_string())]);
+        ground_args_from_context(&mut args, &target_id, &campaign);
+
+        assert_eq!(args["NS"], "dungeon");
     }
 
     #[test]

--- a/crates/campaign/src/lib.rs
+++ b/crates/campaign/src/lib.rs
@@ -7,6 +7,7 @@ pub mod failure_analyzers;
 pub mod grounding;
 pub mod output_parsers;
 pub mod pending_view;
+pub mod provenance;
 pub mod rules;
 pub mod runtime;
 pub mod shell_cmd;
@@ -17,16 +18,19 @@ pub use c2::ExecTtp;
 pub use campaign::{
     best_tool_readiness, Campaign, CampaignEntityRef, CampaignSystemEntityMut,
     CampaignSystemEntityRef, EntityType, ExecuteActionError, ExecuteActionRequest,
-    ExecuteActionResult, ExecutedActionEvent, TtpExecutionProcessing,
+    ExecuteActionResult, ExecutedActionEvent, InitialClusterKnowledge, InitialKnowledge,
+    InitialKubeconfigKnowledge, TtpExecutionProcessing,
 };
 pub use effects::{EffectCategory, EffectKind, FactsUpdate};
 pub use execution_record::ExecutionRecord;
 pub use external_parser::{ExternalParseRequest, ExternalParseResponse, ExternalParser};
 pub use output_parsers::{ParseAudit, ParseResult};
 pub use pending_view::PendingView;
+pub use provenance::{KnowledgeProvenance, KnowledgeProvenanceStore, RelationProvenanceKey};
 pub use rules::{run_rules_fixpoint, InferenceRule};
 pub use runtime::{
     spawn_c2_event_processor, spawn_c2_event_processor_with_external_parser, CampaignEvent,
     CampaignEventBus, EntitySummary,
 };
 pub use traversal::{CommandTraversal, TraversalHop};
+pub use ttp_applicability::AuthIdentitySummary;

--- a/crates/campaign/src/output_parsers/file.rs
+++ b/crates/campaign/src/output_parsers/file.rs
@@ -1,8 +1,6 @@
-use ran_domain::{Entity, K8sCredential, Uses};
-use serde::Deserialize;
-
 use super::ParserOutput;
 use crate::FactsUpdate;
+use ran_domain::{Entity, K8sCredential, Uses};
 
 // ---------------------------------------------------------------------------
 // Path extraction
@@ -46,38 +44,6 @@ pub(super) fn is_kubeconfig_content(content: &str) -> bool {
 // Kubeconfig YAML parsing
 // ---------------------------------------------------------------------------
 
-#[derive(Debug, Deserialize)]
-struct KubeconfigYaml {
-    clusters: Option<Vec<ClusterEntry>>,
-    users: Option<Vec<UserEntry>>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ClusterEntry {
-    cluster: Option<ClusterData>,
-}
-
-#[derive(Debug, Deserialize)]
-struct ClusterData {
-    server: Option<String>,
-    #[serde(rename = "certificate-authority-data")]
-    certificate_authority_data: Option<String>,
-}
-
-#[derive(Debug, Deserialize)]
-struct UserEntry {
-    user: Option<UserData>,
-}
-
-#[derive(Debug, Deserialize)]
-struct UserData {
-    token: Option<String>,
-    #[serde(rename = "client-certificate-data")]
-    client_certificate_data: Option<String>,
-    #[serde(rename = "client-key-data")]
-    client_key_data: Option<String>,
-}
-
 /// Parse kubeconfig YAML and build a `K8sCredential` entity.
 ///
 /// Extracts the first cluster's `server` and `certificate-authority-data`, and
@@ -85,33 +51,18 @@ struct UserData {
 ///
 /// Returns `None` when the YAML does not contain a usable cluster entry.
 fn credential_from_kubeconfig(content: &str) -> Option<K8sCredential> {
-    let kc: KubeconfigYaml = serde_yaml::from_str(content).ok()?;
-
-    let cluster = kc
-        .clusters
-        .as_ref()
-        .and_then(|c| c.first())
-        .and_then(|e| e.cluster.as_ref());
-
-    let endpoint = cluster.and_then(|c| c.server.clone()).unwrap_or_default();
-
-    let ca_data = cluster.and_then(|c| c.certificate_authority_data.clone());
-
-    let user = kc
-        .users
-        .as_ref()
-        .and_then(|u| u.first())
-        .and_then(|e| e.user.as_ref());
-
-    let token = user.and_then(|u| u.token.clone());
-    let cert_data = user.and_then(|u| u.client_certificate_data.clone());
-    let key_data = user.and_then(|u| u.client_key_data.clone());
-
-    let mut cred = K8sCredential::new(&endpoint);
-    cred.ca_data = ca_data;
-    cred.token = token;
-    cred.cert_data = cert_data;
-    cred.key_data = key_data;
+    let resolved = k8s::resolve_kubeconfig_yaml(content, None).ok()?;
+    let mut cred = K8sCredential::new(resolved.server.clone().unwrap_or_default());
+    cred.context_name = Some(resolved.context_name);
+    cred.user_name = resolved.user_name;
+    cred.auth_method = resolved.auth_method;
+    cred.has_token = resolved.has_token;
+    cred.has_client_certificate = resolved.has_client_certificate;
+    cred.has_client_key = resolved.has_client_key;
+    cred.ca_data = resolved.ca_data;
+    cred.token = resolved.token;
+    cred.cert_data = resolved.cert_data;
+    cred.key_data = resolved.key_data;
 
     Some(cred)
 }

--- a/crates/campaign/src/output_parsers/iam.rs
+++ b/crates/campaign/src/output_parsers/iam.rs
@@ -3,8 +3,8 @@ use std::collections::HashMap;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use ran_domain::{
-    Contains, Entity, JwToken, K8sNode, NameConfidence, Namespace, Pod, RbacPermission, RunsOn,
-    ServiceAccount, ServiceAccountToken, Uses,
+    Contains, Entity, JwToken, K8sCredential, K8sNode, NameConfidence, Namespace, Pod,
+    RbacPermission, RunsOn, ServiceAccount, ServiceAccountToken, Uses,
 };
 use serde::Deserialize;
 
@@ -363,6 +363,7 @@ pub(super) fn parse_self_subject_rules_review(
     _stderr: &str,
     target_id: &str,
     token_arg: &str,
+    namespace_arg: &str,
 ) -> ParserOutput {
     if stdout.trim().is_empty() {
         return ParserOutput::KnownFailure("empty output".to_string());
@@ -394,19 +395,28 @@ pub(super) fn parse_self_subject_rules_review(
     };
     let (resource_rules, non_resource_rules) = rules;
 
-    // Resolve SA identity from the TOKEN arg (preferred — the JWT identifies the
-    // exact SA whose permissions were reviewed) or from the target_id entity ID
-    // string (for SA targets like `ns/default/sa/mysa`).
-    // Pod targets require a TOKEN arg; without one the namespace/name cannot be
-    // determined without campaign access, which parsers must not use.
-    let Some((sa_name, sa_namespace)) =
+    // Kubeconfig reviews are attributed directly to the selected credential.
+    // Service-account reviews retain the existing JWT/target-ID resolution.
+    let credential_name = target_id.strip_prefix("k8s/credential/");
+    let service_account = if credential_name.is_some() {
+        None
+    } else {
         resolve_sa_from_token(token_arg).or_else(|| parse_sa_identity_from_target(target_id))
-    else {
-        return ParserOutput::KnownFailure(format!(
-            "cannot resolve a ServiceAccount for target '{target_id}': \
-             no valid TOKEN arg and target is not an SA entity ID (ns/…/sa/…)"
-        ));
     };
+    if credential_name.is_none() && service_account.is_none() {
+        return ParserOutput::KnownFailure(format!(
+            "cannot resolve an RBAC identity for target '{target_id}': \
+             target is neither a K8sCredential nor a ServiceAccount and TOKEN is invalid"
+        ));
+    }
+    let permission_namespace = credential_name
+        .map(|_| namespace_arg.trim())
+        .or_else(|| {
+            service_account
+                .as_ref()
+                .map(|(_, namespace)| namespace.as_str())
+        })
+        .unwrap_or("");
     let mut entitlements: Vec<RbacPermission> = Vec::new();
 
     for rule in &resource_rules {
@@ -427,9 +437,9 @@ pub(super) fn parse_self_subject_rules_review(
 
                 for api_group in &effective_groups {
                     let scope = if is_namespaced_resource(resource, api_group)
-                        && !sa_namespace.is_empty()
+                        && !permission_namespace.is_empty()
                     {
-                        Some(sa_namespace.clone())
+                        Some(permission_namespace.to_string())
                     } else {
                         None
                     };
@@ -464,11 +474,16 @@ pub(super) fn parse_self_subject_rules_review(
     }
 
     let perm_count = entitlements.len();
-    let mut sa = ServiceAccount::new(&sa_name, &sa_namespace);
-    sa.entitlements = entitlements;
-
     let mut facts = FactsUpdate::default();
-    facts.new_entities.push(Box::new(sa));
+    if let Some(name) = credential_name {
+        let mut credential = K8sCredential::new("").with_name(name);
+        credential.entitlements = entitlements;
+        facts.new_entities.push(Box::new(credential));
+    } else if let Some((sa_name, sa_namespace)) = service_account {
+        let mut sa = ServiceAccount::new(sa_name, sa_namespace);
+        sa.entitlements = entitlements;
+        facts.new_entities.push(Box::new(sa));
+    }
 
     ParserOutput::SuccessWithFacts(
         facts,
@@ -998,6 +1013,7 @@ mod tests {
             "",
             "ns/default/pod/some-other-pod", // target_id is a pod — SA comes from JWT
             &jwt,
+            "",
         );
 
         let ParserOutput::SuccessWithFacts(facts, detail) = result else {
@@ -1035,8 +1051,13 @@ mod tests {
 
         // target_id is the SA entity ID — identity is parsed from the string directly,
         // no campaign lookup required.
-        let result =
-            parse_self_subject_rules_review(kubectl_output, "", "ns/default/sa/mysa", &non_k8s_jwt);
+        let result = parse_self_subject_rules_review(
+            kubectl_output,
+            "",
+            "ns/default/sa/mysa",
+            &non_k8s_jwt,
+            "",
+        );
 
         let ParserOutput::SuccessWithFacts(facts, _) = result else {
             panic!("expected SuccessWithFacts, got {:?}", result);
@@ -1064,6 +1085,7 @@ mod tests {
             "",
             "ns/default/pod/some-pod",
             "", // no token
+            "",
         );
 
         assert!(
@@ -1071,5 +1093,46 @@ mod tests {
             "expected KnownFailure for pod target without TOKEN, got {:?}",
             result
         );
+    }
+
+    #[test]
+    fn ssrr_parser_attributes_permissions_to_kubeconfig_credential() {
+        let response = r#"{
+            "status": {
+                "resourceRules": [{
+                    "verbs": ["get", "list"],
+                    "apiGroups": [""],
+                    "resources": ["pods"],
+                    "resourceNames": []
+                }],
+                "nonResourceRules": [],
+                "incomplete": false
+            }
+        }"#;
+
+        let result = parse_self_subject_rules_review(
+            response,
+            "",
+            "k8s/credential/developer-kubeconfig",
+            "",
+            "dungeon",
+        );
+
+        let ParserOutput::SuccessWithFacts(facts, _) = result else {
+            panic!("expected SuccessWithFacts, got {:?}", result);
+        };
+        let credential = facts.new_entities[0]
+            .as_any()
+            .downcast_ref::<K8sCredential>()
+            .expect("permissions should update the K8sCredential");
+        assert_eq!(
+            credential.entity_id().0,
+            "k8s/credential/developer-kubeconfig"
+        );
+        assert!(credential.entitlements.iter().any(|permission| {
+            permission.verb == "list"
+                && permission.resource_type == "pods"
+                && permission.scope.as_deref() == Some("dungeon")
+        }));
     }
 }

--- a/crates/campaign/src/output_parsers/k8s.rs
+++ b/crates/campaign/src/output_parsers/k8s.rs
@@ -12,6 +12,7 @@ use super::ParserOutput;
 use crate::FactsUpdate;
 
 pub(super) fn register(m: &mut HashMap<&'static str, super::ParserFn>) {
+    m.insert("k8s.namespacelist", parse_k8s_namespace_list);
     m.insert("k8s.podlist", parse_k8s_pod_list);
     m.insert("k8s.nodelist", parse_k8s_node_list);
     m.insert("k8s.serviceaccountlist", parse_k8s_service_account_list);
@@ -57,6 +58,21 @@ mod k8s_json {
         pub uid: Option<String>,
         #[serde(rename = "ownerReferences", default)]
         pub owner_references: Vec<OwnerReference>,
+        #[serde(default)]
+        pub labels: HashMap<String, String>,
+    }
+
+    // --- Namespace ---
+
+    #[derive(Deserialize)]
+    pub struct NamespaceItem {
+        pub metadata: Meta,
+    }
+
+    #[derive(Deserialize)]
+    pub struct NamespaceList {
+        #[serde(default)]
+        pub items: Vec<NamespaceItem>,
     }
 
     // --- Pod ---
@@ -603,6 +619,44 @@ fn check_k8s_api_error(stdout: &str) -> Option<ParserOutput> {
     } else {
         None
     }
+}
+
+fn parse_k8s_namespace_list(
+    stdout: &str,
+    _stderr: &str,
+    _args: &HashMap<String, String>,
+) -> ParserOutput {
+    if stdout.trim().is_empty() {
+        return ParserOutput::KnownFailure("empty stdout".to_string());
+    }
+    if let Some(error) = check_k8s_api_error(stdout) {
+        return error;
+    }
+    let list: k8s_json::NamespaceList = match serde_json::from_str(stdout) {
+        Ok(list) => list,
+        Err(error) => {
+            return ParserOutput::UnknownFormat(format!("JSON parse error: {error}"));
+        }
+    };
+    if list.items.is_empty() {
+        return ParserOutput::KnownFailure("NamespaceList contained no items".to_string());
+    }
+
+    let mut facts = FactsUpdate::default();
+    for item in list.items {
+        if item.metadata.name.is_empty() {
+            continue;
+        }
+        let mut namespace = Namespace::new(item.metadata.name);
+        namespace.labels = item.metadata.labels;
+        facts.new_entities.push(Box::new(namespace));
+    }
+
+    let count = facts.new_entities.len();
+    ParserOutput::SuccessWithFacts(
+        facts,
+        format!("parsed {count} namespace(s) from NamespaceList"),
+    )
 }
 
 fn parse_k8s_pod_list(
@@ -1485,4 +1539,43 @@ fn parse_k8s_http_route_list(
         facts,
         format!("parsed {} HTTPRoute(s) from HTTPRouteList", count),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn namespace_list_emits_namespace_entities_with_labels() {
+        let output = r#"{
+            "kind": "NamespaceList",
+            "items": [
+                {"metadata": {"name": "default", "labels": {"environment": "shared"}}},
+                {"metadata": {"name": "dungeon", "labels": {"team": "red"}}}
+            ]
+        }"#;
+
+        let result = parse_k8s_namespace_list(output, "", &HashMap::new());
+        let ParserOutput::SuccessWithFacts(facts, detail) = result else {
+            panic!("expected namespace facts, got {result:?}");
+        };
+
+        assert_eq!(detail, "parsed 2 namespace(s) from NamespaceList");
+        let namespaces: Vec<&Namespace> = facts
+            .new_entities
+            .iter()
+            .filter_map(|entity| entity.as_any().downcast_ref::<Namespace>())
+            .collect();
+        assert_eq!(namespaces.len(), 2);
+        assert!(namespaces.iter().any(|namespace| {
+            namespace.name == "dungeon"
+                && namespace.labels.get("team").map(String::as_str) == Some("red")
+        }));
+    }
+
+    #[test]
+    fn namespace_list_rejects_empty_items() {
+        let result = parse_k8s_namespace_list(r#"{"items": []}"#, "", &HashMap::new());
+        assert!(matches!(result, ParserOutput::KnownFailure(_)));
+    }
 }

--- a/crates/campaign/src/output_parsers/mod.rs
+++ b/crates/campaign/src/output_parsers/mod.rs
@@ -202,6 +202,7 @@ pub fn parse_output_effect(
         network::parse_nmap(stdout, source_id, cidr)
     } else if normalized == "k8s.selfsubjectrulesreview" {
         let token_arg = cmd.args.get("TOKEN").map(String::as_str).unwrap_or("");
+        let namespace_arg = cmd.args.get("NS").map(String::as_str).unwrap_or("");
         // When an exec system is selected, cmd.target_id is rewritten to the pod ID.
         // TARGET_ID always holds the original logical target (SA entity) from the request.
         let fallback_target = cmd
@@ -209,7 +210,13 @@ pub fn parse_output_effect(
             .get("TARGET_ID")
             .map(String::as_str)
             .unwrap_or(&cmd.target_id);
-        iam::parse_self_subject_rules_review(stdout, stderr, fallback_target, token_arg)
+        iam::parse_self_subject_rules_review(
+            stdout,
+            stderr,
+            fallback_target,
+            token_arg,
+            namespace_arg,
+        )
     } else if normalized.starts_with("file:content(") {
         // Parametric effect: path is in the effect ID, not in args.
         // Step 1: record the path in the target's system.files via apply_system_update.
@@ -363,6 +370,7 @@ fn parse_sys_node_name(campaign: &Campaign, cmd: &ExecTtp, stdout: &str) -> Pars
         new_entities: vec![Box::new(real_node)],
         new_relations: vec![],
         entity_aliases: IndexSet::new(),
+        ..Default::default()
     };
     if let Some(stale) = stale_node_id {
         tracing::info!(
@@ -693,6 +701,7 @@ mod tests {
             target_id: "ns/default/pod/demo".to_string(),
             exec_chain: vec!["ns/default/pod/demo".to_string()],
             exec_system_id: String::new(),
+            auth_identity_id: None,
             started_at_ms: 0,
             output_transform: None,
             is_cleanup: false,

--- a/crates/campaign/src/provenance.rs
+++ b/crates/campaign/src/provenance.rs
@@ -1,0 +1,103 @@
+use std::collections::{BTreeSet, HashMap};
+
+use ran_domain::{EntityId, Relation};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum KnowledgeProvenance {
+    Scenario,
+    Operator,
+    Action,
+    Inference,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct RelationProvenanceKey(String);
+
+impl RelationProvenanceKey {
+    pub fn new(
+        name: impl Into<String>,
+        source_id: impl Into<String>,
+        target_id: impl Into<String>,
+    ) -> Self {
+        let name = name.into();
+        let source_id = EntityId::new(source_id);
+        let target_id = EntityId::new(target_id);
+        Self(format!(
+            "{}\u{1f}{}\u{1f}{}",
+            name, source_id.0, target_id.0
+        ))
+    }
+
+    pub fn from_relation(relation: &dyn Relation) -> Self {
+        Self::new(
+            relation.relation_name(),
+            relation.source_id().0.clone(),
+            relation.target_id().0.clone(),
+        )
+    }
+
+    fn parts(&self) -> Option<(&str, &str, &str)> {
+        let mut parts = self.0.splitn(3, '\u{1f}');
+        Some((parts.next()?, parts.next()?, parts.next()?))
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct KnowledgeProvenanceStore {
+    #[serde(default)]
+    pub entities: HashMap<EntityId, BTreeSet<KnowledgeProvenance>>,
+    #[serde(default)]
+    pub relations: HashMap<RelationProvenanceKey, BTreeSet<KnowledgeProvenance>>,
+}
+
+impl KnowledgeProvenanceStore {
+    pub fn add_entity(&mut self, id: EntityId, provenance: KnowledgeProvenance) {
+        self.entities.entry(id).or_default().insert(provenance);
+    }
+
+    pub fn add_relation(&mut self, key: RelationProvenanceKey, provenance: KnowledgeProvenance) {
+        self.relations.entry(key).or_default().insert(provenance);
+    }
+
+    pub fn entity(&self, id: &EntityId) -> BTreeSet<KnowledgeProvenance> {
+        self.entities.get(id).cloned().unwrap_or_default()
+    }
+
+    pub fn relation(&self, key: &RelationProvenanceKey) -> BTreeSet<KnowledgeProvenance> {
+        self.relations.get(key).cloned().unwrap_or_default()
+    }
+
+    pub fn merge_entity(&mut self, stale: &EntityId, preferred: &EntityId) {
+        if let Some(origins) = self.entities.remove(stale) {
+            self.entities
+                .entry(preferred.clone())
+                .or_default()
+                .extend(origins);
+        }
+
+        let mut rewritten = HashMap::new();
+        for (key, origins) in std::mem::take(&mut self.relations) {
+            let Some((name, source, target)) = key.parts() else {
+                rewritten.entry(key).or_insert(origins);
+                continue;
+            };
+            let source = if source == stale.0 {
+                preferred.0.as_str()
+            } else {
+                source
+            };
+            let target = if target == stale.0 {
+                preferred.0.as_str()
+            } else {
+                target
+            };
+            rewritten
+                .entry(RelationProvenanceKey::new(name, source, target))
+                .or_insert_with(BTreeSet::new)
+                .extend(origins);
+        }
+        self.relations = rewritten;
+    }
+}

--- a/crates/campaign/src/rules.rs
+++ b/crates/campaign/src/rules.rs
@@ -1,4 +1,4 @@
-use crate::{Campaign, FactsUpdate};
+use crate::{Campaign, FactsUpdate, KnowledgeProvenance};
 
 pub trait InferenceRule: Send + Sync {
     fn name(&self) -> &'static str;
@@ -23,7 +23,8 @@ pub fn run_rules_fixpoint(
         let mut next = FactsUpdate::default();
 
         for rule in rules {
-            let inferred = rule.infer(campaign, &acc);
+            let mut inferred = rule.infer(campaign, &acc);
+            inferred.attribute_unattributed(KnowledgeProvenance::Inference);
             let has_output = !inferred.new_entities.is_empty()
                 || !inferred.new_relations.is_empty()
                 || !inferred.entity_aliases.is_empty();

--- a/crates/campaign/src/ttp_applicability.rs
+++ b/crates/campaign/src/ttp_applicability.rs
@@ -1,7 +1,111 @@
-use ran_domain::{AccessLevel, C2Server, Entity as _, Pod, ServiceAccount};
+use ran_domain::{AccessLevel, C2Server, Entity as _, K8sCredential, Pod, ServiceAccount};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{Campaign, CampaignEntityRef};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AuthIdentitySummary {
+    pub id: String,
+    pub name: String,
+    pub kind: String,
+}
+
+pub fn ttp_uses_k8s_auth(ttp: &armory::Ttp) -> bool {
+    ttp.procedures.iter().any(|procedure| {
+        procedure.k8s_request.is_some()
+            || procedure.command.contains("kubectl ")
+            || procedure
+                .command
+                .trim_start()
+                .starts_with("k8sSelfSubjectRulesReview(")
+    })
+}
+
+fn entitlements_satisfy(ttp: &armory::Ttp, entitlements: &[ran_domain::RbacPermission]) -> bool {
+    let Some(Value::Array(requirements)) = ttp.requires.get("rbacPermissions") else {
+        return true;
+    };
+    requirements.iter().all(|requirement| {
+        let Some(requirement) = requirement.as_object() else {
+            return true;
+        };
+        let verb = requirement
+            .get("verb")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let resource = requirement
+            .get("resourceType")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        (verb.is_empty() || resource.is_empty())
+            || entitlements
+                .iter()
+                .any(|permission| permission.satisfies(verb, resource))
+    })
+}
+
+/// Return the executable identities that witness this action's existential
+/// authentication/RBAC precondition. Identity-inspection actions are pinned to
+/// the selected identity target; other Kubernetes actions may use any matching
+/// active kubeconfig or captured ServiceAccount token.
+pub fn eligible_auth_identities(
+    ttp: &armory::Ttp,
+    campaign: &Campaign,
+    target_id: &str,
+) -> Vec<AuthIdentitySummary> {
+    if !ttp_uses_k8s_auth(ttp) {
+        return Vec::new();
+    }
+
+    let identity_target = ttp
+        .requires
+        .get("kind")
+        .and_then(Value::as_str)
+        .filter(|kind| matches!(*kind, "ServiceAccount" | "K8sCredential"));
+    let active_kubeconfig_required = ttp
+        .requires
+        .get("activeKubeconfig")
+        .and_then(Value::as_bool)
+        == Some(true);
+
+    let mut identities = Vec::new();
+    if !active_kubeconfig_required {
+        identities.extend(
+            campaign
+                .entities
+                .values::<ServiceAccount>()
+                .filter(|account| account.raw_token().is_some())
+                .filter(|account| {
+                    identity_target != Some("ServiceAccount") || account.entity_id().0 == target_id
+                })
+                .filter(|account| entitlements_satisfy(ttp, &account.entitlements))
+                .map(|account| AuthIdentitySummary {
+                    id: account.entity_id().0,
+                    name: account.entity_name().to_string(),
+                    kind: "ServiceAccount".to_string(),
+                }),
+        );
+    }
+    identities.extend(
+        campaign
+            .entities
+            .values::<K8sCredential>()
+            .filter(|credential| credential.active)
+            .filter(|credential| {
+                identity_target != Some("K8sCredential") || credential.entity_id().0 == target_id
+            })
+            .filter(|credential| entitlements_satisfy(ttp, &credential.entitlements))
+            .map(|credential| AuthIdentitySummary {
+                id: credential.entity_id().0,
+                name: credential.entity_name().to_string(),
+                kind: "K8sCredential".to_string(),
+            }),
+    );
+    identities.sort_by(|a, b| a.name.cmp(&b.name).then(a.id.cmp(&b.id)));
+    identities
+}
 
 /// The per-target facts the applicability predicates need to evaluate a TTP
 /// against a concrete entity. Resolved once per target via
@@ -19,6 +123,8 @@ pub struct TargetContext {
     pub access_level: AccessLevel,
     /// `true` when the target is a ServiceAccount holding a non-empty token.
     pub has_token: bool,
+    /// `true` when the target credential backs the process' active K8s client.
+    pub active_kubeconfig: bool,
 }
 
 /// Resolve the [`TargetContext`] for `target_id` from current campaign state.
@@ -61,6 +167,10 @@ pub fn resolve_target_context(campaign: &Campaign, target_id: &str) -> Option<Ta
         CampaignEntityRef::ServiceAccount(sa) => sa.raw_token().is_some(),
         _ => false,
     };
+    let active_kubeconfig = match &entity {
+        CampaignEntityRef::K8sCredential(credential) => credential.active,
+        _ => false,
+    };
 
     Some(TargetContext {
         target_id: target_id.to_string(),
@@ -68,6 +178,7 @@ pub fn resolve_target_context(campaign: &Campaign, target_id: &str) -> Option<Ta
         is_system,
         access_level,
         has_token,
+        active_kubeconfig,
     })
 }
 
@@ -84,6 +195,7 @@ pub fn ttp_applicable_for_target(
         && ttp_exists_satisfied(ttp, campaign)
         && (!tc.is_system || ttp_access_level_satisfied(ttp, tc.access_level))
         && ttp_has_token_satisfied(ttp, tc.has_token)
+        && ttp_active_kubeconfig_satisfied(ttp, tc.active_kubeconfig)
         && ttp_related_satisfied(ttp, &tc.target_id, &tc.target_kind, campaign)
         && ttp_tool_satisfied(ttp, campaign, tc)
 }
@@ -174,12 +286,13 @@ pub fn ttp_exists_satisfied(ttp: &armory::Ttp, campaign: &Campaign) -> bool {
 }
 
 /// Returns `true` when the TTP's RBAC requirements are satisfied by at least
-/// one captured ServiceAccount in the campaign.
+/// one captured ServiceAccount or kubeconfig credential in the campaign.
 ///
 /// - No `rbacPermissions` in `requires` → satisfied (no restriction).
-/// - `rbacPermissions` is present but the campaign has **no** ServiceAccounts
-///   → not satisfied (we have no identity to act with).
-/// - At least one SA must satisfy **all** required permissions.
+/// - `rbacPermissions` is present but no known identity has matching
+///   entitlements → not satisfied.
+/// - At least one ServiceAccount or K8sCredential must satisfy **all** required
+///   permissions.
 pub fn ttp_rbac_satisfied(ttp: &armory::Ttp, campaign: &Campaign) -> bool {
     let Some(Value::Array(reqs)) = ttp.requires.get("rbacPermissions") else {
         return true;
@@ -189,31 +302,30 @@ pub fn ttp_rbac_satisfied(ttp: &armory::Ttp, campaign: &Campaign) -> bool {
         return true;
     }
 
-    // RBAC requirement present: we need at least one known SA that covers all of them.
-    if campaign.entities.get::<ServiceAccount>().is_empty() {
-        return false;
+    campaign
+        .entities
+        .values::<ServiceAccount>()
+        .filter(|account| account.raw_token().is_some())
+        .any(|account| entitlements_satisfy(ttp, &account.entitlements))
+        || campaign
+            .entities
+            .values::<K8sCredential>()
+            .filter(|credential| credential.active)
+            .any(|credential| entitlements_satisfy(ttp, &credential.entitlements))
+}
+
+/// Gate actions that explicitly operate through the process' active
+/// kubeconfig. This prevents a knowledge-only seeded/discovered credential
+/// from accidentally running through a different identity.
+pub fn ttp_active_kubeconfig_satisfied(ttp: &armory::Ttp, active: bool) -> bool {
+    match ttp
+        .requires
+        .get("activeKubeconfig")
+        .and_then(Value::as_bool)
+    {
+        Some(true) => active,
+        _ => true,
     }
-
-    campaign.entities.values::<ServiceAccount>().any(|sa| {
-        reqs.iter().all(|req| {
-            let Some(obj) = req.as_object() else {
-                return true; // under-specified — assume satisfied
-            };
-            let verb = obj.get("verb").and_then(Value::as_str).unwrap_or("");
-            let resource = obj
-                .get("resourceType")
-                .and_then(Value::as_str)
-                .unwrap_or("");
-
-            if verb.is_empty() || resource.is_empty() {
-                return true; // under-specified — assume satisfied
-            }
-
-            sa.entitlements
-                .iter()
-                .any(|perm| perm.satisfies(verb, resource))
-        })
-    })
 }
 
 /// Returns `true` when the TTP's `has-token` requirement is satisfied by the target entity.
@@ -327,7 +439,7 @@ pub fn ttp_related_satisfied(
 #[cfg(test)]
 mod tests {
     use armory::Ttp;
-    use ran_domain::{C2Server, K8sCluster, RbacPermission, ServiceAccount};
+    use ran_domain::{C2Server, K8sCluster, K8sCredential, RbacPermission, ServiceAccount};
     use serde_json::json;
 
     use ran_domain::AccessLevel;
@@ -361,6 +473,15 @@ mod tests {
     fn campaign_with_sa(verb: &str, resource_type: &str) -> crate::Campaign {
         let mut c = empty_campaign();
         let mut sa = ServiceAccount::new("attacker", "default");
+        sa.token = Some(ServiceAccountToken {
+            jwt: JwToken {
+                raw: "header.payload.signature".to_string(),
+                ..Default::default()
+            },
+            namespace: "default".to_string(),
+            service_account_name: "attacker".to_string(),
+            ..Default::default()
+        });
         sa.entitlements
             .push(RbacPermission::new(verb, resource_type));
         c.entities.insert_typed(sa);
@@ -480,8 +601,8 @@ mod tests {
     }
 
     #[test]
-    fn rbac_not_satisfied_when_no_service_accounts_in_campaign() {
-        // TTP has RBAC requirements but no SA has been captured yet → must fail.
+    fn rbac_not_satisfied_when_no_identity_has_permissions() {
+        // TTP has RBAC requirements but no identity has been reviewed yet.
         assert!(!ttp_rbac_satisfied(
             &ttp_with_rbac("delete", "events"),
             &empty_campaign()
@@ -504,6 +625,49 @@ mod tests {
     fn rbac_satisfied_by_wildcard_sa_entitlement() {
         let c = campaign_with_sa("*", "*");
         assert!(ttp_rbac_satisfied(&ttp_with_rbac("delete", "events"), &c));
+    }
+
+    #[test]
+    fn rbac_satisfied_when_matching_kubeconfig_credential_exists() {
+        let mut c = empty_campaign();
+        let mut credential = K8sCredential::new("https://cluster.example");
+        credential.active = true;
+        credential
+            .entitlements
+            .push(RbacPermission::new("list", "pods"));
+        c.entities.insert_typed(credential);
+
+        assert!(ttp_rbac_satisfied(&ttp_with_rbac("list", "pods"), &c));
+        assert!(!ttp_rbac_satisfied(&ttp_with_rbac("delete", "pods"), &c));
+    }
+
+    #[test]
+    fn eligible_identities_return_the_witnesses_for_global_rbac_applicability() {
+        let mut campaign = campaign_with_sa("list", "pods");
+        let mut credential =
+            K8sCredential::new("https://cluster.example").with_name("operator-kubeconfig");
+        credential.active = true;
+        credential
+            .entitlements
+            .push(RbacPermission::new("list", "pods"));
+        let credential_id = credential.entity_id().0;
+        campaign.entities.insert_typed(credential);
+
+        let mut ttp = ttp_with_rbac("list", "pods");
+        ttp.procedures = vec![armory::Procedure::new(
+            "kubectl",
+            "kubectl get pods --output=json",
+        )];
+        let identities =
+            super::eligible_auth_identities(&ttp, &campaign, "k8s/cluster/test-cluster");
+
+        assert_eq!(identities.len(), 2);
+        assert!(identities
+            .iter()
+            .any(|identity| identity.id == credential_id));
+        assert!(identities
+            .iter()
+            .any(|identity| identity.kind == "ServiceAccount"));
     }
 
     use super::kind_matches_target_kind;
@@ -584,6 +748,31 @@ mod tests {
         let tc = resolve_target_context(&c, &id).expect("sa should resolve");
         assert!(!tc.is_system);
         assert!(tc.has_token);
+    }
+
+    #[test]
+    fn active_kubeconfig_precondition_rejects_knowledge_only_credentials() {
+        let mut c = empty_campaign();
+        let mut credential = K8sCredential::new("https://cluster.example");
+        let id = credential.entity_id().0;
+        c.entities.insert_typed(credential.clone());
+
+        let mut ttp = Ttp::new("check", "Check", "Discovery");
+        ttp.status = "enabled".to_string();
+        ttp.requires
+            .insert("kind".to_string(), json!("K8sCredential"));
+        ttp.requires
+            .insert("activeKubeconfig".to_string(), json!(true));
+
+        let tc = resolve_target_context(&c, &id).expect("credential should resolve");
+        assert!(!ttp_applicable_for_target(&ttp, &c, &tc));
+
+        credential.active = true;
+        c.entities
+            .get_mut::<K8sCredential>()
+            .insert(ran_domain::EntityId::new(&id), credential);
+        let tc = resolve_target_context(&c, &id).expect("credential should resolve");
+        assert!(ttp_applicable_for_target(&ttp, &c, &tc));
     }
 
     #[test]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -132,6 +132,7 @@ async fn run_emulate(args: EmulateArgs) -> Result<()> {
         plan: args.plan,
         auto_cleanup: args.cleanup,
         plans_dir,
+        seed_knowledge: cfg.seed_knowledge,
     })
     .await
 }
@@ -151,6 +152,7 @@ async fn run_trigger(args: TriggerArgs) -> Result<()> {
         kubeconfig: args.kubeconfig,
         armory_dir: args.armory,
         namespace_filter: cfg.namespaces,
+        seed_knowledge: cfg.seed_knowledge,
         action_id: args.action_id,
         target_id: args.target_id,
         exec_system_id: args.exec_system_id,

--- a/crates/domain/entities.rs
+++ b/crates/domain/entities.rs
@@ -118,6 +118,8 @@ impl Entity for C2Server {
 /// Target Kubernetes cluster from kubeconfig context.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct K8sCluster {
+    #[serde(default)]
+    pub id: Option<String>,
     pub name: String,
     pub context_name: Option<String>,
     pub server: Option<String>,
@@ -126,6 +128,7 @@ pub struct K8sCluster {
 impl K8sCluster {
     pub fn new(name: impl Into<String>) -> Self {
         Self {
+            id: None,
             name: name.into(),
             context_name: None,
             server: None,
@@ -137,6 +140,11 @@ impl K8sCluster {
         self
     }
 
+    pub fn with_id(mut self, id: impl Into<String>) -> Self {
+        self.id = Some(id.into());
+        self
+    }
+
     pub fn with_server(mut self, server: Option<String>) -> Self {
         self.server = server;
         self
@@ -145,7 +153,10 @@ impl K8sCluster {
 
 impl Entity for K8sCluster {
     fn entity_id(&self) -> EntityId {
-        EntityId::new(format!("k8s/cluster/{}", slugify(&self.name)))
+        EntityId::new(format!(
+            "k8s/cluster/{}",
+            slugify(self.id.as_deref().unwrap_or(&self.name))
+        ))
     }
 
     fn entity_name(&self) -> &str {
@@ -1359,10 +1370,35 @@ impl Merge for K8sHTTPRoute {
 
 /// A Kubernetes API credential extracted from a kubeconfig file.
 ///
-/// Populated by the `file:kubeconfig` and `file:content` output parsers when
-/// they detect kubeconfig YAML in captured file content.
+/// Populated during campaign bootstrap or by the `file:kubeconfig` and
+/// `file:content` output parsers when they detect kubeconfig YAML.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct K8sCredential {
+    /// Stable display/identity name. Discovered credentials default to the
+    /// endpoint; scenario seeds can provide a human-readable identifier.
+    #[serde(default)]
+    pub name: String,
+    #[serde(default = "default_kubeconfig_credential_type")]
+    pub credential_type: String,
+    #[serde(default)]
+    pub context_name: Option<String>,
+    #[serde(default)]
+    pub user_name: Option<String>,
+    #[serde(default)]
+    pub auth_method: String,
+    #[serde(default)]
+    pub has_token: bool,
+    #[serde(default)]
+    pub has_client_certificate: bool,
+    #[serde(default)]
+    pub has_client_key: bool,
+    /// Whether this credential backs the Kubernetes client used by the current
+    /// Ran process. Seeded/discovered kubeconfigs remain knowledge-only.
+    #[serde(default)]
+    pub active: bool,
+    /// RBAC permissions observed by a SelfSubjectRulesReview for this identity.
+    #[serde(default)]
+    pub entitlements: Vec<RbacPermission>,
     /// API server URL (e.g. `https://10.96.0.1:6443`).
     pub endpoint: String,
     /// Base64-encoded CA certificate from the kubeconfig cluster entry.
@@ -1382,28 +1418,57 @@ pub struct K8sCredential {
 
 impl K8sCredential {
     pub fn new(endpoint: impl Into<String>) -> Self {
+        let endpoint = endpoint.into();
         Self {
-            endpoint: endpoint.into(),
+            name: endpoint.clone(),
+            credential_type: default_kubeconfig_credential_type(),
+            context_name: None,
+            user_name: None,
+            auth_method: String::new(),
+            has_token: false,
+            has_client_certificate: false,
+            has_client_key: false,
+            active: false,
+            entitlements: Vec::new(),
+            endpoint,
             ca_data: None,
             token: None,
             cert_data: None,
             key_data: None,
         }
     }
+
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = name.into();
+        self
+    }
+}
+
+fn default_kubeconfig_credential_type() -> String {
+    "kubeconfig".to_string()
 }
 
 impl Entity for K8sCredential {
     fn entity_id(&self) -> EntityId {
-        let slug = if self.endpoint.is_empty() {
+        let identity = if self.name.is_empty() {
+            &self.endpoint
+        } else {
+            &self.name
+        };
+        let slug = if identity.is_empty() {
             "unknown".to_string()
         } else {
-            slugify(&self.endpoint)
+            slugify(identity)
         };
         EntityId::new(format!("k8s/credential/{}", slug))
     }
 
     fn entity_name(&self) -> &str {
-        &self.endpoint
+        if self.name.is_empty() {
+            &self.endpoint
+        } else {
+            &self.name
+        }
     }
 
     fn entity_kind(&self) -> &str {
@@ -1809,6 +1874,27 @@ impl Merge for Job {
 
 impl Merge for K8sCredential {
     fn merge_from(&mut self, incoming: &Self) {
+        if self.name.is_empty() {
+            self.name = incoming.name.clone();
+        }
+        if self.context_name.is_none() {
+            self.context_name = incoming.context_name.clone();
+        }
+        if self.user_name.is_none() {
+            self.user_name = incoming.user_name.clone();
+        }
+        if self.auth_method.is_empty() {
+            self.auth_method = incoming.auth_method.clone();
+        }
+        self.has_token |= incoming.has_token;
+        self.has_client_certificate |= incoming.has_client_certificate;
+        self.has_client_key |= incoming.has_client_key;
+        self.active |= incoming.active;
+        for permission in &incoming.entitlements {
+            if !self.entitlements.contains(permission) {
+                self.entitlements.push(permission.clone());
+            }
+        }
         if self.ca_data.is_none() {
             self.ca_data = incoming.ca_data.clone();
         }

--- a/crates/domain/mod.rs
+++ b/crates/domain/mod.rs
@@ -19,8 +19,9 @@ pub use identity::{JwToken, ServiceAccountToken};
 pub use rbac::RbacPermission;
 pub use relation::{C2Channel, Relation};
 pub use relations::{
-    BindsTo, CanReach, ContainerEscape, Contains, Grants, KubeletExecSink, KubeletExecSource,
-    ManagesNode, Owns, PodExec, RceCanExec, RelationSummary, RunsOn, SessionChannel, Uses,
+    AuthenticatesTo, BindsTo, CanReach, ContainerEscape, Contains, Grants, KubeletExecSink,
+    KubeletExecSource, ManagesNode, Owns, PodExec, RceCanExec, RelationSummary, RunsOn,
+    SessionChannel, Uses,
 };
 pub use types::{
     AccessLevel, BinaryPresence, Confidence, Container, EntityId, K8sMeta, Mount, NameConfidence,

--- a/crates/domain/relations.rs
+++ b/crates/domain/relations.rs
@@ -405,6 +405,44 @@ impl Relation for Uses {
     }
 }
 
+// ---------------------------------------------------------------------------
+// AuthenticatesTo
+// ---------------------------------------------------------------------------
+
+/// A credential is valid for authentication to a Kubernetes cluster.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthenticatesTo {
+    pub credential_id: EntityId,
+    pub cluster_id: EntityId,
+}
+
+impl AuthenticatesTo {
+    pub fn new(credential_id: impl Into<String>, cluster_id: impl Into<String>) -> Self {
+        Self {
+            credential_id: EntityId::new(credential_id),
+            cluster_id: EntityId::new(cluster_id),
+        }
+    }
+}
+
+impl Relation for AuthenticatesTo {
+    fn relation_name(&self) -> &str {
+        "authenticates-to"
+    }
+
+    fn source_id(&self) -> &EntityId {
+        &self.credential_id
+    }
+
+    fn target_id(&self) -> &EntityId {
+        &self.cluster_id
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 // ManagesNode
 // ---------------------------------------------------------------------------
 

--- a/crates/k8s/Cargo.toml
+++ b/crates/k8s/Cargo.toml
@@ -8,6 +8,11 @@ anyhow = "1"
 futures = "0.3"
 k8s-openapi = { version = "0.27", features = ["v1_32"] }
 kube = { version = "3.1", default-features = true, features = ["ws", "runtime"] }
+http = "1"
+regex = "1"
 serde = { workspace = true }
-tokio = { version = "1", features = ["io-util", "rt", "time"] }
+serde_json = "1"
+serde_yaml = "0.9"
+secrecy = "0.10.2"
+tokio = { version = "1", features = ["io-util", "process", "rt", "time"] }
 tracing = "0.1"

--- a/crates/k8s/src/lib.rs
+++ b/crates/k8s/src/lib.rs
@@ -2,13 +2,16 @@ use std::{env, path::PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use futures::StreamExt;
+use http::{Method, Request};
+use k8s_openapi::api::authorization::v1::{SelfSubjectRulesReview, SelfSubjectRulesReviewSpec};
 use k8s_openapi::api::core::v1::Pod;
 use kube::{
-    api::{AttachParams, ListParams},
+    api::{AttachParams, ListParams, PostParams},
     config::{KubeConfigOptions, Kubeconfig},
     runtime::{reflector, watcher},
-    Api, Client, Config,
+    Api, Client as KubeClient, Config,
 };
+use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -47,6 +50,158 @@ pub struct TargetCluster {
     pub name: String,
     pub context_name: Option<String>,
     pub server: Option<String>,
+}
+
+/// Context-aware kubeconfig data shared by runtime client construction and
+/// campaign knowledge bootstrap.
+#[derive(Debug, Clone)]
+pub struct ResolvedKubeconfig {
+    kubeconfig: Kubeconfig,
+    source_path: Option<PathBuf>,
+    pub context_name: String,
+    pub cluster_name: String,
+    pub user_name: Option<String>,
+    pub server: Option<String>,
+    pub ca_data: Option<String>,
+    pub token: Option<String>,
+    pub cert_data: Option<String>,
+    pub key_data: Option<String>,
+    pub auth_method: String,
+    pub has_token: bool,
+    pub has_client_certificate: bool,
+    pub has_client_key: bool,
+}
+
+impl ResolvedKubeconfig {
+    pub fn target_cluster(&self) -> TargetCluster {
+        TargetCluster {
+            name: self.cluster_name.clone(),
+            context_name: Some(self.context_name.clone()),
+            server: self.server.clone(),
+        }
+    }
+
+    fn options(&self) -> KubeConfigOptions {
+        KubeConfigOptions {
+            context: Some(self.context_name.clone()),
+            cluster: None,
+            user: None,
+        }
+    }
+}
+
+/// Resolve one context from a kubeconfig file without constructing a client.
+pub fn resolve_kubeconfig(
+    path: impl Into<PathBuf>,
+    context_override: Option<&str>,
+) -> Result<ResolvedKubeconfig> {
+    let path = path.into();
+    let kubeconfig = Kubeconfig::read_from(path.clone())
+        .with_context(|| format!("failed to read kubeconfig at {}", path.display()))?;
+    let mut resolved = resolve_kubeconfig_data(kubeconfig, context_override)
+        .with_context(|| format!("failed to resolve kubeconfig at {}", path.display()))?;
+    resolved.source_path = Some(path);
+    Ok(resolved)
+}
+
+/// Resolve one context from already-loaded kubeconfig data.
+pub fn resolve_kubeconfig_data(
+    kubeconfig: Kubeconfig,
+    context_override: Option<&str>,
+) -> Result<ResolvedKubeconfig> {
+    let context_name = context_override
+        .map(str::to_string)
+        .or_else(|| kubeconfig.current_context.clone())
+        .ok_or_else(|| anyhow!("kubeconfig does not define current-context"))?;
+
+    let named_context = kubeconfig
+        .contexts
+        .iter()
+        .find(|ctx| ctx.name == context_name)
+        .ok_or_else(|| anyhow!("context '{}' not found in kubeconfig", context_name))?;
+    let context = named_context
+        .context
+        .as_ref()
+        .ok_or_else(|| anyhow!("context '{}' has no configuration", context_name))?;
+
+    let cluster_name = context.cluster.clone();
+    let cluster = kubeconfig
+        .clusters
+        .iter()
+        .find(|cluster| cluster.name == cluster_name)
+        .and_then(|cluster| cluster.cluster.as_ref())
+        .ok_or_else(|| {
+            anyhow!(
+                "cluster '{}' referenced by context '{}' not found in kubeconfig",
+                cluster_name,
+                context_name
+            )
+        })?;
+
+    let user_name = context.user.clone();
+    let auth = user_name
+        .as_deref()
+        .and_then(|name| kubeconfig.auth_infos.iter().find(|user| user.name == name))
+        .and_then(|user| user.auth_info.as_ref());
+    if user_name.is_some() && auth.is_none() {
+        return Err(anyhow!(
+            "user '{}' referenced by context '{}' not found in kubeconfig",
+            user_name.as_deref().unwrap_or_default(),
+            context_name
+        ));
+    }
+
+    let token = auth
+        .and_then(|a| a.token.as_ref())
+        .map(|value| value.expose_secret().to_string());
+    let cert_data = auth.and_then(|a| a.client_certificate_data.clone());
+    let key_data = auth
+        .and_then(|a| a.client_key_data.as_ref())
+        .map(|value| value.expose_secret().to_string());
+    let has_token = token.is_some() || auth.is_some_and(|a| a.token_file.is_some());
+    let has_client_certificate =
+        cert_data.is_some() || auth.is_some_and(|a| a.client_certificate.is_some());
+    let has_client_key = key_data.is_some() || auth.is_some_and(|a| a.client_key.is_some());
+    let auth_method = match auth {
+        Some(a) if a.exec.is_some() => "exec",
+        Some(a) if a.auth_provider.is_some() => "auth-provider",
+        Some(_) if has_token => "token",
+        Some(_) if has_client_certificate || has_client_key => "client-certificate",
+        Some(a) if a.username.is_some() || a.password.is_some() => "basic",
+        Some(_) => "unknown",
+        None => "anonymous",
+    }
+    .to_string();
+    let server = cluster.server.clone();
+    let ca_data = cluster.certificate_authority_data.clone();
+
+    Ok(ResolvedKubeconfig {
+        kubeconfig,
+        source_path: None,
+        context_name,
+        cluster_name,
+        user_name,
+        server,
+        ca_data,
+        token,
+        cert_data,
+        key_data,
+        auth_method,
+        has_token,
+        has_client_certificate,
+        has_client_key,
+    })
+}
+
+/// Parse kubeconfig YAML and resolve its selected context using the same rules
+/// as file-backed runtime configuration.
+pub fn resolve_kubeconfig_yaml(
+    content: &str,
+    context_override: Option<&str>,
+) -> Result<ResolvedKubeconfig> {
+    let kubeconfig: Kubeconfig =
+        serde_yaml::from_str(content).context("failed to parse kubeconfig YAML")?;
+    resolve_kubeconfig_data(kubeconfig, context_override)
 }
 
 fn pod_to_running_pod(pod: &Pod) -> Option<RunningPod> {
@@ -93,23 +248,29 @@ fn pod_to_running_pod(pod: &Pod) -> Option<RunningPod> {
 }
 
 #[derive(Clone)]
-pub struct K8sService {
-    client: Client,
+pub struct Client {
+    client: KubeClient,
+    kubeconfig_path: Option<PathBuf>,
 }
 
-impl K8sService {
+impl Client {
     pub async fn from_kubeconfig(kubeconfig: Option<PathBuf>) -> Result<Self> {
         let path = kubeconfig.unwrap_or_else(default_kubeconfig_path);
-        let kubeconfig = Kubeconfig::read_from(path.clone())
-            .with_context(|| format!("failed to read kubeconfig at {}", path.display()))?;
+        let resolved = resolve_kubeconfig(path, None)?;
+        Self::from_resolved_kubeconfig(&resolved).await
+    }
 
-        let opts = KubeConfigOptions::default();
-        let config = Config::from_custom_kubeconfig(kubeconfig, &opts)
-            .await
-            .context("failed to load Kubernetes config from kubeconfig")?;
-        let client = Client::try_from(config).context("failed to create Kubernetes client")?;
+    pub async fn from_resolved_kubeconfig(resolved: &ResolvedKubeconfig) -> Result<Self> {
+        let config =
+            Config::from_custom_kubeconfig(resolved.kubeconfig.clone(), &resolved.options())
+                .await
+                .context("failed to load Kubernetes config from kubeconfig")?;
+        let client = KubeClient::try_from(config).context("failed to create Kubernetes client")?;
 
-        Ok(Self { client })
+        Ok(Self {
+            client,
+            kubeconfig_path: resolved.source_path.clone(),
+        })
     }
 
     pub async fn get_running_pods(&self, namespace: Option<&str>) -> Result<Vec<RunningPod>> {
@@ -128,6 +289,123 @@ impl K8sService {
         };
 
         Ok(pods.iter().filter_map(pod_to_running_pod).collect())
+    }
+
+    /// Ask Kubernetes which RBAC rules apply to the identity represented by
+    /// this client's kubeconfig. The native response shape is retained so the
+    /// campaign can reuse its existing SelfSubjectRulesReview parser.
+    pub async fn self_subject_rules_review(&self, namespace: &str) -> Result<String> {
+        let reviews: Api<SelfSubjectRulesReview> = Api::all(self.client.clone());
+        let review = SelfSubjectRulesReview {
+            spec: SelfSubjectRulesReviewSpec {
+                namespace: Some(namespace.to_string()),
+            },
+            ..Default::default()
+        };
+        let response = reviews
+            .create(&PostParams::default(), &review)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed to review kubeconfig permissions in namespace '{}'",
+                    namespace
+                )
+            })?;
+        serde_json::to_string(&response)
+            .context("failed to serialize SelfSubjectRulesReview response")
+    }
+
+    /// Execute a grounded structured Kubernetes request with this client's
+    /// authentication and TLS configuration. Authentication fields embedded in
+    /// the request description are deliberately ignored.
+    pub async fn execute_request(&self, request: &serde_json::Value) -> Result<String> {
+        #[derive(Deserialize)]
+        struct Spec {
+            api: String,
+            resource: String,
+            #[serde(default)]
+            namespace: String,
+            #[serde(default)]
+            cluster_scoped: serde_json::Value,
+            #[serde(default)]
+            query: String,
+            #[serde(default = "default_method")]
+            method: String,
+            #[serde(default)]
+            body: serde_json::Value,
+        }
+        fn default_method() -> String {
+            "GET".to_string()
+        }
+        fn is_true(value: &serde_json::Value) -> bool {
+            value.as_bool().unwrap_or_else(|| {
+                value
+                    .as_str()
+                    .is_some_and(|value| value.eq_ignore_ascii_case("true"))
+            })
+        }
+
+        let spec: Spec = serde_json::from_value(request.clone())
+            .context("invalid structured Kubernetes request")?;
+        let api = spec.api.trim_matches('/');
+        let resource = spec.resource.trim_matches('/');
+        let mut path = if is_true(&spec.cluster_scoped) || spec.namespace.trim().is_empty() {
+            format!("/{api}/{resource}")
+        } else {
+            format!("/{api}/namespaces/{}/{resource}", spec.namespace.trim())
+        };
+        if !spec.query.trim().is_empty() {
+            path.push('?');
+            path.push_str(spec.query.trim());
+        }
+        let method = Method::from_bytes(spec.method.trim().as_bytes())
+            .with_context(|| format!("invalid Kubernetes request method '{}'", spec.method))?;
+        let body = if spec.body.is_null() {
+            Vec::new()
+        } else {
+            serde_json::to_vec(&spec.body).context("failed to encode Kubernetes request body")?
+        };
+        let request = Request::builder()
+            .method(method)
+            .uri(path)
+            .header("Accept", "application/json")
+            .header("Content-Type", "application/json")
+            .body(body)
+            .context("failed to build Kubernetes request")?;
+        self.client
+            .request_text(request)
+            .await
+            .context("Kubernetes API request failed")
+    }
+
+    /// Run a kubectl procedure on the Ran host using the active kubeconfig via
+    /// process environment. The kubeconfig path is not appended to the command,
+    /// recorded in execution args, or returned to callers.
+    pub async fn execute_kubectl_command(&self, command: &str) -> Result<PodExecOutput> {
+        let kubeconfig = self
+            .kubeconfig_path
+            .as_ref()
+            .ok_or_else(|| anyhow!("active Kubernetes client has no file-backed kubeconfig"))?;
+        let empty_equals = regex::Regex::new(
+            r#"\s+--token=(?:""|''|\$TOKEN|\$\{TOKEN\}|\{\{\s*Token\s*\}\})?(\s|$)"#,
+        )?;
+        let empty_separate = regex::Regex::new(
+            r#"\s+--token\s+(?:""|''|\$TOKEN|\$\{TOKEN\}|\{\{\s*Token\s*\}\})(\s|$)"#,
+        )?;
+        let command = empty_equals.replace_all(command, "$1");
+        let command = empty_separate.replace_all(&command, "$1");
+        let output = tokio::process::Command::new("/bin/sh")
+            .arg("-lc")
+            .arg(command.as_ref())
+            .env("KUBECONFIG", kubeconfig)
+            .output()
+            .await
+            .context("failed to execute kubectl procedure")?;
+        Ok(PodExecOutput {
+            stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+            exit_code: output.status.code().unwrap_or(1),
+        })
     }
 
     /// Start a live watch on pods in the given namespace (or all namespaces if `None`/empty).
@@ -344,36 +622,67 @@ pub fn kubeconfig_path_or_err(path: Option<PathBuf>) -> Result<PathBuf> {
 
 pub fn target_cluster_from_kubeconfig(path: Option<PathBuf>) -> Result<TargetCluster> {
     let path = kubeconfig_path_or_err(path)?;
-    let kubeconfig = Kubeconfig::read_from(path.clone())
-        .with_context(|| format!("failed to read kubeconfig at {}", path.display()))?;
+    Ok(resolve_kubeconfig(path, None)?.target_cluster())
+}
 
-    let context_name = kubeconfig
-        .current_context
-        .clone()
-        .ok_or_else(|| anyhow!("kubeconfig does not define current-context"))?;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let context = kubeconfig
-        .contexts
-        .iter()
-        .find(|ctx| ctx.name == context_name)
-        .ok_or_else(|| anyhow!("current-context '{}' not found in kubeconfig", context_name))?;
+    const KUBECONFIG: &str = r#"apiVersion: v1
+kind: Config
+clusters:
+- name: cluster-a
+  cluster:
+    server: https://a.example
+- name: cluster-b
+  cluster:
+    server: https://b.example
+contexts:
+- name: context-a
+  context:
+    cluster: cluster-a
+    user: user-a
+- name: context-b
+  context:
+    cluster: cluster-b
+    user: user-b
+current-context: context-a
+users:
+- name: user-a
+  user:
+    token: secret-a
+- name: user-b
+  user:
+    client-certificate-data: CERT
+    client-key-data: KEY
+"#;
 
-    let cluster_name = context
-        .context
-        .as_ref()
-        .map(|ctx| ctx.cluster.clone())
-        .ok_or_else(|| anyhow!("context '{}' does not reference a cluster", context_name))?;
+    #[test]
+    fn resolver_uses_current_context_by_default() {
+        let resolved = resolve_kubeconfig_yaml(KUBECONFIG, None).unwrap();
+        assert_eq!(resolved.context_name, "context-a");
+        assert_eq!(resolved.cluster_name, "cluster-a");
+        assert_eq!(resolved.user_name.as_deref(), Some("user-a"));
+        assert_eq!(resolved.server.as_deref(), Some("https://a.example"));
+        assert!(resolved.has_token);
+        assert_eq!(resolved.auth_method, "token");
+    }
 
-    let server = kubeconfig
-        .clusters
-        .iter()
-        .find(|cluster| cluster.name == cluster_name)
-        .and_then(|cluster| cluster.cluster.as_ref())
-        .and_then(|cluster| cluster.server.clone());
+    #[test]
+    fn resolver_honors_context_override() {
+        let resolved = resolve_kubeconfig_yaml(KUBECONFIG, Some("context-b")).unwrap();
+        assert_eq!(resolved.cluster_name, "cluster-b");
+        assert_eq!(resolved.user_name.as_deref(), Some("user-b"));
+        assert!(resolved.has_client_certificate);
+        assert!(resolved.has_client_key);
+        assert_eq!(resolved.auth_method, "client-certificate");
+    }
 
-    Ok(TargetCluster {
-        name: cluster_name,
-        context_name: Some(context_name),
-        server,
-    })
+    #[test]
+    fn resolver_rejects_missing_context_and_user() {
+        assert!(resolve_kubeconfig_yaml(KUBECONFIG, Some("missing")).is_err());
+        let missing_user = KUBECONFIG.replace("user: user-a", "user: missing");
+        assert!(resolve_kubeconfig_yaml(&missing_user, None).is_err());
+    }
 }

--- a/crates/planner/src/executor.rs
+++ b/crates/planner/src/executor.rs
@@ -130,6 +130,7 @@ impl PlanExecutor {
                     request: ExecuteActionRequest {
                         action_id: step.action.clone(),
                         exec_system_id: exec_system_id.clone(),
+                        auth_identity_id: token_target_id.clone(),
                         target_id,
                         procedure_id: procedure.clone(),
                         args,

--- a/crates/planner/src/exporter.rs
+++ b/crates/planner/src/exporter.rs
@@ -352,6 +352,7 @@ mod tests {
             tactic: "Execution".to_string(),
             target_id: target_id.to_string(),
             exec_system_id: target_id.to_string(),
+            auth_identity_id: None,
             procedure_id: procedure_id.to_string(),
             command: "echo test".to_string(),
             args: HashMap::new(),

--- a/crates/utility-ai/src/considerations.rs
+++ b/crates/utility-ai/src/considerations.rs
@@ -532,6 +532,7 @@ mod tests {
             is_system: true,
             access_level: AccessLevel::Exec,
             has_token: false,
+            active_kubeconfig: false,
         }
     }
 
@@ -738,6 +739,7 @@ mod tests {
             tactic: "Discovery".to_string(),
             target_id: target_id.to_string(),
             exec_system_id: target_id.to_string(),
+            auth_identity_id: None,
             procedure_id: "p".to_string(),
             command: "x".to_string(),
             args: std::collections::HashMap::new(),

--- a/crates/utility-ai/src/replay.rs
+++ b/crates/utility-ai/src/replay.rs
@@ -205,6 +205,7 @@ fn reconstruct_cmd(rec: &ExecutionRecord, armory: &[Ttp]) -> Option<ExecTtp> {
         // reconstruct. Semantic (target_id-keyed) effects still apply.
         exec_chain: Vec::new(),
         exec_system_id: rec.exec_system_id.clone(),
+        auth_identity_id: rec.auth_identity_id.clone(),
         started_at_ms: rec.started_at_ms,
         // Stored `results` are already post-unwrap, so no transform on replay.
         output_transform: None,
@@ -252,6 +253,7 @@ mod tests {
             tactic: "Discovery".to_string(),
             target_id: target_id.to_string(),
             exec_system_id: target_id.to_string(),
+            auth_identity_id: None,
             procedure_id: "shell".to_string(),
             command: "id".to_string(),
             args: HashMap::new(),

--- a/crates/utility-ai/src/scorer.rs
+++ b/crates/utility-ai/src/scorer.rs
@@ -242,6 +242,7 @@ mod tests {
             tactic: "Discovery".to_string(),
             target_id: target_id.to_string(),
             exec_system_id: target_id.to_string(),
+            auth_identity_id: None,
             procedure_id: "shell".to_string(),
             command: "id".to_string(),
             args: HashMap::new(),

--- a/frontend/src/lib/api/gen_types.ts
+++ b/frontend/src/lib/api/gen_types.ts
@@ -84,6 +84,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/eligible-auth-identities": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get eligible Kubernetes authentication identities
+         * @description Returns identities satisfying the action's authentication and RBAC requirements for the selected target.
+         */
+        get: operations["getEligibleAuthIdentities"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/recommendations": {
         parameters: {
             query?: never;
@@ -523,6 +543,7 @@ export interface components {
             };
             compromised?: boolean;
             isRunning?: boolean;
+            provenance?: ("scenario" | "operator" | "action" | "inference")[];
         };
         Edge: {
             id: string;
@@ -536,6 +557,7 @@ export interface components {
             targetId: string;
             /** @description Backend ID of the active persistent session on this exec-channel edge, if any. */
             sessionId?: string;
+            provenance?: ("scenario" | "operator" | "action" | "inference")[];
         };
         CampaignState: {
             entities: {
@@ -639,6 +661,8 @@ export interface components {
         ExecuteActionCmd: {
             actionId: string;
             execSystemId?: string;
+            /** @description Entity ID of the ServiceAccount or active K8sCredential used for Kubernetes authentication. */
+            authIdentityId?: string;
             targetId: string;
             procedureId?: string;
             args?: {
@@ -646,6 +670,11 @@ export interface components {
             };
             /** @description Free-text rationale for choosing this action at this point in the assessment — why this TTP against this target now. Optional, but strongly encouraged when driving the campaign programmatically: it is stored on the resulting execution record so the timeline is self-explaining and auditable. */
             reasoning?: string;
+        };
+        AuthIdentity: {
+            id: string;
+            name: string;
+            kind: string;
         };
         K8sResource: {
             id: string;
@@ -663,6 +692,7 @@ export interface components {
             kind?: string;
             rbacPermissions?: components["schemas"]["RBACPermission"][];
             accessLevel?: string;
+            activeKubeconfig?: boolean;
             exists?: string[];
         };
         RBACPermission: {
@@ -690,6 +720,8 @@ export interface components {
             target_id: string;
             /** @description ID of the system that ran the command; empty for direct builtin exec */
             exec_system_id: string;
+            /** @description ID of the Kubernetes authentication identity selected for the action */
+            auth_identity_id?: string;
             procedure_id: string;
             /** @description Fully grounded command string sent to the C2 backend */
             command: string;
@@ -988,6 +1020,38 @@ export interface operations {
                 };
             };
             /** @description Target not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    getEligibleAuthIdentities: {
+        parameters: {
+            query: {
+                actionId: string;
+                targetId: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Eligible identities */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthIdentity"][];
+                };
+            };
+            /** @description Action or target not found */
             404: {
                 headers: {
                     [name: string]: unknown;

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -19,6 +19,7 @@ export type TTPParam = components['schemas']['TTPParam'];
 export type TTPDefense = components['schemas']['TTPDefense'];
 export type SigmaRule = components['schemas']['SigmaRule'];
 export type ExecuteActionCmd = components['schemas']['ExecuteActionCmd'];
+export type AuthIdentity = components['schemas']['AuthIdentity'];
 export type ExecutionRecordEntry = components['schemas']['ExecutionRecordEntry'];
 export type K8sResource = components['schemas']['K8sResource'];
 export type ApiError = components['schemas']['Error'];

--- a/frontend/src/lib/components/CampaignState.svelte.ts
+++ b/frontend/src/lib/components/CampaignState.svelte.ts
@@ -21,6 +21,7 @@ export type Entity = {
 	ready?: boolean;
 	stateReason?: string;
 	ips?: string[];
+	provenance?: string[];
 };
 
 export type Relation = {

--- a/frontend/src/lib/knowledgeProvenance.test.ts
+++ b/frontend/src/lib/knowledgeProvenance.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { hasKnowledgeProvenance, knowledgeProvenanceBadges } from './knowledgeProvenance';
+
+describe('knowledge provenance presentation', () => {
+	it('builds scenario and operator badges in source order', () => {
+		expect(knowledgeProvenanceBadges(['scenario', 'operator'])).toEqual([
+			{ origin: 'scenario', label: 'Scenario-provided' },
+			{ origin: 'operator', label: 'Operator-provided' }
+		]);
+	});
+
+	it('detects scenario styling without accepting absent provenance', () => {
+		expect(hasKnowledgeProvenance(['scenario'], 'scenario')).toBe(true);
+		expect(hasKnowledgeProvenance(undefined, 'scenario')).toBe(false);
+	});
+});

--- a/frontend/src/lib/knowledgeProvenance.ts
+++ b/frontend/src/lib/knowledgeProvenance.ts
@@ -1,0 +1,21 @@
+export type KnowledgeProvenance = 'scenario' | 'operator' | 'action' | 'inference';
+
+const LABELS: Record<KnowledgeProvenance, string> = {
+	scenario: 'Scenario-provided',
+	operator: 'Operator-provided',
+	action: 'Action-discovered',
+	inference: 'Inferred'
+};
+
+export function hasKnowledgeProvenance(
+	values: readonly string[] | undefined,
+	origin: string
+): boolean {
+	return values?.includes(origin) ?? false;
+}
+
+export function knowledgeProvenanceBadges(values: readonly string[] | undefined) {
+	return (values ?? [])
+		.filter((value): value is KnowledgeProvenance => value in LABELS)
+		.map((origin) => ({ origin, label: LABELS[origin] }));
+}

--- a/frontend/src/lib/modals/ActionParamsModal.svelte
+++ b/frontend/src/lib/modals/ActionParamsModal.svelte
@@ -2,7 +2,7 @@
 	import { Combobox, useListCollection } from '@skeletonlabs/skeleton-svelte';
 
 	import { parseEntityId } from '$lib/model';
-	import type { TTP, TTPParam, RBACPermission } from '$lib/api/index';
+	import type { TTP, TTPParam, RBACPermission, AuthIdentity } from '$lib/api/index';
 	import { getCampaignState, type Entity } from '$lib/components/CampaignState.svelte';
 	import { getRanAPI } from '$lib/ran_api';
 	import { untrack } from 'svelte';
@@ -11,7 +11,7 @@
 		targetId: string;
 		ttp: TTP;
 		argContext: Record<string, any>;
-		onExecute: (ttpId: string, execSystemId: string, procedureId: string, args: Record<string, string>) => void;
+		onExecute: (ttpId: string, execSystemId: string, authIdentityId: string, procedureId: string, args: Record<string, string>) => void;
 		onCancel: () => void;
 	}
 	let { targetId = $bindable(), ttp, argContext, onExecute, onCancel }: ParamProps = $props();
@@ -45,6 +45,8 @@
 	let availableEntities: Entity[] = $state([]);
 	let namespaceArgName: string = "";
 	let selectedExecSystemId = $state('');
+	let eligibleAuthIdentities = $state<AuthIdentity[]>([]);
+	let selectedAuthIdentityId = $state('');
 	let formElement: HTMLFormElement | undefined = $state();
 
 	const compromisedSystems = $derived(campaignState.getCompromisedSystems());
@@ -56,6 +58,48 @@
 	const selectedExecSystem = $derived(
 		compromisedSystems.find(e => e.id === selectedExecSystemId)
 	);
+	const selectedAuthIdentity = $derived(
+		eligibleAuthIdentities.find(identity => identity.id === selectedAuthIdentityId)
+	);
+
+	$effect(() => {
+		const actionId = ttp?.id;
+		const selectedTargetId = targetId;
+		if (!actionId || !selectedTargetId) {
+			eligibleAuthIdentities = [];
+			selectedAuthIdentityId = '';
+			return;
+		}
+		ranAPI.GetEligibleAuthIdentities(actionId, selectedTargetId)
+			.then((identities) => {
+				eligibleAuthIdentities = identities;
+				if (!identities.some(identity => identity.id === selectedAuthIdentityId)) {
+					selectedAuthIdentityId = identities.find(identity => identity.id === selectedTargetId)?.id
+						?? (identities.length === 1 ? identities[0].id : '');
+				}
+			})
+			.catch(() => {
+				eligibleAuthIdentities = [];
+				selectedAuthIdentityId = '';
+			});
+	});
+
+	$effect(() => {
+		const identity = selectedAuthIdentity;
+		if (!identity) return;
+		if (identity.kind === 'K8sCredential') {
+			const native = ttp.procedures.find(procedure => procedure.id === 'k8s-request')
+				?? ttp.procedures.find(procedure => procedure.id === 'kubectl');
+			if (native) procedureId = native.id;
+		} else if (identity.kind === 'ServiceAccount') {
+			const tokenIndex = args.findIndex(arg => arg.Name === 'TOKEN');
+			if (tokenIndex !== -1) {
+				args[tokenIndex] = { ...args[tokenIndex], Value: identity.id };
+				args = [...args];
+				bumpArgVersion('TOKEN');
+			}
+		}
+	});
 
 	const target = $derived.by(() => { return campaignState.getObjectById(targetId); });
 
@@ -565,7 +609,10 @@
 			{} as { [key: string]: string }
 		);
 
-		onExecute(ttp.id, selectedExecSystemId, procedureId, argsDict);
+		if (selectedAuthIdentity?.kind === 'K8sCredential') {
+			delete argsDict.TOKEN;
+		}
+		onExecute(ttp.id, selectedExecSystemId, selectedAuthIdentityId, procedureId, argsDict);
 	}
 
 	function executingSystemHasTool(tool: string): boolean {
@@ -668,6 +715,19 @@
 			<span class="h6 label text-xs md:text-sm lg:text-base">Description</span>
 			{ttp.description}
 		</div>
+			{#if eligibleAuthIdentities.length > 0}
+				<label class="label mt-5">
+					<span class="h6 label-text text-xs md:text-sm lg:text-base">Authenticate As</span>
+					<select id="authIdentity" class="input mt-2 text-xs md:text-sm lg:text-base" bind:value={selectedAuthIdentityId} required>
+						{#if eligibleAuthIdentities.length > 1}
+							<option value="" disabled>Select an identity…</option>
+						{/if}
+						{#each eligibleAuthIdentities as identity (identity.id)}
+							<option value={identity.id}>{identity.kind}: {identity.name}</option>
+						{/each}
+					</select>
+				</label>
+			{/if}
 			{#if execSystemOptions.length > 0}
 				<label class="label mt-5">
 					<span class="h6 label-text text-xs md:text-sm lg:text-base">Execute On</span>

--- a/frontend/src/lib/modals/ActionParamsModal.svelte
+++ b/frontend/src/lib/modals/ActionParamsModal.svelte
@@ -380,7 +380,10 @@
 
 					if (param.type === 'Namespace') {
 						namespaceArgName = param.name;
-						if (param.default === "" && currentTargetId.startsWith("ns/")) {
+						if (
+							currentTargetId.startsWith("ns/")
+							&& (value === "" || value === "${NS}" || value === "${NAMESPACE}")
+						) {
 							value = currentTargetId.split("/")[1];
 						}
 					} else if (param.type === 'Pod') {

--- a/frontend/src/lib/ran_api.ts
+++ b/frontend/src/lib/ran_api.ts
@@ -316,6 +316,14 @@ export class RanAPI {
 		return data;
 	}
 
+	async GetEligibleAuthIdentities(actionId: string, targetId: string) {
+		const { data, error } = await this.restClient.GET('/api/eligible-auth-identities', {
+			params: { query: { actionId, targetId } }
+		});
+		if (error) throw new Error(error.error || 'Failed to get eligible authentication identities');
+		return data;
+	}
+
 	async GetRecommendations(targetId?: string, limit?: number): Promise<Array<ScoredCandidate>> {
 		const query: { targetId?: string; limit?: number } = {};
 		if (targetId) query.targetId = targetId;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -256,7 +256,13 @@
 	async function sendAction(ttp: TTP, args = {}) {
 		selectedTTP = ttp;
 		ttpArgContext = { ...args, ...activeGlobalConditions };
-		if (ttp.params) {
+		const usesK8sAuth = ttp.procedures?.some(procedure =>
+			procedure.id === 'kubectl'
+			|| procedure.id === 'k8s-request'
+			|| procedure.command?.includes('kubectl ')
+			|| procedure.command?.startsWith('k8sSelfSubjectRulesReview(')
+		);
+		if (ttp.params || usesK8sAuth) {
 			showParamModal = true;
 		} else if ((ttp.procedures?.length ?? 0) > 1) {
 			showParamModal = true;
@@ -475,14 +481,14 @@
 		}
 	});
 
-	async function onExecuteTTP(ttpId: string, execSystemId: string, procedureId: string, args: Record<string, string>) {
+	async function onExecuteTTP(ttpId: string, execSystemId: string, authIdentityId: string, procedureId: string, args: Record<string, string>) {
 		const ttp = campaignState.getTtpById(ttpId);
 		const targetName = campaignState.getEntityById(selectedObjectId)?.name ?? selectedObjectId;
 
 		closeModal();
 
 		try {
-			const result = await ExecuteAction({ actionId: ttpId, execSystemId, targetId: selectedObjectId, procedureId, args });
+			const result = await ExecuteAction({ actionId: ttpId, execSystemId, authIdentityId: authIdentityId || undefined, targetId: selectedObjectId, procedureId, args });
 			const cmdId = (result as any)?.cmdId ?? crypto.randomUUID();
 			const differsFromTarget = execSystemId && execSystemId !== selectedObjectId;
 			timeline.addTtpAction({

--- a/frontend/src/routes/components/elk_layout.ts
+++ b/frontend/src/routes/components/elk_layout.ts
@@ -46,6 +46,7 @@ export const NODE_LAYER: Record<string, number> = {
   CronJob: 4,
   // RBAC / k8s resources (tend to be used BY workloads, so one step right)
   ServiceAccount: 5,
+  K8sCredential: 5,
   Role: 5,
   ClusterRole: 5,
   RoleBinding: 5,

--- a/frontend/src/routes/components/entityInfo.svelte
+++ b/frontend/src/routes/components/entityInfo.svelte
@@ -5,6 +5,7 @@
 	import type {RBACPermission, TTP} from '$lib/api/index';
 	import { showToast } from '$lib/components/toaster';
 	import { getCampaignState } from '$lib/components/CampaignState.svelte';
+	import { knowledgeProvenanceBadges } from '$lib/knowledgeProvenance';
 
 
 	type ObjectInfoProps = {
@@ -170,7 +171,7 @@
 	}
 
 	// Fields handled explicitly in the header — skip from the generic loop
-	const HEADER_FIELDS = new Set(['id', 'name', 'namespace', 'kind', 'entityId', 'parent', 'entity', 'compromised']);
+	const HEADER_FIELDS = new Set(['id', 'name', 'namespace', 'kind', 'entityId', 'parent', 'entity', 'compromised', 'provenance']);
 
 	function shouldShowField(label: string, data: any): boolean {
 		if (HEADER_FIELDS.has(label)) return false;
@@ -248,6 +249,21 @@
 			{#if obj.kind}
 				<span class="badge bg-indigo-200 text-indigo-800 text-xs shrink-0">{obj.kind}</span>
 			{/if}
+			{#each knowledgeProvenanceBadges(obj.provenance) as badge}
+				<span
+					class="badge text-xs shrink-0"
+					class:bg-amber-200={badge.origin === 'scenario'}
+					class:text-amber-900={badge.origin === 'scenario'}
+					class:bg-sky-200={badge.origin === 'operator'}
+					class:text-sky-900={badge.origin === 'operator'}
+					class:bg-emerald-200={badge.origin === 'action'}
+					class:text-emerald-900={badge.origin === 'action'}
+					class:bg-violet-200={badge.origin === 'inference'}
+					class:text-violet-900={badge.origin === 'inference'}
+				>
+					{badge.label}
+				</span>
+			{/each}
 			<button
 				class="shrink-0 cursor-pointer rounded p-0.5 hover:bg-surface-300 dark:hover:bg-surface-700 transition-colors"
 				title={obj.id}

--- a/frontend/src/routes/components/graph.svelte
+++ b/frontend/src/routes/components/graph.svelte
@@ -7,6 +7,7 @@
 	// @ts-ignore
 	import expandCollapse from 'cytoscape-expand-collapse';
 	import { toaster } from '$lib/components/toaster';
+	import { hasKnowledgeProvenance } from '$lib/knowledgeProvenance';
 
 	import { getGraphStyle, applyCompromisedStyle } from './graph_style';
 	import { createElkLayout, isValidPosition, DEFAULT_LAYOUT_PARAMS } from './elk_layout';
@@ -29,7 +30,7 @@
 	type CyNode = {
 		id: string;
 		label: string;
-		data: Node;
+		data: Node & { scenarioProvided: boolean };
 		position?: { x: number; y: number };
 	};
 	type Pos = { x: number; y: number };
@@ -541,7 +542,7 @@
 		let cyNode: CyNode = {
 			id: n.id,
 			label: n.name,
-			data: { ...n }
+			data: { ...n, scenarioProvided: hasKnowledgeProvenance(n.provenance, 'scenario') }
 		};
 
 		// Add parent relationship if exists (required for expand-collapse)
@@ -568,6 +569,7 @@
 				source: e.sourceId,
 				target: e.targetId,
 				...e,
+				scenarioProvided: hasKnowledgeProvenance(e.provenance, 'scenario'),
 				informational: isInformational(e.name)
 			}
 		};

--- a/frontend/src/routes/components/graph_style.ts
+++ b/frontend/src/routes/components/graph_style.ts
@@ -26,6 +26,7 @@ const kind_svg_map = {
 	User: 'k8s/user.svg',
 	Volume: 'k8s/vol.svg',
 	KubeApiServer: 'k8s/api.svg',
+	K8sCredential: 'k8s/secret.svg',
 	MicroService: '{k8s/pod_unlabeled.svg',
 	GCPBucket: 'gcp/storage.svg',
 	GCPServiceAccount: 'gcp/iam.svg',
@@ -115,6 +116,14 @@ export function getGraphStyle(isDark: boolean = false) {
 				'target-arrow-color': primary,
 				'border-width': 2
 				// 'background-image': null
+			}
+		},
+		{
+			selector: 'node[?scenarioProvided]',
+			style: {
+				'border-width': 3,
+				'border-style': 'double',
+				'border-color': '#f59e0b'
 			}
 		},
 		{
@@ -314,6 +323,14 @@ export function getGraphStyle(isDark: boolean = false) {
 				'line-color': textColor,
 				'target-arrow-color': textColor
 				// 'font-weight': 'bold'
+			}
+		},
+		{
+			selector: 'edge[?scenarioProvided]',
+			style: {
+				'line-style': 'dashed',
+				'line-color': '#f59e0b',
+				'target-arrow-color': '#f59e0b'
 			}
 		},
 		{

--- a/ran.yaml.example
+++ b/ran.yaml.example
@@ -20,3 +20,24 @@ namespaces:
 #
 # Note: If 'included' has items, it takes precedence over 'excluded'
 # (only included namespaces will be shown, excluded list is ignored)
+
+# Optional scenario-provided knowledge. Relative paths are resolved from this file.
+# seedKnowledge:
+#   - type: credential
+#     credentialType: kubeconfig
+#     id: developer-kubeconfig
+#     path: kubeconfigs/developer.yaml
+#     context: developer-context # optional; defaults to current-context
+#     provenance: scenario
+#
+# To assign the cluster a stable scenario ID, declare it and reference the alias:
+#   - type: cluster
+#     id: target-cluster
+#     server: https://cluster.example
+#     provenance: scenario
+#   - type: credential
+#     credentialType: kubeconfig
+#     id: developer-kubeconfig
+#     path: kubeconfigs/developer.yaml
+#     cluster: target-cluster
+#     provenance: scenario


### PR DESCRIPTION
Assimilates active and seeded kubeconfigs into campaign knowledge with credential-to-cluster edges, provenance, deduplication, reset support, safe API redaction, and graph styling.

Actions can select eligible ServiceAccount or active K8sCredential identities, execute structured Kubernetes or kubectl procedures through the active client, and retain the chosen identity in audit records.

Adds kubeconfig permission discovery and namespace discovery TTPs, including namespace output parsing.

Validation: `cargo clippy --workspace -- -D warnings`, targeted backend tests, 25 frontend tests, and the production frontend build.