### PR TITLE
release: prepare v0.2.2-alpha.1

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -259,12 +259,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if gh release view "${{ github.ref_name }}" &>/dev/null; then
-            gh release upload "${{ github.ref_name }}" artifacts/*.tar.gz --clobber
+          tag="${{ github.ref_name }}"
+          release_args=()
+          if [[ "$tag" == *-* ]]; then
+            release_args+=(--prerelease --latest=false)
+          fi
+
+          if gh release view "$tag" &>/dev/null; then
+            gh release upload "$tag" artifacts/*.tar.gz --clobber
+            if ((${#release_args[@]})); then
+              gh release edit "$tag" "${release_args[@]}"
+            fi
           else
-            gh release create "${{ github.ref_name }}" \
-              --title "${{ github.ref_name }}" \
+            gh release create "$tag" \
+              --title "$tag" \
               --generate-notes \
+              "${release_args[@]}" \
               artifacts/*.tar.gz
           fi
 
@@ -316,10 +326,12 @@ jobs:
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            latest=false
           tags: |
             type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest
+            type=semver,pattern={{major}}.{{minor}},enable=${{ !contains(github.ref_name, '-') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
 
       - name: Build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli"
-version = "0.2.1-alpha.1"
+version = "0.2.2-alpha.1"
 dependencies = [
  "anyhow",
  "app",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1-alpha.1"
+version = "0.2.2-alpha.1"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- bump the Rust CLI release version to 0.2.2-alpha.1
- classify generated GitHub releases as prereleases without changing Latest
- publish only the exact prerelease GHCR tag, leaving stable aliases untouched

## Validation

- cargo fmt --check
- cargo clippy --workspace --locked -- -D warnings
- cargo test --workspace --locked
- make test-frontend
- pnpm --prefix frontend build
- cargo build --locked --release --package cli --features cli/bundled-armory
- ./target/release/ran --version