### PR TITLE
Add one-command Conductor workspace dev runner

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,11 @@
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+setup = "pnpm --dir frontend install --frozen-lockfile"
+run_mode = "concurrent"
+
+[scripts.run.dev]
+available_in = [ "local" ]
+command = "make dev-workspace"
+default = true
+icon = "play"

--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,7 @@ ran.yaml.worktrees
 # mdBook build output
 docs/book/book/
 ran.yaml
+# kubeconfig downloaded from the target cluster by ixiplay.sh
+/ixi-config.yaml
 # tuned scoring profile sidecar (written by the scoring tuner UI)
 ran.scoring.yaml

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ install-hooks:
 	@chmod +x .git/hooks/pre-commit
 	@echo "pre-commit hook installed"
 
+.PHONY: dev-workspace
+dev-workspace:
+	./scripts/dev-workspace.zsh
+
 # === Code Generation ===
 .PHONY: generate-api
 generate-api:

--- a/crates/api/src/api_handlers.rs
+++ b/crates/api/src/api_handlers.rs
@@ -849,7 +849,9 @@ struct StaticAssets;
 
 #[cfg(debug_assertions)]
 pub async fn frontend_handler(req: axum::extract::Request) -> impl axum::response::IntoResponse {
-    const VITE_ORIGIN: &str = "http://localhost:5173";
+    let vite_origin =
+        std::env::var("RAN_VITE_ORIGIN").unwrap_or_else(|_| "http://localhost:5173".to_string());
+    let vite_origin = vite_origin.trim_end_matches('/');
     let client = Client::new();
 
     let (parts, body) = req.into_parts();
@@ -858,7 +860,7 @@ pub async fn frontend_handler(req: axum::extract::Request) -> impl axum::respons
         .path_and_query()
         .map(|pq| pq.as_str())
         .unwrap_or("/");
-    let url = format!("{VITE_ORIGIN}{path_and_query}");
+    let url = format!("{vite_origin}{path_and_query}");
 
     let mut headers = HeaderMap::new();
     for (name, value) in parts.headers.iter() {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -4,6 +4,12 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import Icons from 'unplugin-icons/vite'
 import { defineConfig } from 'vite';
 
+const viteHost = process.env.RAN_VITE_HOST ?? 'localhost';
+const requestedPort = Number.parseInt(process.env.RAN_VITE_PORT ?? '5173', 10);
+const vitePort = Number.isInteger(requestedPort) && requestedPort > 0 && requestedPort <= 65535
+	? requestedPort
+	: 5173;
+
 export default defineConfig({
 	plugins: [tailwindcss(), sveltekit(), Icons({
 		compiler: 'svelte',
@@ -11,12 +17,15 @@ export default defineConfig({
 	})],
 
 	server: {
+		host: viteHost,
+		port: vitePort,
+		strictPort: true,
 		// When frontend is served through the Rust proxy, HMR must connect directly
 		// to the Vite server because the proxy path only supports plain HTTP forwarding.
 		hmr: {
-			host: 'localhost',
-			port: 5173,
-			clientPort: 5173,
+			host: viteHost,
+			port: vitePort,
+			clientPort: vitePort,
 			protocol: 'ws'
 		}
 	},

--- a/scripts/dev-workspace.zsh
+++ b/scripts/dev-workspace.zsh
@@ -1,0 +1,91 @@
+#!/bin/zsh
+set -eu
+
+workspace_path="${CONDUCTOR_WORKSPACE_PATH:-$PWD}"
+root_path="${CONDUCTOR_ROOT_PATH:-$workspace_path}"
+backend_port="${CONDUCTOR_PORT:-8080}"
+
+if [[ "$backend_port" != <-> ]] || (( backend_port < 1 || backend_port >= 65535 )); then
+  print -u2 "CONDUCTOR_PORT must be an integer between 1 and 65534"
+  exit 1
+fi
+
+vite_port=$((backend_port + 1))
+root_kubeconfig="$root_path/ixi-config.yaml"
+workspace_kubeconfig="$workspace_path/ixi-config.yaml"
+
+if [[ ! -r "$root_kubeconfig" ]]; then
+  print -u2 "Missing $root_kubeconfig"
+  print -u2 "Start $root_path/ixiplay.sh first so the tunnel and kubeconfig are available."
+  exit 1
+fi
+
+if [[ "$root_path" != "$workspace_path" ]]; then
+  ln -sfn "$root_kubeconfig" "$workspace_kubeconfig"
+fi
+
+if ! KUBECONFIG="$workspace_kubeconfig" kubectl get --raw=/version --request-timeout=5s >/dev/null 2>&1; then
+  print -u2 "The target cluster is not reachable through $workspace_kubeconfig"
+  print -u2 "Keep $root_path/ixiplay.sh running, then try again."
+  exit 1
+fi
+
+export RAN_VITE_HOST="127.0.0.1"
+export RAN_VITE_PORT="$vite_port"
+export RAN_VITE_ORIGIN="http://127.0.0.1:$vite_port"
+
+typeset -a child_pids
+
+terminate_tree() {
+  local pid="$1"
+  local child
+  for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+    terminate_tree "$child"
+  done
+  kill -TERM "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  trap - EXIT HUP INT TERM
+  local pid
+  for pid in $child_pids; do
+    terminate_tree "$pid"
+  done
+  for pid in $child_pids; do
+    wait "$pid" 2>/dev/null || true
+  done
+}
+
+trap 'exit_code=$?; cleanup; exit $exit_code' EXIT
+trap 'cleanup; exit 130' HUP INT TERM
+
+(
+  cd "$workspace_path/frontend"
+  pnpm run dev
+) &
+child_pids+=($!)
+
+(
+  cd "$workspace_path"
+  RAN_LOG="${RAN_LOG:-debug}" cargo run -p cli -- \
+    emulate \
+    --port "$backend_port" \
+    --kubeconfig "$workspace_kubeconfig"
+) &
+child_pids+=($!)
+
+print "Frontend: http://127.0.0.1:$vite_port"
+print "Ran:      http://127.0.0.1:$backend_port"
+
+while true; do
+  for pid in $child_pids; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      set +e
+      wait "$pid"
+      child_status=$?
+      set -e
+      exit "$child_status"
+    fi
+  done
+  sleep 1
+done


### PR DESCRIPTION
Adds a dependency-free zsh supervisor and Make target that start the frontend and backend together on per-worktree ports. The runner links the root repository's ignored `ixi-config.yaml`, validates the existing `ixiplay.sh` tunnel, configures the Rust proxy and Vite HMR, and shuts both child processes down together. Adds the shared Conductor Run configuration; validated with frontend tests/build, API tests, Clippy, syntax checks, and an end-to-end start/proxy/stop lifecycle.