### PR TITLE
Hide action and operator provenance badges

### DIFF
--- a/frontend/src/lib/knowledgeProvenance.test.ts
+++ b/frontend/src/lib/knowledgeProvenance.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from 'vitest';
 import { hasKnowledgeProvenance, knowledgeProvenanceBadges } from './knowledgeProvenance';
 
 describe('knowledge provenance presentation', () => {
-	it('builds scenario and operator badges in source order', () => {
-		expect(knowledgeProvenanceBadges(['scenario', 'operator'])).toEqual([
-			{ origin: 'scenario', label: 'Scenario-provided' },
-			{ origin: 'operator', label: 'Operator-provided' }
+	it('builds scenario and inference badges in source order', () => {
+		expect(knowledgeProvenanceBadges(['inference', 'scenario'])).toEqual([
+			{ origin: 'inference', label: 'Inferred' },
+			{ origin: 'scenario', label: 'Scenario-provided' }
 		]);
+	});
+
+	it('does not build operator or action badges', () => {
+		expect(knowledgeProvenanceBadges(['operator', 'action'])).toEqual([]);
 	});
 
 	it('detects scenario styling without accepting absent provenance', () => {

--- a/frontend/src/lib/knowledgeProvenance.ts
+++ b/frontend/src/lib/knowledgeProvenance.ts
@@ -1,9 +1,9 @@
 export type KnowledgeProvenance = 'scenario' | 'operator' | 'action' | 'inference';
 
-const LABELS: Record<KnowledgeProvenance, string> = {
+type KnowledgeProvenanceBadge = Extract<KnowledgeProvenance, 'scenario' | 'inference'>;
+
+const BADGE_LABELS: Record<KnowledgeProvenanceBadge, string> = {
 	scenario: 'Scenario-provided',
-	operator: 'Operator-provided',
-	action: 'Action-discovered',
 	inference: 'Inferred'
 };
 
@@ -16,6 +16,6 @@ export function hasKnowledgeProvenance(
 
 export function knowledgeProvenanceBadges(values: readonly string[] | undefined) {
 	return (values ?? [])
-		.filter((value): value is KnowledgeProvenance => value in LABELS)
-		.map((origin) => ({ origin, label: LABELS[origin] }));
+		.filter((value): value is KnowledgeProvenanceBadge => value in BADGE_LABELS)
+		.map((origin) => ({ origin, label: BADGE_LABELS[origin] }));
 }

--- a/frontend/src/routes/components/entityInfo.svelte
+++ b/frontend/src/routes/components/entityInfo.svelte
@@ -254,10 +254,6 @@
 					class="badge text-xs shrink-0"
 					class:bg-amber-200={badge.origin === 'scenario'}
 					class:text-amber-900={badge.origin === 'scenario'}
-					class:bg-sky-200={badge.origin === 'operator'}
-					class:text-sky-900={badge.origin === 'operator'}
-					class:bg-emerald-200={badge.origin === 'action'}
-					class:text-emerald-900={badge.origin === 'action'}
 					class:bg-violet-200={badge.origin === 'inference'}
 					class:text-violet-900={badge.origin === 'inference'}
 				>


### PR DESCRIPTION
## Summary
- hide Operator-provided and Action-discovered badges from the entity info header
- preserve all provenance values and graph behavior
- retain Scenario-provided and Inferred badges with focused unit coverage

## Validation
- `pnpm exec vitest --run src/lib/knowledgeProvenance.test.ts` (3 tests passed)
- `cargo check` (passed via commit hook)
- `git diff --check` (passed)

## Known baseline issues
- `pnpm check` still reports 59 pre-existing errors in unrelated frontend code and dependency typings