### PR TITLE
Fix pnpm workspace config for container builds

### DIFF
--- a/frontend/pnpm-workspace.yaml
+++ b/frontend/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - .
+
 allowBuilds:
   esbuild: true


### PR DESCRIPTION
Declares the frontend root as the workspace package while preserving the esbuild build permission. This makes pnpm 9 accept the workspace configuration during the Dockerfile.dev frozen install and restores the build-containers workflow. Validated with a pnpm 9 frozen install, the frontend production build, and the repository commit hook.