### PR TITLE
release: prepare v0.2.2-alpha.2

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -252,6 +252,7 @@ jobs:
           cd artifacts
           for dir in ran-*/; do
             name="${dir%/}"
+            chmod +x "$dir"/*
             tar -czvf "${name}.tar.gz" -C "$dir" .
           done
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli"
-version = "0.2.2-alpha.1"
+version = "0.2.2-alpha.2"
 dependencies = [
  "anyhow",
  "app",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2-alpha.1"
+version = "0.2.2-alpha.2"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary

- preserve executable permissions when packaging downloaded release artifacts
- bump the corrected prerelease to 0.2.2-alpha.2
- leave the already-published v0.2.2-alpha.1 tag immutable

## Validation

- cargo fmt --check
- cargo clippy --workspace --locked -- -D warnings
- cargo test --workspace --locked
- archive permission simulation (`ran` stored as executable)
- cargo build --locked --release --package cli --features cli/bundled-armory
- ./target/release/ran --version