### PR TITLE
Open TTP details from the operation timeline

### DIFF
--- a/frontend/src/lib/components/AttackStepDrawer.svelte
+++ b/frontend/src/lib/components/AttackStepDrawer.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import type { AttackStep } from '$lib/api';
+	import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
+	import AttackStepDetails from './attack_step_details.svelte';
+
+	interface Props {
+		step: AttackStep | null;
+		onclose: () => void;
+	}
+
+	let { step, onclose }: Props = $props();
+
+	const animDrawer =
+		'transition transition-discrete opacity-0 translate-x-full starting:data-[state=open]:opacity-0 starting:data-[state=open]:translate-x-full data-[state=open]:opacity-100 data-[state=open]:translate-x-0';
+	const animBackdrop =
+		'transition transition-discrete opacity-0 starting:data-[state=open]:opacity-0 data-[state=open]:opacity-100';
+</script>
+
+<Dialog
+	open={step !== null}
+	onOpenChange={(event) => {
+		if (!event.open) onclose();
+	}}
+>
+	<Portal>
+		<Dialog.Backdrop
+			class="fixed inset-0 z-50 bg-surface-50-950/50 transition transition-discrete {animBackdrop}"
+		/>
+		<Dialog.Positioner class="fixed inset-0 z-50 flex justify-end">
+			<Dialog.Content
+				class="h-screen w-xl space-y-4 overflow-auto bg-surface-100-900 p-4 shadow-xl {animDrawer}"
+			>
+				{#if step}
+					<AttackStepDetails {step} />
+				{/if}
+			</Dialog.Content>
+		</Dialog.Positioner>
+	</Portal>
+</Dialog>

--- a/frontend/src/lib/components/AttackStepDrawer.svelte.test.ts
+++ b/frontend/src/lib/components/AttackStepDrawer.svelte.test.ts
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import type { AttackStep } from '$lib/api';
+import AttackStepDrawer from './AttackStepDrawer.svelte';
+
+const step: AttackStep = {
+	id: 'cmd-1',
+	targetId: 'target-1',
+	command: 'id',
+	traversal: [],
+	innerCommand: '',
+	args: {},
+	procedureId: 'shell',
+	TTP: {
+		id: 'whoami',
+		name: 'Who am I',
+		description: 'Identify the current user',
+		tactic: 'Discovery',
+		techniques: ['T1033']
+	},
+	results: ['uid=1000'],
+	startedAt: '2026-08-15T09:10:11Z',
+	completedAt: '2026-08-15T09:10:12Z',
+	executedOn: 'target-1',
+	status: 'Success',
+	success: true
+};
+
+function renderDrawer(onclose = vi.fn()) {
+	return {
+		...render(AttackStepDrawer, {
+			props: { step, onclose },
+			context: new Map([['$_campaignState', { getEntityById: () => ({ name: 'target-pod' }) }]])
+		}),
+		onclose
+	};
+}
+
+describe('AttackStepDrawer', () => {
+	it('renders the shared attack-step details', () => {
+		renderDrawer();
+
+		expect(screen.getByRole('dialog')).toBeInTheDocument();
+		expect(screen.getByRole('heading', { name: 'Who am I' })).toBeInTheDocument();
+		expect(screen.getByText('uid=1000')).toBeInTheDocument();
+	});
+
+	it('closes when its selected step is cleared', async () => {
+		const { rerender } = renderDrawer();
+
+		await rerender({ step: null });
+
+		await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+	});
+});

--- a/frontend/src/lib/components/OperationTimeline.svelte
+++ b/frontend/src/lib/components/OperationTimeline.svelte
@@ -6,9 +6,10 @@
         entries: TopEntry[];
         onfocusentity: (targetId: string) => void;
         ontogglegroup: (cmdId: string) => void;
+        onviewaction: (cmdId: string) => void;
     }
 
-    let { entries, onfocusentity, ontogglegroup }: Props = $props();
+    let { entries, onfocusentity, ontogglegroup, onviewaction }: Props = $props();
 
     const MIN_HEIGHT = 120;
     const MAX_HEIGHT = 800;
@@ -253,7 +254,20 @@
                         <!-- Label: ttpName on target [via execSystem] -->
                         <div class="flex-1 min-w-0">
                             <div class="flex items-center gap-1 flex-wrap leading-tight">
-                                <span class="font-medium">{entry.action.ttpName}</span>
+                                {#if entry.action.startup}
+                                    <span class="font-medium">{entry.action.ttpName}</span>
+                                {:else}
+                                    <button
+                                        type="button"
+                                        class="font-medium text-primary-500 hover:underline"
+                                        onclick={(event) => {
+                                            event.stopPropagation();
+                                            onviewaction(entry.action.id);
+                                        }}
+                                    >
+                                        {entry.action.ttpName}
+                                    </button>
+                                {/if}
                                 {#if entry.action.startup}
                                     <span class="text-surface-500 text-xs">{entry.action.detail}</span>
                                 {:else}

--- a/frontend/src/lib/components/OperationTimeline.svelte.test.ts
+++ b/frontend/src/lib/components/OperationTimeline.svelte.test.ts
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import { describe, expect, it, vi } from 'vitest';
 import OperationTimeline from './OperationTimeline.svelte';
-import type { TopEntry } from '$lib/stores/timelineStore.svelte';
+import type { ActionGroup, TopEntry } from '$lib/stores/timelineStore.svelte';
 
 function compactTimestamp(date: Date): string {
 	return date.toLocaleTimeString([], {
@@ -15,13 +15,96 @@ function fullTimestamp(date: Date): string {
 	return date.toLocaleString([], { dateStyle: 'medium', timeStyle: 'long' });
 }
 
-function renderTimeline(entries: TopEntry[]) {
-	return render(OperationTimeline, {
+function renderTimeline(
+	entries: TopEntry[],
+	handlers: {
+		onfocusentity?: (targetId: string) => void;
+		ontogglegroup?: (cmdId: string) => void;
+		onviewaction?: (cmdId: string) => void;
+	} = {}
+) {
+	const onfocusentity = handlers.onfocusentity ?? vi.fn();
+	const ontogglegroup = handlers.ontogglegroup ?? vi.fn();
+	const onviewaction = handlers.onviewaction ?? vi.fn();
+	const result = render(OperationTimeline, {
 		entries,
-		onfocusentity: vi.fn(),
-		ontogglegroup: vi.fn()
+		onfocusentity,
+		ontogglegroup,
+		onviewaction
 	});
+	return { ...result, onfocusentity, ontogglegroup, onviewaction };
 }
+
+function actionEntry(overrides: Partial<ActionGroup> = {}): ActionGroup {
+	return {
+		kind: 'action-group',
+		action: {
+			kind: 'ttp-action',
+			id: 'action',
+			ttpId: 'list-pods',
+			ttpName: 'List pods',
+			targetId: 'target',
+			targetName: 'target-pod',
+			status: 'success'
+		},
+		effects: [],
+		collapsed: true,
+		...overrides
+	};
+}
+
+describe('OperationTimeline action interactions', () => {
+	it('opens details from the TTP name without toggling the group', async () => {
+		const { onviewaction, ontogglegroup } = renderTimeline([actionEntry()]);
+
+		await fireEvent.click(screen.getByRole('button', { name: 'List pods' }));
+
+		expect(onviewaction).toHaveBeenCalledWith('action');
+		expect(ontogglegroup).not.toHaveBeenCalled();
+	});
+
+	it('still toggles the group when the action row itself is clicked', async () => {
+		const { onviewaction, ontogglegroup } = renderTimeline([actionEntry()]);
+		const row = screen.getByRole('button', { name: 'List pods' }).closest('[aria-expanded]');
+
+		expect(row).not.toBeNull();
+		await fireEvent.click(row!);
+
+		expect(ontogglegroup).toHaveBeenCalledWith('action');
+		expect(onviewaction).not.toHaveBeenCalled();
+	});
+
+	it('focuses a target without opening details or toggling the group', async () => {
+		const { onfocusentity, onviewaction, ontogglegroup } = renderTimeline([actionEntry()]);
+
+		await fireEvent.click(screen.getByRole('button', { name: 'target-pod' }));
+
+		expect(onfocusentity).toHaveBeenCalledWith('target');
+		expect(onviewaction).not.toHaveBeenCalled();
+		expect(ontogglegroup).not.toHaveBeenCalled();
+	});
+
+	it('keeps startup action names as plain text', () => {
+		renderTimeline([
+			actionEntry({
+				action: {
+					kind: 'ttp-action',
+					id: 'startup',
+					ttpId: '',
+					ttpName: 'Read kubeconfig',
+					targetId: '',
+					targetName: '',
+					status: 'success',
+					startup: true,
+					detail: 'developer'
+				}
+			})
+		]);
+
+		expect(screen.getByText('Read kubeconfig')).not.toBeInstanceOf(HTMLButtonElement);
+		expect(screen.queryByRole('button', { name: 'Read kubeconfig' })).not.toBeInTheDocument();
+	});
+});
 
 describe('OperationTimeline timestamps', () => {
 	it('shows compact timestamps with full hover text for every row type', async () => {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import Armory from './components/armory.svelte';
-	import type { Node, TTP, ScoredCandidate } from '$lib/api/index';
+	import type { AttackStep, Node, TTP, ScoredCandidate } from '$lib/api/index';
 	import Icon from '@iconify/svelte';
 	import Graph from './components/graph.svelte';
 	import { Dialog, Popover, Portal } from '@skeletonlabs/skeleton-svelte';
@@ -10,6 +10,7 @@
 	import { toaster } from '$lib/components/toaster';
 	import { timeline } from '$lib/stores/timelineStore.svelte';
 	import OperationTimeline from '$lib/components/OperationTimeline.svelte';
+	import AttackStepDrawer from '$lib/components/AttackStepDrawer.svelte';
 	import EntityInfo from './components/entityInfo.svelte';
 	import { getCampaignState } from '$lib/components/CampaignState.svelte';
 	import { ExecuteAction, getRanAPI } from '$lib/ran_api';
@@ -29,6 +30,8 @@
 	let showFileViewer: boolean = $state(false);
 	let fileViewerPath: string = $state('');
 	let fileViewerContent: string = $state('');
+	let selectedAttackStep: AttackStep | null = $state(null);
+	let actionDetailsRequestId = 0;
 
 	// Armory resize and collapse state
 	const ARMORY_WIDTH_KEY = '_armoryWidth';
@@ -244,6 +247,8 @@
 		// reset the page/graph state when the campaign resets
 		selectedObjectId = '';
 		selectedObject = undefined;
+		selectedAttackStep = null;
+		actionDetailsRequestId++;
 	})
 
 	// Reset entity info to content-fit when a new node is selected
@@ -513,6 +518,36 @@
 			type: 'error'
 		});
 	}
+
+	async function viewTimelineAction(commandId: string) {
+		const requestId = ++actionDetailsRequestId;
+
+		try {
+			const flow = await ranAPI.GetFlow();
+			if (requestId !== actionDetailsRequestId) return;
+
+			const step = flow.steps.find((candidate) => candidate.id === commandId);
+			if (!step) {
+				throw new Error(`No flow step found for action ${commandId}`);
+			}
+
+			selectedAttackStep = step;
+		} catch (error) {
+			if (requestId !== actionDetailsRequestId) return;
+			selectedAttackStep = null;
+			const description = error instanceof Error ? error.message : 'Unknown error';
+			toaster.create({
+				title: 'Action details unavailable',
+				description,
+				type: 'error'
+			});
+		}
+	}
+
+	function closeAttackStepDrawer() {
+		actionDetailsRequestId++;
+		selectedAttackStep = null;
+	}
 </script>
 
 <div class="relative flex h-[calc(100vh-35px)] gap-x-0">
@@ -586,6 +621,7 @@
 				entries={timeline.topEntries}
 				onfocusentity={(id) => { selectedObjectId = id; }}
 				ontogglegroup={(cmdId) => timeline.toggleGroup(cmdId)}
+				onviewaction={viewTimelineAction}
 			/>
 		{/if}
 	</div>
@@ -626,6 +662,8 @@
 				</Dialog.Positioner>
 			</Portal>
 		</Dialog>
+
+		<AttackStepDrawer step={selectedAttackStep} onclose={closeAttackStepDrawer} />
 	{:else}
 		<div class="flex items-center justify-center w-full h-full">
 			<div class="text-center">

--- a/frontend/src/routes/flow/+page.svelte
+++ b/frontend/src/routes/flow/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { type FlowEdge, type AttackFlow, type AttackStep } from '$lib/api/index';
-    import AttackStepDetails from '$lib/components/attack_step_details.svelte';
+    import AttackStepDrawer from '$lib/components/AttackStepDrawer.svelte';
     import ActionNode from '$lib/components/flow/attack_node.svelte';
     import {
         SvelteFlow,
@@ -14,7 +14,6 @@
     } from '@xyflow/svelte';
     import dagre from '@dagrejs/dagre';
     import '@xyflow/svelte/dist/style.css';
-    import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
 	import { getCampaignState } from '$lib/components/CampaignState.svelte';
 	import { ranAPI } from '$lib/ran_api';
     import { getContext } from 'svelte';
@@ -102,9 +101,6 @@
             console.error(err);
         });
 
-    const animModal =
-        'transition transition-discrete opacity-0 translate-x-full starting:data-[state=open]:opacity-0 starting:data-[state=open]:translate-x-full data-[state=open]:opacity-100 data-[state=open]:translate-x-0';
-    const animBackdrop = 'transition transition-discrete opacity-0 starting:data-[state=open]:opacity-0 data-[state=open]:opacity-100';
 </script>
 
 <div class="items-top mx-auto flex h-dvh w-full justify-center">
@@ -139,23 +135,7 @@
     </SvelteFlow>
 </div>
 
-<Dialog
-    open={selectedStep !== null}
-    onOpenChange={(e) => {
-        if (!e.open) {
-            selectedStep = null;
-        }
-    }}
->
-    <Portal>
-    <Dialog.Backdrop class="fixed inset-0 z-50 bg-surface-50-950/50 transition transition-discrete {animBackdrop}" />
-		<Dialog.Positioner class="fixed inset-0 z-50 flex justify-end">
-			<Dialog.Content class="w-xl h-screen overflow-auto bg-surface-100-900 p-4 space-y-4 shadow-xl {animModal}">
-                <AttackStepDetails step={selectedStep!} />
-			</Dialog.Content>
-		</Dialog.Positioner>
-    </Portal>
-</Dialog>
+<AttackStepDrawer step={selectedStep} onclose={() => (selectedStep = null)} />
 
 <style>
     :global(.svelte-flow__node) {


### PR DESCRIPTION
Makes non-startup TTP names in the operation timeline open the matching action details while preserving row collapse and target-link behavior. Extracts the flow details dialog into a shared drawer, fetches authoritative flow data on selection, ignores stale responses, and reports lookup failures through a toast. Adds focused drawer and timeline interaction coverage; all 40 frontend tests pass, the production build passes, and the commit hook completed the Rust workspace check. `pnpm check` remains blocked by the repository’s existing 57 type errors in 13 files.