### PR TITLE
Simplify API discovery action titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ The armory is Ran's library of executable TTPs. Each TTP is a YAML file describi
 
 ```yaml
 id: get-pods
-name: Get Pods via K8s API
+name: Get Pods
 tactic: Discovery
 techniques: ["Container and Resource Discovery", T1613]
 preconditions:

--- a/armory/TTPs/Discovery/get_clusterrolebindings.yaml
+++ b/armory/TTPs/Discovery/get_clusterrolebindings.yaml
@@ -1,5 +1,5 @@
 id: get-clusterrolebindings
-name: Get ClusterRoleBindings via API Server
+name: Get ClusterRoleBindings
 description: Get a list of ClusterRoleBindings via the K8s API server
 tactic: Discovery
 techniques: [ "Container and Resource Discovery", T1613 ]

--- a/armory/TTPs/Discovery/get_clusterroles.yaml
+++ b/armory/TTPs/Discovery/get_clusterroles.yaml
@@ -1,5 +1,5 @@
 id: get-clusterroles
-name: Get ClusterRoles via API Server
+name: Get ClusterRoles
 description: Get a list of ClusterRoles via the K8s API server
 tactic: Discovery
 techniques: [ "Container and Resource Discovery", T1613 ]

--- a/armory/TTPs/Discovery/get_deployments.yaml
+++ b/armory/TTPs/Discovery/get_deployments.yaml
@@ -1,4 +1,4 @@
-name: Get Deployments via API Server
+name: Get Deployments
 description: Get a list of deployments via the API server
 tactic: Discovery
 techniques: [ "Container and Resource Discovery", T1613 ]

--- a/armory/TTPs/Discovery/get_gateways.yaml
+++ b/armory/TTPs/Discovery/get_gateways.yaml
@@ -1,5 +1,5 @@
 id: get-gateways
-name: Get Gateways via API Server
+name: Get Gateways
 description: Enumerate Kubernetes Gateway API Gateway resources to identify
   externally exposed listeners, gateway implementations, and assigned external
   addresses

--- a/armory/TTPs/Discovery/get_httproutes.yaml
+++ b/armory/TTPs/Discovery/get_httproutes.yaml
@@ -1,5 +1,5 @@
 id: get-httproutes
-name: Get HTTPRoutes via API Server
+name: Get HTTPRoutes
 description: Enumerate Kubernetes Gateway API HTTPRoute resources to map routing
   rules, discover backend services reachable via Gateways, and identify
   hostname-to-service mappings

--- a/armory/TTPs/Discovery/get_ingresses.yaml
+++ b/armory/TTPs/Discovery/get_ingresses.yaml
@@ -1,5 +1,5 @@
 id: get-ingresses
-name: Get Ingresses via API Server
+name: Get Ingresses
 description: Enumerate Kubernetes Ingress resources to map externally exposed
   HTTP/HTTPS entry points, identify backend services, and discover TLS secret
   references

--- a/armory/TTPs/Discovery/get_namespaces.yaml
+++ b/armory/TTPs/Discovery/get_namespaces.yaml
@@ -1,5 +1,5 @@
 id: get-namespaces
-name: Get Namespaces via K8s API
+name: Get Namespaces
 description: Get a list of namespaces from the Kubernetes API server
 tactic: Discovery
 techniques: ["Container and Resource Discovery", "T1613"]

--- a/armory/TTPs/Discovery/get_nodes.yaml
+++ b/armory/TTPs/Discovery/get_nodes.yaml
@@ -1,4 +1,4 @@
-name: Get Nodes via API Server
+name: Get Nodes
 description: Get a list of nodes in the cluster via the API server
 tactic: Discovery
 techniques: [ "Cloud Infrastructure Discovery", T1580 ]

--- a/armory/TTPs/Discovery/get_pods.yaml
+++ b/armory/TTPs/Discovery/get_pods.yaml
@@ -1,5 +1,5 @@
 id: get-pods
-name: Get Pods via K8s API
+name: Get Pods
 description: Get a list of pods via the K8s API server
 tactic: Discovery
 techniques: [ "Container and Resource Discovery", T1613 ]

--- a/armory/TTPs/Discovery/get_rolebindings.yaml
+++ b/armory/TTPs/Discovery/get_rolebindings.yaml
@@ -1,5 +1,5 @@
 id: get-rolebindings
-name: Get RoleBindings via API Server
+name: Get RoleBindings
 description: Get a list of RoleBindings via the K8s API server
 tactic: Discovery
 techniques: [ "Container and Resource Discovery", T1613 ]

--- a/armory/TTPs/Discovery/get_roles.yaml
+++ b/armory/TTPs/Discovery/get_roles.yaml
@@ -1,4 +1,4 @@
-name: Get Roles via API Server
+name: Get Roles
 description: Get a list of ServiceAccounts via the API server
 tactic: Discovery
 techniques: [ "Container and Resource Discovery", T1613 ]

--- a/armory/TTPs/Discovery/get_serviceaccounts.yaml
+++ b/armory/TTPs/Discovery/get_serviceaccounts.yaml
@@ -1,4 +1,4 @@
-name: Get ServiceAccounts via API Server
+name: Get ServiceAccounts
 description: Get a list of ServiceAccounts via the API server
 tactic: Discovery
 techniques: [ "Container and Resource Discovery", T1613 ]

--- a/armory/TTPs/Discovery/get_services.yaml
+++ b/armory/TTPs/Discovery/get_services.yaml
@@ -1,5 +1,5 @@
 id: get-services
-name: Get Services via API Server
+name: Get Services
 description: Enumerate Kubernetes Services via the K8s API server to map
   internal service endpoints and identify externally exposed workloads
 tactic: Discovery

--- a/docs/book/src/armory/anatomy.md
+++ b/docs/book/src/armory/anatomy.md
@@ -4,7 +4,7 @@ Every TTP in the armory is a YAML file. Here is a representative example — the
 *Get ServiceAccounts* technique from the Discovery tactic:
 
 ```yaml
-name: Get ServiceAccounts via API Server
+name: Get ServiceAccounts
 description: Get a list of ServiceAccounts via the API server
 tactic: Discovery
 techniques: ["Container and Resource Discovery", T1613]


### PR DESCRIPTION
Removes the redundant API server/K8s API suffix from 13 default Kubernetes discovery action titles while preserving alternate kubelet and node/proxy labels.

Updates the README and armory anatomy examples to match.

Tests: cargo test -p armory (11 passed); repository pre-commit Cargo check.