### PR TITLE
Remove the Inferred badge from the entity info popup

### DIFF
--- a/frontend/src/lib/knowledgeProvenance.test.ts
+++ b/frontend/src/lib/knowledgeProvenance.test.ts
@@ -2,9 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { hasKnowledgeProvenance, knowledgeProvenanceBadges } from './knowledgeProvenance';
 
 describe('knowledge provenance presentation', () => {
-	it('builds scenario and inference badges in source order', () => {
+	it('builds a scenario badge and ignores inference', () => {
 		expect(knowledgeProvenanceBadges(['inference', 'scenario'])).toEqual([
-			{ origin: 'inference', label: 'Inferred' },
 			{ origin: 'scenario', label: 'Scenario-provided' }
 		]);
 	});

--- a/frontend/src/lib/knowledgeProvenance.ts
+++ b/frontend/src/lib/knowledgeProvenance.ts
@@ -1,10 +1,9 @@
 export type KnowledgeProvenance = 'scenario' | 'operator' | 'action' | 'inference';
 
-type KnowledgeProvenanceBadge = Extract<KnowledgeProvenance, 'scenario' | 'inference'>;
+type KnowledgeProvenanceBadge = Extract<KnowledgeProvenance, 'scenario'>;
 
 const BADGE_LABELS: Record<KnowledgeProvenanceBadge, string> = {
-	scenario: 'Scenario-provided',
-	inference: 'Inferred'
+	scenario: 'Scenario-provided'
 };
 
 export function hasKnowledgeProvenance(

--- a/frontend/src/routes/components/entityInfo.svelte
+++ b/frontend/src/routes/components/entityInfo.svelte
@@ -254,8 +254,6 @@
 					class="badge text-xs shrink-0"
 					class:bg-amber-200={badge.origin === 'scenario'}
 					class:text-amber-900={badge.origin === 'scenario'}
-					class:bg-violet-200={badge.origin === 'inference'}
-					class:text-violet-900={badge.origin === 'inference'}
 				>
 					{badge.label}
 				</span>


### PR DESCRIPTION
Removes the "Inferred" provenance badge from the entity info popup while keeping the "Scenario-provided" badge. The removal is done at the data layer by dropping `inference` from `BADGE_LABELS` in `knowledgeProvenance.ts`, so the popup's badge loop naturally never emits it; the now-dead violet styling in `entityInfo.svelte` is also removed. The `provenance` data field (including the `inference` value) is untouched, and the vitest test was updated to assert no inference badge is produced.