### PR TITLE
Show compact timestamps in the operation timeline

### DIFF
--- a/frontend/src/lib/components/OperationTimeline.svelte
+++ b/frontend/src/lib/components/OperationTimeline.svelte
@@ -65,9 +65,29 @@
         }
     }
 
-    function formatTime(d?: Date): string {
-        if (!d) return 'Startup';
-        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false });
+    function formatCompactTime(d: Date): string {
+        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+    }
+
+    function formatFullTime(d: Date): string {
+        return d.toLocaleString([], { dateStyle: 'medium', timeStyle: 'long' });
+    }
+
+    let timestampTooltip = $state<{ text: string; left: number; top: number }>();
+
+    function showTimestampTooltip(event: MouseEvent | FocusEvent, timestamp: Date) {
+        const trigger = event.currentTarget;
+        if (!(trigger instanceof HTMLElement)) return;
+        const bounds = trigger.getBoundingClientRect();
+        timestampTooltip = {
+            text: formatFullTime(timestamp),
+            left: bounds.left + bounds.width / 2,
+            top: bounds.top - 6
+        };
+    }
+
+    function hideTimestampTooltip() {
+        timestampTooltip = undefined;
     }
 
     function entityPrefix(entry: EntityEntry): string {
@@ -123,6 +143,7 @@
 
     function onTimelineScroll() {
         if (!scrollEl) return;
+        hideTimestampTooltip();
         const slack = 24; // px tolerance — near-bottom still counts as bottom
         stickToBottom =
             scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - slack;
@@ -138,6 +159,26 @@
         }
     });
 </script>
+
+{#snippet timestamp(value?: Date, startup = false)}
+    {#if value}
+        {@const fullTimestamp = formatFullTime(value)}
+        <button
+            type="button"
+            class="text-surface-500 text-xs shrink-0 mt-0.5 cursor-help"
+            aria-label={fullTimestamp}
+            onmouseenter={(event) => showTimestampTooltip(event, value)}
+            onmouseleave={hideTimestampTooltip}
+            onfocus={(event) => showTimestampTooltip(event, value)}
+            onblur={hideTimestampTooltip}
+            onclick={(event) => event.stopPropagation()}
+        >
+            {startup ? 'Startup' : formatCompactTime(value)}
+        </button>
+    {:else}
+        <span class="text-surface-500 text-xs shrink-0 mt-0.5">Startup</span>
+    {/if}
+{/snippet}
 
 <div
     class="shrink-0 bg-surface-100-900 border-t border-surface-200-800 flex flex-col relative"
@@ -260,7 +301,7 @@
                         </div>
 
                         <!-- Timestamp -->
-                        <span class="text-surface-500 text-xs shrink-0 mt-0.5">{formatTime(entry.action.timestamp)}</span>
+                        {@render timestamp(entry.action.timestamp, entry.action.startup)}
                     </div>
 
                     <!-- Expanded child effect rows -->
@@ -277,7 +318,7 @@
                                         onclick={() => onfocusentity(effect.entityId)}
                                     >{effect.entityName}</button>
                                 </div>
-                                <span class="text-surface-500 text-xs shrink-0 mt-0.5">{formatTime(effect.timestamp)}</span>
+                                {@render timestamp(effect.timestamp)}
                             </div>
                         {/each}
                     {/if}
@@ -295,10 +336,20 @@
                                 onclick={() => onfocusentity(entry.entityId)}
                             >{entry.entityName}</button>
                         </div>
-                        <span class="text-surface-500 text-xs shrink-0 mt-0.5">{formatTime(entry.timestamp)}</span>
+                        {@render timestamp(entry.timestamp)}
                     </div>
                 {/if}
             {/each}
         {/if}
     </div>
+
+    {#if timestampTooltip}
+        <div
+            role="tooltip"
+            class="fixed z-[100] pointer-events-none -translate-x-1/2 -translate-y-full whitespace-nowrap bg-surface-100-900 border border-surface-300-700 rounded px-2 py-1 shadow-lg text-xs"
+            style="left: {timestampTooltip.left}px; top: {timestampTooltip.top}px"
+        >
+            {timestampTooltip.text}
+        </div>
+    {/if}
 </div>

--- a/frontend/src/lib/components/OperationTimeline.svelte.test.ts
+++ b/frontend/src/lib/components/OperationTimeline.svelte.test.ts
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import OperationTimeline from './OperationTimeline.svelte';
+import type { TopEntry } from '$lib/stores/timelineStore.svelte';
+
+function compactTimestamp(date: Date): string {
+	return date.toLocaleTimeString([], {
+		hour: '2-digit',
+		minute: '2-digit',
+		hour12: false
+	});
+}
+
+function fullTimestamp(date: Date): string {
+	return date.toLocaleString([], { dateStyle: 'medium', timeStyle: 'long' });
+}
+
+function renderTimeline(entries: TopEntry[]) {
+	return render(OperationTimeline, {
+		entries,
+		onfocusentity: vi.fn(),
+		ontogglegroup: vi.fn()
+	});
+}
+
+describe('OperationTimeline timestamps', () => {
+	it('shows compact timestamps with full hover text for every row type', async () => {
+		const actionTimestamp = new Date(2026, 4, 25, 12, 34, 56);
+		const effectTimestamp = new Date(2026, 4, 25, 12, 35, 57);
+		const standaloneTimestamp = new Date(2026, 4, 25, 12, 36, 58);
+		const entries: TopEntry[] = [
+			{
+				kind: 'discovery',
+				id: 'standalone',
+				entityId: 'standalone',
+				entityName: 'standalone-pod',
+				entityKind: 'Pod',
+				timestamp: standaloneTimestamp
+			},
+			{
+				kind: 'action-group',
+				action: {
+					kind: 'ttp-action',
+					id: 'action',
+					ttpId: 'list-pods',
+					ttpName: 'List pods',
+					targetId: 'target',
+					targetName: 'target-pod',
+					status: 'success',
+					timestamp: actionTimestamp
+				},
+				effects: [
+					{
+						kind: 'discovery',
+						id: 'effect',
+						entityId: 'effect',
+						entityName: 'effect-pod',
+						entityKind: 'Pod',
+						timestamp: effectTimestamp
+					}
+				],
+				collapsed: false
+			}
+		];
+
+		renderTimeline(entries);
+
+		for (const timestamp of [actionTimestamp, effectTimestamp, standaloneTimestamp]) {
+			const full = fullTimestamp(timestamp);
+			const trigger = screen.getByText(compactTimestamp(timestamp));
+			expect(trigger).toHaveAttribute('aria-label', full);
+
+			await fireEvent.mouseEnter(trigger);
+			expect(screen.getByRole('tooltip')).toHaveTextContent(full);
+
+			await fireEvent.mouseLeave(trigger);
+			expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+		}
+	});
+
+	it('keeps the Startup label and shows its full timestamp on hover', async () => {
+		const startupTimestamp = new Date(2026, 4, 25, 12, 37, 59);
+		renderTimeline([
+			{
+				kind: 'action-group',
+				action: {
+					kind: 'ttp-action',
+					id: 'startup',
+					ttpId: '',
+					ttpName: 'Read kubeconfig',
+					targetId: '',
+					targetName: '',
+					status: 'success',
+					startup: true,
+					detail: 'developer',
+					timestamp: startupTimestamp
+				},
+				effects: [],
+				collapsed: true
+			}
+		]);
+
+		const trigger = screen.getByText('Startup');
+		await fireEvent.mouseEnter(trigger);
+		expect(screen.getByRole('tooltip')).toHaveTextContent(fullTimestamp(startupTimestamp));
+	});
+});

--- a/frontend/src/lib/stores/timelineStore.svelte.test.ts
+++ b/frontend/src/lib/stores/timelineStore.svelte.test.ts
@@ -286,7 +286,7 @@ describe('TimelineStore', () => {
         expect(startup.kind).toBe('action-group');
         if (startup.kind === 'action-group') {
             expect(startup.action.startup).toBe(true);
-            expect(startup.action.timestamp).toBeUndefined();
+            expect(startup.action.timestamp).toBeInstanceOf(Date);
             expect(startup.effects.map((effect) => effect.entityKind)).toEqual([
                 'K8sCredential',
                 'Cluster',

--- a/frontend/src/lib/stores/timelineStore.svelte.ts
+++ b/frontend/src/lib/stores/timelineStore.svelte.ts
@@ -190,6 +190,7 @@ export class TimelineStore {
      * stable backend IDs, so repeated campaign-state refreshes are idempotent.
      */
     backfillBootstrap(operations: BootstrapOperation[]): void {
+        const timestamp = new Date();
         for (const operation of [...operations].sort((a, b) => b.id.localeCompare(a.id))) {
             if (this.index.has(operation.id)) continue;
 
@@ -204,7 +205,8 @@ export class TimelineStore {
                     targetName: '',
                     status: 'success',
                     startup: true,
-                    detail: operation.detail
+                    detail: operation.detail,
+                    timestamp
                 },
                 effects: [],
                 collapsed: true


### PR DESCRIPTION
## Summary
- Show compact local `HH:mm` timestamps for operation timeline entries.
- Display the full localized timestamp in a fixed hover/focus tooltip that is not clipped by the timeline scroller.
- Preserve the `Startup` label while assigning bootstrap entries a timestamp for the same tooltip behavior.

## Testing
- `pnpm test` (30 tests passed)
- `cargo check` (pre-commit hook)