### PR TITLE
Discover default namespaces from kubeconfig contexts

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -716,6 +716,47 @@ components:
           items:
             type: object
             additionalProperties: true
+        bootstrapOperations:
+          type: array
+          items:
+            $ref: '#/components/schemas/BootstrapOperation'
+
+    BootstrapOperation:
+      type: object
+      required:
+        - id
+        - name
+        - detail
+        - effects
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        detail:
+          type: string
+        effects:
+          type: array
+          items:
+            $ref: '#/components/schemas/BootstrapEffect'
+
+    BootstrapEffect:
+      type: object
+      required:
+        - entityId
+        - entityName
+        - entityKind
+        - category
+      properties:
+        entityId:
+          type: string
+        entityName:
+          type: string
+        entityKind:
+          type: string
+        category:
+          type: string
+          enum: [credential, discovery]
 
     AttackFlow:
       type: object

--- a/crates/api/build.rs
+++ b/crates/api/build.rs
@@ -70,6 +70,8 @@ fn main() -> Result<()> {
         "K8sResource",
         "Error",
         "CampaignState",
+        "BootstrapOperation",
+        "BootstrapEffect",
         "Graph",
         "Node",
         "Edge",

--- a/crates/api/src/state_conversions.rs
+++ b/crates/api/src/state_conversions.rs
@@ -1,10 +1,10 @@
 use std::collections::{HashMap, HashSet};
 
 use campaign::{Campaign, CampaignEntityRef};
-use ran_domain::{AccessLevel, PodPhase};
+use ran_domain::{AccessLevel, Entity, EntityId, K8sCredential, PodPhase};
 use serde_json::Value;
 
-use crate::{CampaignState, Graph, GraphEdge, GraphNode};
+use crate::{BootstrapEffect, BootstrapOperation, CampaignState, Graph, GraphEdge, GraphNode};
 
 pub(crate) fn campaign_to_campaign_state(campaign: &Campaign) -> CampaignState {
     let mut entities = HashMap::new();
@@ -70,6 +70,91 @@ pub(crate) fn campaign_to_campaign_state(campaign: &Campaign) -> CampaignState {
                 m
             })
             .collect(),
+        bootstrap_operations: Some(bootstrap_operations(campaign)),
+    }
+}
+
+fn bootstrap_operations(campaign: &Campaign) -> Vec<BootstrapOperation> {
+    let mut operations = campaign
+        .entities
+        .values::<K8sCredential>()
+        .filter_map(|credential| {
+            let credential_id = credential.entity_id();
+            let provenance = campaign.entity_provenance(&credential_id);
+            if !provenance.contains(&campaign::KnowledgeProvenance::Operator)
+                && !provenance.contains(&campaign::KnowledgeProvenance::Scenario)
+            {
+                return None;
+            }
+
+            let cluster_id = campaign
+                .graph
+                .targets_of(&credential_id, "authenticates-to")
+                .first()
+                .cloned()
+                .cloned()?;
+            let cluster = campaign
+                .get_entities()
+                .into_iter()
+                .find(|entity| entity.entity_id() == cluster_id)?;
+            let mut effects = vec![bootstrap_effect(
+                credential_id.clone(),
+                credential.entity_name(),
+                credential.entity_kind(),
+            )];
+            effects.push(bootstrap_effect(
+                cluster_id.clone(),
+                cluster.entity_name(),
+                cluster.entity_kind(),
+            ));
+
+            if let Some(namespace) = credential.default_namespace.as_deref() {
+                let namespace_id = EntityId::new(format!("ns/{namespace}"));
+                let is_contained = campaign
+                    .graph
+                    .targets_of(&cluster_id, "contains")
+                    .contains(&&namespace_id);
+                if is_contained {
+                    if let Some(namespace_entity) = campaign
+                        .get_entities()
+                        .into_iter()
+                        .find(|entity| entity.entity_id() == namespace_id)
+                    {
+                        effects.push(bootstrap_effect(
+                            namespace_id,
+                            namespace_entity.entity_name(),
+                            namespace_entity.entity_kind(),
+                        ));
+                    }
+                }
+            }
+
+            let detail = match credential.context_name.as_deref() {
+                Some(context) => format!("{} (context: {context})", credential.entity_name()),
+                None => credential.entity_name().to_string(),
+            };
+            Some(BootstrapOperation {
+                id: format!("bootstrap:kubeconfig:{}", credential_id.0),
+                name: "Read kubeconfig".to_string(),
+                detail,
+                effects,
+            })
+        })
+        .collect::<Vec<_>>();
+    operations.sort_by(|a, b| a.id.cmp(&b.id));
+    operations
+}
+
+fn bootstrap_effect(entity_id: EntityId, entity_name: &str, entity_kind: &str) -> BootstrapEffect {
+    BootstrapEffect {
+        entity_id: entity_id.0,
+        entity_name: entity_name.to_string(),
+        entity_kind: entity_kind.to_string(),
+        category: if entity_kind == "K8sCredential" {
+            "credential".to_string()
+        } else {
+            "discovery".to_string()
+        },
     }
 }
 
@@ -379,6 +464,8 @@ mod tests {
         let cluster = K8sCluster::new("demo").with_server(Some("https://demo".into()));
         let cluster_id = cluster.entity_id();
         let mut credential = K8sCredential::new("https://demo").with_name("developer");
+        credential.context_name = Some("demo-context".to_string());
+        credential.default_namespace = Some("default".to_string());
         credential.token = Some("super-secret".into());
         credential.key_data = Some("private-key".into());
         credential.cert_data = Some("certificate".into());
@@ -441,5 +528,44 @@ mod tests {
             edge.name == "authenticates-to"
                 && edge.provenance.as_deref() == Some(["scenario".to_string()].as_slice())
         }));
+
+        let operations = state.bootstrap_operations.unwrap();
+        assert_eq!(operations.len(), 1);
+        assert_eq!(operations[0].name, "Read kubeconfig");
+        assert_eq!(operations[0].detail, "developer (context: demo-context)");
+        assert_eq!(
+            operations[0]
+                .effects
+                .iter()
+                .map(|effect| effect.entity_kind.as_str())
+                .collect::<Vec<_>>(),
+            vec!["K8sCredential", "Cluster", "Namespace"]
+        );
+    }
+
+    #[test]
+    fn action_discovered_credentials_do_not_create_bootstrap_operations() {
+        let cluster = K8sCluster::new("external").with_server(Some("https://external".into()));
+        let cluster_id = cluster.entity_id();
+        let credential = K8sCredential::new("https://external").with_name("captured");
+        let campaign = Campaign::bootstrap_with_knowledge(
+            "test",
+            InitialKnowledge {
+                clusters: vec![InitialClusterKnowledge {
+                    cluster,
+                    provenance: BTreeSet::from([KnowledgeProvenance::Action]),
+                }],
+                kubeconfigs: vec![InitialKubeconfigKnowledge {
+                    credential,
+                    cluster_id,
+                    provenance: BTreeSet::from([KnowledgeProvenance::Action]),
+                }],
+            },
+        );
+
+        assert!(campaign_to_campaign_state(&campaign)
+            .bootstrap_operations
+            .unwrap()
+            .is_empty());
     }
 }

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1085,6 +1085,7 @@ fn credential_from_resolved(
     let mut credential =
         K8sCredential::new(resolved.server.clone().unwrap_or_default()).with_name(name);
     credential.context_name = Some(resolved.context_name.clone());
+    credential.default_namespace = resolved.default_namespace.clone();
     credential.user_name = resolved.user_name.clone();
     credential.auth_method = resolved.auth_method.clone();
     credential.has_token = resolved.has_token;
@@ -1338,6 +1339,7 @@ contexts:
   context:
     cluster: demo
     user: developer
+    namespace: default
 current-context: demo-context
 users:
 - name: developer
@@ -1377,6 +1379,13 @@ users:
         );
         assert_eq!(initial.kubeconfigs.len(), 1);
         assert!(initial.kubeconfigs[0].credential.active);
+        assert_eq!(
+            initial.kubeconfigs[0]
+                .credential
+                .default_namespace
+                .as_deref(),
+            Some("default")
+        );
         assert_eq!(
             initial.kubeconfigs[0].credential.entity_name(),
             "developer-kubeconfig"

--- a/crates/campaign/src/analyzers.rs
+++ b/crates/campaign/src/analyzers.rs
@@ -106,21 +106,38 @@ impl InferenceRule for NamespaceClusterAnalyzer {
     }
     fn infer(&self, campaign: &Campaign, update: &FactsUpdate) -> FactsUpdate {
         let mut inferred = FactsUpdate::default();
+        let view = PendingView::new(campaign, update);
+        let clusters = view.collect::<K8sCluster>();
+        let cluster_ids = clusters.iter().map(Entity::entity_id).collect::<Vec<_>>();
+        let relations = view.relations();
 
-        // Only one cluster is currently supported; bail out if none is known.
-        let Some(cluster) = campaign.entities.values::<K8sCluster>().next() else {
+        // An unqualified namespace can only be attached automatically when the
+        // campaign has exactly one possible cluster. Kubeconfig discovery adds
+        // an explicit relation to its resolved cluster below, which also keeps
+        // multi-cluster campaigns from choosing an arbitrary parent.
+        let [cluster_id] = cluster_ids.as_slice() else {
             return inferred;
         };
-        let cluster_id = cluster.entity_id();
 
         for entity in &update.new_entities {
             let Some(ns) = entity.as_any().downcast_ref::<Namespace>() else {
                 continue;
             };
+            let namespace_id = ns.entity_id();
+            let already_attached = relations.iter().any(|relation| {
+                relation.name == "contains"
+                    && relation.target_id == namespace_id.0
+                    && cluster_ids
+                        .iter()
+                        .any(|candidate| candidate.0 == relation.source_id)
+            });
+            if already_attached {
+                continue;
+            }
 
             inferred.new_relations.push(Box::new(Contains::new(
                 cluster_id.0.clone(),
-                ns.entity_id().0.clone(),
+                namespace_id.0,
             )));
         }
 
@@ -1709,7 +1726,8 @@ impl InferenceRule for KubeconfigCredentialAnalyzer {
 
     fn infer(&self, campaign: &Campaign, update: &FactsUpdate) -> FactsUpdate {
         let mut inferred = FactsUpdate::default();
-        let relations = PendingView::new(campaign, update).relations();
+        let view = PendingView::new(campaign, update);
+        let relations = view.relations();
 
         for entity in &update.new_entities {
             let Some(cred) = entity.as_any().downcast_ref::<K8sCredential>() else {
@@ -1749,9 +1767,27 @@ impl InferenceRule for KubeconfigCredentialAnalyzer {
                 .contains(&&cluster_id);
             if !already_related {
                 inferred.new_relations.push(Box::new(AuthenticatesTo::new(
-                    credential_id.0,
-                    cluster_id.0,
+                    credential_id.0.clone(),
+                    cluster_id.0.clone(),
                 )));
+            }
+
+            if let Some(namespace) = cred.default_namespace.as_deref() {
+                let (namespace_id, new_namespace) = view.ensure_namespace(namespace);
+                if let Some(namespace) = new_namespace {
+                    inferred.new_entities.push(Box::new(namespace));
+                }
+                let already_contained = relations.iter().any(|relation| {
+                    relation.name == "contains"
+                        && relation.source_id == cluster_id.0
+                        && relation.target_id == namespace_id.0
+                });
+                if !already_contained {
+                    inferred.new_relations.push(Box::new(Contains::new(
+                        cluster_id.0.clone(),
+                        namespace_id.0,
+                    )));
+                }
             }
         }
 
@@ -2621,6 +2657,41 @@ mod tests {
                 .any(|e| e.entity_kind() == "Cluster"),
             "expected K8sCluster entity to be derived from K8sCredential"
         );
+    }
+
+    #[test]
+    fn kubeconfig_namespace_is_attached_to_the_resolved_external_cluster() {
+        let campaign = test_campaign();
+        let active_cluster_id = campaign
+            .entities
+            .values::<K8sCluster>()
+            .next()
+            .unwrap()
+            .entity_id();
+        let endpoint = "https://external.example:6443";
+        let external_cluster_id = K8sCluster::new(endpoint)
+            .with_server(Some(endpoint.to_string()))
+            .entity_id();
+        let mut credential = K8sCredential::new(endpoint);
+        credential.default_namespace = Some("default".to_string());
+
+        let mut update = FactsUpdate::default();
+        update.new_entities.push(Box::new(credential));
+        let inferred = run_rules_fixpoint(&campaign, &default_rules(), update);
+
+        assert!(inferred.new_entities.iter().any(|entity| {
+            entity.entity_kind() == "Namespace" && entity.entity_id().0 == "ns/default"
+        }));
+        assert!(inferred.new_relations.iter().any(|relation| {
+            relation.is::<Contains>()
+                && relation.source_id() == &external_cluster_id
+                && relation.target_id().0 == "ns/default"
+        }));
+        assert!(!inferred.new_relations.iter().any(|relation| {
+            relation.is::<Contains>()
+                && relation.source_id() == &active_cluster_id
+                && relation.target_id().0 == "ns/default"
+        }));
     }
 
     #[test]

--- a/crates/campaign/src/campaign/state.rs
+++ b/crates/campaign/src/campaign/state.rs
@@ -2,8 +2,8 @@ use std::collections::{BTreeSet, HashMap};
 
 use cortex::KnowledgeGraph;
 use ran_domain::{
-    AuthenticatesTo, C2Server, Entity, EntityId, K8sCluster, K8sCredential, K8sNode, Pod, PodExec,
-    Relation, RelationSummary, SessionStatus, UnknownSystem,
+    AuthenticatesTo, C2Server, Contains, Entity, EntityId, K8sCluster, K8sCredential, K8sNode,
+    Namespace, Pod, PodExec, Relation, RelationSummary, SessionStatus, UnknownSystem,
 };
 use serde::{Deserialize, Serialize};
 
@@ -105,6 +105,7 @@ impl Campaign {
 
         for entry in initial.kubeconfigs {
             let credential_id = entry.credential.entity_id();
+            let default_namespace = entry.credential.default_namespace.clone();
             entities.insert_typed(entry.credential);
             graph.ensure_node(credential_id.clone());
             let relation =
@@ -114,10 +115,33 @@ impl Campaign {
                 relation.target_id(),
                 cortex::edge_data_for(relation.relation_name(), None, None),
             );
-            for origin in entry.provenance {
-                knowledge_provenance.add_entity(credential_id.clone(), origin);
+            for origin in &entry.provenance {
+                knowledge_provenance.add_entity(credential_id.clone(), *origin);
                 knowledge_provenance
-                    .add_relation(RelationProvenanceKey::from_relation(&relation), origin);
+                    .add_relation(RelationProvenanceKey::from_relation(&relation), *origin);
+            }
+
+            if let Some(namespace_name) = default_namespace {
+                let namespace = Namespace::new(namespace_name);
+                let namespace_id = namespace.entity_id();
+                entities.insert_typed(namespace);
+                graph.ensure_node(namespace_id.clone());
+                let contains = Contains::new(entry.cluster_id.0.clone(), namespace_id.0.clone());
+                if !graph
+                    .targets_of(&entry.cluster_id, contains.relation_name())
+                    .contains(&&namespace_id)
+                {
+                    graph.insert_edge(
+                        contains.source_id(),
+                        contains.target_id(),
+                        cortex::edge_data_for(contains.relation_name(), None, None),
+                    );
+                }
+                for origin in &entry.provenance {
+                    knowledge_provenance.add_entity(namespace_id.clone(), *origin);
+                    knowledge_provenance
+                        .add_relation(RelationProvenanceKey::from_relation(&contains), *origin);
+                }
             }
         }
 
@@ -701,8 +725,10 @@ mod planner_helper_tests {
     fn bootstrap_with_kubeconfig_records_relation_and_provenance() {
         let cluster = K8sCluster::new("demo").with_server(Some("https://demo".into()));
         let cluster_id = cluster.entity_id();
-        let credential = K8sCredential::new("https://demo").with_name("developer");
+        let mut credential = K8sCredential::new("https://demo").with_name("developer");
+        credential.default_namespace = Some("default".to_string());
         let credential_id = credential.entity_id();
+        let namespace_id = EntityId::new("ns/default");
         let origins =
             BTreeSet::from([KnowledgeProvenance::Operator, KnowledgeProvenance::Scenario]);
         let initial = InitialKnowledge {
@@ -726,11 +752,18 @@ mod planner_helper_tests {
             vec![&cluster_id]
         );
         assert_eq!(campaign.entity_provenance(&credential_id), origins);
+        assert!(campaign.entities.contains::<Namespace>(&namespace_id));
+        assert_eq!(
+            campaign.graph.targets_of(&cluster_id, "contains"),
+            vec![&namespace_id]
+        );
+        assert_eq!(campaign.entity_provenance(&namespace_id), origins);
         assert!(campaign.execution_records.is_empty());
         assert!(serde_json::to_string(&campaign).is_ok());
 
         campaign.reset_with_knowledge("test", initial);
         assert!(campaign.entities.contains::<K8sCredential>(&credential_id));
+        assert!(campaign.entities.contains::<Namespace>(&namespace_id));
         assert_eq!(
             campaign
                 .graph

--- a/crates/campaign/src/output_parsers/file.rs
+++ b/crates/campaign/src/output_parsers/file.rs
@@ -50,10 +50,12 @@ pub(super) fn is_kubeconfig_content(content: &str) -> bool {
 /// the first user's `token` or `client-certificate-data` + `client-key-data`.
 ///
 /// Returns `None` when the YAML does not contain a usable cluster entry.
-fn credential_from_kubeconfig(content: &str) -> Option<K8sCredential> {
+fn credential_from_kubeconfig(content: &str) -> Option<(K8sCredential, String)> {
     let resolved = k8s::resolve_kubeconfig_yaml(content, None).ok()?;
+    let cluster_name = resolved.cluster_name.clone();
     let mut cred = K8sCredential::new(resolved.server.clone().unwrap_or_default());
     cred.context_name = Some(resolved.context_name);
+    cred.default_namespace = resolved.default_namespace;
     cred.user_name = resolved.user_name;
     cred.auth_method = resolved.auth_method;
     cred.has_token = resolved.has_token;
@@ -64,7 +66,7 @@ fn credential_from_kubeconfig(content: &str) -> Option<K8sCredential> {
     cred.cert_data = resolved.cert_data;
     cred.key_data = resolved.key_data;
 
-    Some(cred)
+    Some((cred, cluster_name))
 }
 
 // ---------------------------------------------------------------------------
@@ -86,7 +88,7 @@ pub(super) fn parse_file_kubeconfig(stdout: &str, source_id: &str) -> ParserOutp
         return ParserOutput::KnownFailure("empty stdout for file:kubeconfig".to_string());
     }
 
-    let cred = match credential_from_kubeconfig(stdout) {
+    let (cred, cluster_name) = match credential_from_kubeconfig(stdout) {
         Some(c) => c,
         None => {
             return ParserOutput::UnknownFormat(
@@ -96,12 +98,15 @@ pub(super) fn parse_file_kubeconfig(stdout: &str, source_id: &str) -> ParserOutp
     };
 
     let detail = format!(
-        "extracted K8sCredential for endpoint '{}' (token={}, cert={})",
+        "extracted K8sCredential for endpoint '{}' (context={}, cluster={}, default_namespace={}, token={}, cert={})",
         if cred.endpoint.is_empty() {
             "unknown"
         } else {
             &cred.endpoint
         },
+        cred.context_name.as_deref().unwrap_or("unknown"),
+        cluster_name,
+        cred.default_namespace.as_deref().unwrap_or("none"),
         cred.token.is_some(),
         cred.cert_data.is_some(),
     );
@@ -173,6 +178,7 @@ contexts:
 - context:
     cluster: test-cluster
     user: admin
+    namespace: default
   name: test-context
 current-context: test-context
 users:
@@ -259,6 +265,7 @@ users:
             .downcast_ref::<K8sCredential>()
             .unwrap();
         assert_eq!(cred.endpoint, "https://10.96.0.1:6443");
+        assert_eq!(cred.default_namespace.as_deref(), Some("default"));
         assert_eq!(cred.token.as_deref(), Some("ya29.supersecrettoken"));
         assert!(cred.cert_data.is_none());
         assert!(cred.ca_data.is_some());

--- a/crates/domain/entities.rs
+++ b/crates/domain/entities.rs
@@ -1382,6 +1382,9 @@ pub struct K8sCredential {
     pub credential_type: String,
     #[serde(default)]
     pub context_name: Option<String>,
+    /// Explicit default namespace configured on the selected kubeconfig context.
+    #[serde(default)]
+    pub default_namespace: Option<String>,
     #[serde(default)]
     pub user_name: Option<String>,
     #[serde(default)]
@@ -1423,6 +1426,7 @@ impl K8sCredential {
             name: endpoint.clone(),
             credential_type: default_kubeconfig_credential_type(),
             context_name: None,
+            default_namespace: None,
             user_name: None,
             auth_method: String::new(),
             has_token: false,
@@ -1879,6 +1883,9 @@ impl Merge for K8sCredential {
         }
         if self.context_name.is_none() {
             self.context_name = incoming.context_name.clone();
+        }
+        if self.default_namespace.is_none() {
+            self.default_namespace = incoming.default_namespace.clone();
         }
         if self.user_name.is_none() {
             self.user_name = incoming.user_name.clone();

--- a/crates/k8s/src/lib.rs
+++ b/crates/k8s/src/lib.rs
@@ -47,6 +47,9 @@ pub struct ResolvedKubeconfig {
     kubeconfig: Kubeconfig,
     source_path: Option<PathBuf>,
     pub context_name: String,
+    /// Explicit default namespace configured on the selected context.
+    /// Kubernetes' implicit `default` fallback is intentionally not inferred.
+    pub default_namespace: Option<String>,
     pub cluster_name: String,
     pub user_name: Option<String>,
     pub server: Option<String>,
@@ -127,6 +130,12 @@ pub fn resolve_kubeconfig_data(
         })?;
 
     let user_name = context.user.clone();
+    let default_namespace = context
+        .namespace
+        .as_deref()
+        .map(str::trim)
+        .filter(|namespace| !namespace.is_empty())
+        .map(str::to_string);
     let auth = user_name
         .as_deref()
         .and_then(|name| kubeconfig.auth_infos.iter().find(|user| user.name == name))
@@ -167,6 +176,7 @@ pub fn resolve_kubeconfig_data(
         kubeconfig,
         source_path: None,
         context_name,
+        default_namespace,
         cluster_name,
         user_name,
         server,
@@ -565,10 +575,12 @@ contexts:
   context:
     cluster: cluster-a
     user: user-a
+    namespace: default
 - name: context-b
   context:
     cluster: cluster-b
     user: user-b
+    namespace: "   "
 current-context: context-a
 users:
 - name: user-a
@@ -584,6 +596,7 @@ users:
     fn resolver_uses_current_context_by_default() {
         let resolved = resolve_kubeconfig_yaml(KUBECONFIG, None).unwrap();
         assert_eq!(resolved.context_name, "context-a");
+        assert_eq!(resolved.default_namespace.as_deref(), Some("default"));
         assert_eq!(resolved.cluster_name, "cluster-a");
         assert_eq!(resolved.user_name.as_deref(), Some("user-a"));
         assert_eq!(resolved.server.as_deref(), Some("https://a.example"));
@@ -595,6 +608,7 @@ users:
     fn resolver_honors_context_override() {
         let resolved = resolve_kubeconfig_yaml(KUBECONFIG, Some("context-b")).unwrap();
         assert_eq!(resolved.cluster_name, "cluster-b");
+        assert_eq!(resolved.default_namespace, None);
         assert_eq!(resolved.user_name.as_deref(), Some("user-b"));
         assert!(resolved.has_client_certificate);
         assert!(resolved.has_client_key);

--- a/frontend/src/lib/api/gen_types.ts
+++ b/frontend/src/lib/api/gen_types.ts
@@ -542,6 +542,20 @@ export interface components {
             relations: {
                 [key: string]: unknown;
             }[];
+            bootstrapOperations?: components["schemas"]["BootstrapOperation"][];
+        };
+        BootstrapOperation: {
+            id: string;
+            name: string;
+            detail: string;
+            effects: components["schemas"]["BootstrapEffect"][];
+        };
+        BootstrapEffect: {
+            entityId: string;
+            entityName: string;
+            entityKind: string;
+            /** @enum {string} */
+            category: "credential" | "discovery";
         };
         AttackFlow: {
             steps: components["schemas"]["AttackStep"][];

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -11,6 +11,7 @@ export type Graph = components['schemas']['Graph'];
 export type Node = components['schemas']['Node'];
 export type Edge = components['schemas']['Edge'];
 export type CampaignState = components['schemas']['CampaignState'];
+export type BootstrapOperation = components['schemas']['BootstrapOperation'];
 export type AttackFlow = components['schemas']['AttackFlow'];
 export type AttackStep = components['schemas']['AttackStep'];
 export type TraversalHop = components['schemas']['TraversalHop'];

--- a/frontend/src/lib/components/CampaignState.svelte.ts
+++ b/frontend/src/lib/components/CampaignState.svelte.ts
@@ -1,6 +1,12 @@
 import { getContext, setContext } from 'svelte';
 import type { ArmoryType, Node } from '$lib/model';
-import type { AttackFlow, CampaignState as State, Graph, TTP, ExecuteActionRequest } from '$lib/api/index';
+import type {
+	AttackFlow,
+	CampaignState as State,
+	Graph,
+	TTP,
+	ExecuteActionRequest
+} from '$lib/api/index';
 import { showToast, type ToastType } from '$lib/components/toaster';
 import { getRanAPI, RanAPI } from '$lib/ran_api';
 import { timeline } from '$lib/stores/timelineStore.svelte';
@@ -88,13 +94,16 @@ class CampaignState {
 			this.api.GetGraph().then((g: Graph) => {
 				this.graph = g;
 			});
-			
+
 			const stateCallId = ++this.getCampaignStateCounter;
-			this.api.GetCampaignState().then((s: State) => {
-				this.#setState(s);
-			}).catch((err) => {
-				console.error(`❌ [Event ${eventId}->Call ${stateCallId}] GetCampaignState failed:`, err);
-			});
+			this.api
+				.GetCampaignState()
+				.then((s: State) => {
+					this.#setState(s);
+				})
+				.catch((err) => {
+					console.error(`❌ [Event ${eventId}->Call ${stateCallId}] GetCampaignState failed:`, err);
+				});
 		});
 		this.api.on('parse-audited', (data: any) => {
 			const audits = (data?.audits ?? []).map(normalizeParseAudit);
@@ -104,10 +113,15 @@ class CampaignState {
 			}
 
 			const logOnly = new Set(['NoParser', 'KnownFailure']);
-			const problematic = audits.filter((a: ParseAuditUI) => a.parseResult !== 'Parsed' && !logOnly.has(a.parseResult));
+			const problematic = audits.filter(
+				(a: ParseAuditUI) => a.parseResult !== 'Parsed' && !logOnly.has(a.parseResult)
+			);
 			const gaps = audits.filter((a: ParseAuditUI) => logOnly.has(a.parseResult));
 			if (gaps.length > 0) {
-				console.log('[parse-audited] parser gaps (log only):', gaps.map((a: ParseAuditUI) => `${a.effectId}: ${a.parseResult} (${a.detail})`));
+				console.log(
+					'[parse-audited] parser gaps (log only):',
+					gaps.map((a: ParseAuditUI) => `${a.effectId}: ${a.parseResult} (${a.detail})`)
+				);
 			}
 			if (problematic.length > 0) {
 				const details = problematic
@@ -290,16 +304,15 @@ class CampaignState {
 		let namespaces = [];
 		let pods = [];
 		let serviceAccounts = [];
-		
+
 		const timestamp = new Date().toISOString();
 		for (const [id, entity] of Object.entries(state.entities || {})) {
 			const typedEntity = entity as unknown as Entity;
 			if (typedEntity === null) {
 				console.warn(`⚠️ Skipping entity with id ${id} because it is null`);
-				console.log(state.entities)
+				console.log(state.entities);
 				continue;
 			}
-
 
 			if (typedEntity.kind === 'Namespace') {
 				namespaces.push(typedEntity);
@@ -314,14 +327,14 @@ class CampaignState {
 			}
 			entities.push(typedEntity);
 		}
-		
+
 		this.entities = entities;
 		this.namespaces = namespaces;
 		this.pods = pods;
 		this.serviceAccounts = serviceAccounts;
 
 		// Process relations
-		console.info("Setting campaign state with relations:", state.relations);
+		console.info('Setting campaign state with relations:', state.relations);
 		const relationsMap = new Map<string, Relation>();
 		for (const relation of state.relations || []) {
 			// Extract source and target from the relation
@@ -332,6 +345,7 @@ class CampaignState {
 			}
 		}
 		this.relations = relationsMap;
+		timeline.backfillBootstrap(state.bootstrapOperations ?? []);
 	}
 
 	// #updateState is currently unused but kept for potential future use
@@ -399,7 +413,7 @@ class CampaignState {
 	}
 
 	getEntityById(id: string): Entity | undefined {
-		if (id === "") {
+		if (id === '') {
 			return undefined;
 		}
 		const found = this.entities.find((entity) => entity.id === id);
@@ -410,16 +424,16 @@ class CampaignState {
 	}
 
 	getRelationById(id: string): Relation | undefined {
-		if (id === "") {
+		if (id === '') {
 			return undefined;
 		}
-		
+
 		// First check if we have the full relation data stored
 		const storedRelation = this.relations.get(id);
 		if (storedRelation) {
 			return storedRelation;
 		}
-		
+
 		// Fallback: parse the ID to create a basic relation object
 		const parts = id.match(/^(.+?)-\[(.+?)\]->(.+)$/);
 		if (parts) {
@@ -434,13 +448,13 @@ class CampaignState {
 		return undefined;
 	}
 
-
-
 	getCompromisedSystems(): Entity[] {
 		const systemKinds = ['Pod', 'K8sNode', 'UnknownSystem'];
 		return this.entities.filter(
-			(entity) => systemKinds.includes(entity.kind ?? '') &&
-				typeof entity.accessLevel === 'string' && entity.accessLevel.endsWith('exec')
+			(entity) =>
+				systemKinds.includes(entity.kind ?? '') &&
+				typeof entity.accessLevel === 'string' &&
+				entity.accessLevel.endsWith('exec')
 		);
 	}
 
@@ -454,26 +468,30 @@ class CampaignState {
 
 	getServiceAccountsWithTokens(ns?: string): Entity[] {
 		// Get all service account tokens
-		const tokens = this.entities.filter((entity) => entity.kind === 'ServiceAccountToken' || (entity.kind === 'ServiceAccount' && entity.hasOwnProperty('token'))); // Include ServiceAccounts that have token binaries
-		
+		const tokens = this.entities.filter(
+			(entity) =>
+				entity.kind === 'ServiceAccountToken' ||
+				(entity.kind === 'ServiceAccount' && entity.hasOwnProperty('token'))
+		); // Include ServiceAccounts that have token binaries
+
 		// Extract the ServiceAccount IDs from tokens (tokens have ID format: ns/{namespace}/sa/{saName}/token)
 		const saIdsWithTokens = new Set(
-			tokens.map(token => {
+			tokens.map((token) => {
 				// Extract SA ID from token ID by removing the /token suffix
 				const tokenId = token.id;
 				return tokenId.replace(/\/token$/, '');
 			})
 		);
-		
+
 		// Filter ServiceAccounts to only those that have tokens
 		let serviceAccounts = this.entities.filter(
 			(entity) => entity.kind === 'ServiceAccount' && saIdsWithTokens.has(entity.id)
 		);
-		
+
 		if (ns) {
 			serviceAccounts = serviceAccounts.filter((entity) => entity.namespace === ns);
 		}
-		
+
 		return serviceAccounts || [];
 	}
 
@@ -528,5 +546,5 @@ export function parseArmory(data: TTP[]): ArmoryType {
 	return armoryMap;
 }
 export function isRelation(id: string): boolean {
-		return id.indexOf('->') !== -1;
-	}	
+	return id.indexOf('->') !== -1;
+}

--- a/frontend/src/lib/components/OperationTimeline.svelte
+++ b/frontend/src/lib/components/OperationTimeline.svelte
@@ -65,7 +65,8 @@
         }
     }
 
-    function formatTime(d: Date): string {
+    function formatTime(d?: Date): string {
+        if (!d) return 'Startup';
         return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
     }
 
@@ -212,20 +213,24 @@
                         <div class="flex-1 min-w-0">
                             <div class="flex items-center gap-1 flex-wrap leading-tight">
                                 <span class="font-medium">{entry.action.ttpName}</span>
-                                <span class="text-surface-500">on</span>
-                                <button
-                                    type="button"
-                                    class="text-primary-500 hover:underline truncate"
-                                    title={entry.action.targetName}
-                                    onclick={(e) => { e.stopPropagation(); onfocusentity(entry.action.targetId); }}
-                                >
-                                    {entry.action.targetName}
-                                </button>
-                                {#if entry.action.execSystemName}
-                                    <span class="text-surface-500 text-xs">via</span>
-                                    <span class="text-surface-500 text-xs truncate" title={entry.action.execSystemName}>
-                                        {entry.action.execSystemName}
-                                    </span>
+                                {#if entry.action.startup}
+                                    <span class="text-surface-500 text-xs">{entry.action.detail}</span>
+                                {:else}
+                                    <span class="text-surface-500">on</span>
+                                    <button
+                                        type="button"
+                                        class="text-primary-500 hover:underline truncate"
+                                        title={entry.action.targetName}
+                                        onclick={(e) => { e.stopPropagation(); onfocusentity(entry.action.targetId); }}
+                                    >
+                                        {entry.action.targetName}
+                                    </button>
+                                    {#if entry.action.execSystemName}
+                                        <span class="text-surface-500 text-xs">via</span>
+                                        <span class="text-surface-500 text-xs truncate" title={entry.action.execSystemName}>
+                                            {entry.action.execSystemName}
+                                        </span>
+                                    {/if}
                                 {/if}
                             </div>
                             {#if entry.action.status === 'failed' && entry.action.failReason}

--- a/frontend/src/lib/stores/timelineStore.svelte.test.ts
+++ b/frontend/src/lib/stores/timelineStore.svelte.test.ts
@@ -7,7 +7,9 @@ import {
     type TopEntry
 } from '$lib/stores/timelineStore.svelte';
 
-function makeTtpEntry(overrides: Partial<Omit<TtpActionEntry, 'kind'>> = {}): Omit<TtpActionEntry, 'kind'> {
+function makeTtpEntry(
+    overrides: Partial<Omit<TtpActionEntry, 'kind'>> = {}
+): Omit<TtpActionEntry, 'kind'> {
     return {
         id: 'cmd-abc',
         ttpId: 'list-env',
@@ -20,7 +22,9 @@ function makeTtpEntry(overrides: Partial<Omit<TtpActionEntry, 'kind'>> = {}): Om
     };
 }
 
-function makeExecutedEntry(overrides: Partial<Omit<TtpActionEntry, 'kind'>> = {}): Omit<TtpActionEntry, 'kind'> {
+function makeExecutedEntry(
+    overrides: Partial<Omit<TtpActionEntry, 'kind'>> = {}
+): Omit<TtpActionEntry, 'kind'> {
     return makeTtpEntry({ status: 'success', ...overrides });
 }
 
@@ -116,7 +120,13 @@ describe('TimelineStore', () => {
 
     it('addEntityEvent does not suppress entity when a group has the same id as the entity', () => {
         store.addTtpAction(makeTtpEntry({ id: 'ns/default/pod/web-app' }));
-        store.addEntityEvent(makeEntityEntry({ id: 'ns/default/pod/web-app', entityId: 'ns/default/pod/web-app', cmdId: undefined }));
+        store.addEntityEvent(
+            makeEntityEntry({
+                id: 'ns/default/pod/web-app',
+                entityId: 'ns/default/pod/web-app',
+                cmdId: undefined
+            })
+        );
         expect(store.topEntries).toHaveLength(2);
         expect(store.topEntries[0].kind).toBe('discovery');
     });
@@ -203,7 +213,9 @@ describe('TimelineStore', () => {
             })
         );
         // HTTP response follows with the names the UI knows.
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc', targetName: 'my-pod', status: 'pending' }));
+        store.addTtpAction(
+            makeTtpEntry({ id: 'cmd-abc', targetName: 'my-pod', status: 'pending' })
+        );
         expect(store.topEntries).toHaveLength(1);
         const entry = store.topEntries[0];
         if (entry.kind === 'action-group') {
@@ -238,6 +250,68 @@ describe('TimelineStore', () => {
         expect(() => store.toggleGroup('cmd-unknown')).not.toThrow();
     });
 
+    // startup kubeconfig backfill
+    it('backfillBootstrap creates an oldest successful group with discovery effects', () => {
+        store.addTtpAction(makeTtpEntry({ id: 'cmd-live' }));
+        store.backfillBootstrap([
+            {
+                id: 'bootstrap:kubeconfig:developer',
+                name: 'Read kubeconfig',
+                detail: 'developer (context: demo)',
+                effects: [
+                    {
+                        entityId: 'k8s/credential/developer',
+                        entityName: 'developer',
+                        entityKind: 'K8sCredential',
+                        category: 'credential'
+                    },
+                    {
+                        entityId: 'k8s/cluster/demo',
+                        entityName: 'demo',
+                        entityKind: 'Cluster',
+                        category: 'discovery'
+                    },
+                    {
+                        entityId: 'ns/default',
+                        entityName: 'default',
+                        entityKind: 'Namespace',
+                        category: 'discovery'
+                    }
+                ]
+            }
+        ]);
+
+        expect(store.topEntries).toHaveLength(2);
+        const startup = store.topEntries[1];
+        expect(startup.kind).toBe('action-group');
+        if (startup.kind === 'action-group') {
+            expect(startup.action.startup).toBe(true);
+            expect(startup.action.timestamp).toBeUndefined();
+            expect(startup.effects.map((effect) => effect.entityKind)).toEqual([
+                'K8sCredential',
+                'Cluster',
+                'Namespace'
+            ]);
+        }
+    });
+
+    it('backfillBootstrap is idempotent and can repopulate after clear', () => {
+        const operations = [
+            {
+                id: 'bootstrap:kubeconfig:developer',
+                name: 'Read kubeconfig',
+                detail: 'developer',
+                effects: []
+            }
+        ];
+        store.backfillBootstrap(operations);
+        store.backfillBootstrap(operations);
+        expect(store.topEntries).toHaveLength(1);
+        store.clear();
+        store.backfillBootstrap(operations);
+        expect(store.topEntries).toHaveLength(1);
+    });
+
     // clear
     it('clear removes all entries', () => {
         store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
@@ -255,9 +329,7 @@ describe('TimelineStore', () => {
         store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
         store.addEntityEvent(makeEntityEntry({ id: 'pod-a', entityId: 'pod-a', cmdId: undefined }));
         store.addTtpAction(makeTtpEntry({ id: 'cmd-2' }));
-        const ids = store.topEntries.map((e) =>
-            e.kind === 'action-group' ? e.action.id : e.id
-        );
+        const ids = store.topEntries.map((e) => (e.kind === 'action-group' ? e.action.id : e.id));
         expect(ids).toEqual(['cmd-2', 'pod-a', 'cmd-1']);
     });
 });

--- a/frontend/src/lib/stores/timelineStore.svelte.ts
+++ b/frontend/src/lib/stores/timelineStore.svelte.ts
@@ -1,3 +1,5 @@
+import type { BootstrapOperation } from '$lib/api';
+
 export type TtpActionEntry = {
     kind: 'ttp-action';
     id: string;
@@ -9,7 +11,9 @@ export type TtpActionEntry = {
     execSystemName?: string;
     status: 'pending' | 'success' | 'failed';
     failReason?: string;
-    timestamp: Date;
+    timestamp?: Date;
+    startup?: boolean;
+    detail?: string;
 };
 
 export type EntityEntry = {
@@ -19,7 +23,7 @@ export type EntityEntry = {
     entityName: string;
     entityKind: string;
     cmdId?: string;
-    timestamp: Date;
+    timestamp?: Date;
 };
 
 export type ActionGroup = {
@@ -177,6 +181,49 @@ export class TimelineStore {
                 status: 'pending',
                 timestamp: new Date(r.timestampMs)
             });
+        }
+    }
+
+    /**
+     * Add durable kubeconfig loads that happened before the frontend connected.
+     * Startup groups live at the oldest end of the newest-first store and use
+     * stable backend IDs, so repeated campaign-state refreshes are idempotent.
+     */
+    backfillBootstrap(operations: BootstrapOperation[]): void {
+        for (const operation of [...operations].sort((a, b) => b.id.localeCompare(a.id))) {
+            if (this.index.has(operation.id)) continue;
+
+            const group: ActionGroup = {
+                kind: 'action-group',
+                action: {
+                    kind: 'ttp-action',
+                    id: operation.id,
+                    ttpId: '',
+                    ttpName: operation.name,
+                    targetId: '',
+                    targetName: '',
+                    status: 'success',
+                    startup: true,
+                    detail: operation.detail
+                },
+                effects: [],
+                collapsed: true
+            };
+            this.topEntries = [...this.topEntries, group];
+            const proxy = this.topEntries[this.topEntries.length - 1] as ActionGroup;
+            this.index.set(operation.id, proxy);
+
+            for (const effect of operation.effects) {
+                if (this.seenEntityIds.has(effect.entityId)) continue;
+                this.seenEntityIds.add(effect.entityId);
+                proxy.effects.push({
+                    kind: effect.category === 'credential' ? 'credential' : 'discovery',
+                    id: effect.entityId,
+                    entityId: effect.entityId,
+                    entityName: effect.entityName,
+                    entityKind: effect.entityKind
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Extracts explicit context namespaces from active, seeded, and captured kubeconfigs and attaches each namespace to its resolved cluster with provenance. Adds bootstrap operation data and durable startup groups to the Operation Timeline while keeping captured-file discoveries grouped under their real TTP. Validated with Rust library clippy, 375 campaign tests, API/app/k8s tests, 27 frontend tests, and a production frontend build.