### PR TITLE
Separate Kubernetes authentication from prerequisites

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1086,8 +1086,6 @@ components:
             $ref: '#/components/schemas/RBACPermission'
         accessLevel:
           type: string
-        activeKubeconfig:
-          type: boolean
         activeSession:
           type: boolean
         exists:

--- a/armory/TTPs/Discovery/check_kubeconfig_permissions.yaml
+++ b/armory/TTPs/Discovery/check_kubeconfig_permissions.yaml
@@ -9,7 +9,6 @@ parameters:
     default: default
 preconditions:
   kind: K8sCredential
-  activeKubeconfig: true
 procedures:
   - key: k8s-client
     command: k8sSelfSubjectRulesReview(${NS})

--- a/armory/TTPs/InitialAccess/valid_accounts_kubeconfig.yaml
+++ b/armory/TTPs/InitialAccess/valid_accounts_kubeconfig.yaml
@@ -1,11 +1,10 @@
 id: valid-accounts-kubeconfig
 name: Execute into pod via Valid Account
-description: Use credentials from the active external kubeconfig to establish access to the target pod
+description: Use the selected executable Kubernetes identity to establish access to the target pod
 tactic: Initial Access
 techniques: [Valid Accounts, T1078]
 preconditions:
   kind: Pod
-  activeKubeconfig: true
 parameters:
   K8S_AUTH:
     type: K8sAuth

--- a/crates/armory/src/armory.rs
+++ b/crates/armory/src/armory.rs
@@ -601,13 +601,7 @@ mod tests {
             canonical.requires.get("kind").and_then(|v| v.as_str()),
             Some("Pod")
         );
-        assert_eq!(
-            canonical
-                .requires
-                .get("activeKubeconfig")
-                .and_then(|v| v.as_bool()),
-            Some(true)
-        );
+        assert!(!canonical.requires.contains_key("activeKubeconfig"));
 
         assert_eq!(
             armory

--- a/crates/campaign/src/campaign/execution.rs
+++ b/crates/campaign/src/campaign/execution.rs
@@ -946,6 +946,14 @@ impl Campaign {
         }
         ground_procedure_and_effects(&mut procedure, &mut ttp.effects, &mut args, &ttp.id);
         args.remove("K8S_AUTH");
+        if is_local_control_command(&procedure.command)
+            && matches!(resolved_auth, Some(ResolvedK8sAuth::ServiceAccount { .. }))
+        {
+            return Err(ExecuteActionError::InvalidInput(format!(
+                "procedure '{}' uses the active Kubernetes client and cannot realize a ServiceAccount Authenticate As identity",
+                procedure.id
+            )));
+        }
         if use_kubeconfig {
             if procedure.command.trim().is_empty() {
                 if let Some(request) = procedure.k8s_request.clone() {

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -1669,6 +1669,48 @@ fn kubectl_kubeconfig_auth_uses_explicit_environment_flag() {
 }
 
 #[test]
+fn knowledge_only_kubeconfig_cannot_be_selected_for_execution() {
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+    let target_id = campaign
+        .entities
+        .values::<K8sCluster>()
+        .next()
+        .expect("cluster")
+        .entity_id()
+        .0;
+    let credential = K8sCredential::new("https://cluster.example").with_name("discovered");
+    let credential_id = credential.entity_id().0;
+    campaign.entities.insert_typed(credential);
+    let armory = armory_with_command("test-ttp", "kubectl ${K8S_AUTH} get pods", None);
+
+    let mut request = action_request(&target_id, None);
+    request.auth_identity_id = Some(credential_id.clone());
+    assert!(matches!(
+        campaign.prepare_action(request, &armory),
+        Err(ExecuteActionError::InvalidInput(message))
+            if message.contains(&format!("authentication identity '{credential_id}' is not eligible"))
+    ));
+}
+
+#[test]
+fn active_client_control_command_rejects_service_account_identity() {
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+    let target = Pod::new("victim", "default");
+    let target_id = target.entity_id().0;
+    campaign.entities.insert_typed(target);
+    let auth_identity_id = insert_test_auth_service_account(&mut campaign);
+    let armory = armory_with_command("test-ttp", "c2.kubectl_exec()", None);
+
+    let mut request = action_request(&target_id, None);
+    request.auth_identity_id = Some(auth_identity_id);
+    assert!(matches!(
+        campaign.prepare_action(request, &armory),
+        Err(ExecuteActionError::InvalidInput(message))
+            if message.contains("cannot realize a ServiceAccount")
+    ));
+}
+
+#[test]
 fn prepare_action_grounds_binary_against_target_for_direct_path() {
     // When targeting a pod directly, a non-standard binary path on that pod
     // should be substituted into the procedure command.

--- a/crates/campaign/src/ttp_applicability.rs
+++ b/crates/campaign/src/ttp_applicability.rs
@@ -78,30 +78,22 @@ pub fn eligible_auth_identities(
         .get("kind")
         .and_then(Value::as_str)
         .filter(|kind| matches!(*kind, "ServiceAccount" | "K8sCredential"));
-    let active_kubeconfig_required = ttp
-        .requires
-        .get("activeKubeconfig")
-        .and_then(Value::as_bool)
-        == Some(true);
-
     let mut identities = Vec::new();
-    if !active_kubeconfig_required {
-        identities.extend(
-            campaign
-                .entities
-                .values::<ServiceAccount>()
-                .filter(|account| account.raw_token().is_some())
-                .filter(|account| {
-                    identity_target != Some("ServiceAccount") || account.entity_id().0 == target_id
-                })
-                .filter(|account| entitlements_satisfy(ttp, &account.entitlements))
-                .map(|account| AuthIdentitySummary {
-                    id: account.entity_id().0,
-                    name: account.entity_name().to_string(),
-                    kind: "ServiceAccount".to_string(),
-                }),
-        );
-    }
+    identities.extend(
+        campaign
+            .entities
+            .values::<ServiceAccount>()
+            .filter(|account| account.raw_token().is_some())
+            .filter(|account| {
+                identity_target != Some("ServiceAccount") || account.entity_id().0 == target_id
+            })
+            .filter(|account| entitlements_satisfy(ttp, &account.entitlements))
+            .map(|account| AuthIdentitySummary {
+                id: account.entity_id().0,
+                name: account.entity_name().to_string(),
+                kind: "ServiceAccount".to_string(),
+            }),
+    );
     identities.extend(
         campaign
             .entities
@@ -137,8 +129,6 @@ pub struct TargetContext {
     pub access_level: AccessLevel,
     /// `true` when the target is a ServiceAccount holding a non-empty token.
     pub has_token: bool,
-    /// `true` when the target credential backs the process' active K8s client.
-    pub active_kubeconfig: bool,
     /// `true` when the target system has at least one live shell session.
     pub active_session: bool,
 }
@@ -183,10 +173,6 @@ pub fn resolve_target_context(campaign: &Campaign, target_id: &str) -> Option<Ta
         CampaignEntityRef::ServiceAccount(sa) => sa.raw_token().is_some(),
         _ => false,
     };
-    let active_kubeconfig = match &entity {
-        CampaignEntityRef::K8sCredential(credential) => credential.active,
-        _ => false,
-    };
     let sessions: &[ran_domain::SessionInfo] = match &entity {
         CampaignEntityRef::Pod(pod) => pod.system.sessions.as_slice(),
         CampaignEntityRef::Node(node) => node.system.sessions.as_slice(),
@@ -203,7 +189,6 @@ pub fn resolve_target_context(campaign: &Campaign, target_id: &str) -> Option<Ta
         is_system,
         access_level,
         has_token,
-        active_kubeconfig,
         active_session,
     })
 }
@@ -216,20 +201,11 @@ pub fn ttp_applicable_for_target(
     campaign: &Campaign,
     tc: &TargetContext,
 ) -> bool {
-    let active_kubeconfig = if ttp.id == armory::VALID_ACCOUNTS_KUBECONFIG_ID {
-        campaign
-            .entities
-            .values::<K8sCredential>()
-            .any(|credential| credential.active)
-    } else {
-        tc.active_kubeconfig
-    };
     ttp_target_scope_satisfied(ttp, tc)
         && ttp_auth_satisfied_for_target(ttp, campaign, tc)
         && ttp_exists_satisfied(ttp, campaign)
         && (!tc.is_system || ttp_access_level_satisfied(ttp, tc.access_level))
         && ttp_has_token_satisfied(ttp, tc.has_token)
-        && ttp_active_kubeconfig_satisfied(ttp, active_kubeconfig)
         && ttp_active_session_satisfied(ttp, tc.active_session)
         && ttp_related_satisfied(ttp, &tc.target_id, &tc.target_kind, campaign)
         && ttp_tool_satisfied(ttp, campaign, tc)
@@ -250,20 +226,31 @@ fn ttp_target_scope_satisfied(ttp: &armory::Ttp, tc: &TargetContext) -> bool {
     )
 }
 
-/// When the selected target is an identity and the action has no more specific
-/// semantic target, that identity itself must witness authentication and RBAC.
-/// This makes captured ServiceAccount tokens behave like active kubeconfigs,
-/// while an unread ServiceAccount cannot borrow an unrelated credential.
+/// Require a realizable authentication identity for Kubernetes actions. When
+/// the semantic target is itself an identity, that exact identity must be the
+/// witness; resource targets may use any eligible identity selected through
+/// Authenticate As.
 fn ttp_auth_satisfied_for_target(
     ttp: &armory::Ttp,
     campaign: &Campaign,
     tc: &TargetContext,
 ) -> bool {
-    let selected_identity = matches!(tc.target_kind.as_str(), "K8sCredential" | "ServiceAccount");
-    if selected_identity && !ttp.requires.contains_key("kind") && ttp_uses_k8s_auth(ttp) {
-        return eligible_auth_identities(ttp, campaign, &tc.target_id)
-            .iter()
-            .any(|identity| identity.id == tc.target_id);
+    if ttp_uses_k8s_auth(ttp) {
+        let identities = eligible_auth_identities(ttp, campaign, &tc.target_id);
+        let selected_identity =
+            matches!(tc.target_kind.as_str(), "K8sCredential" | "ServiceAccount");
+        let explicitly_targets_identity = ttp
+            .requires
+            .get("kind")
+            .and_then(Value::as_str)
+            .is_some_and(|kind| matches!(kind, "K8sCredential" | "ServiceAccount"));
+        let identity_must_match = selected_identity
+            && (!ttp.requires.contains_key("kind") || explicitly_targets_identity);
+        return !identities.is_empty()
+            && (!identity_must_match
+                || identities
+                    .iter()
+                    .any(|identity| identity.id == tc.target_id));
     }
 
     ttp_rbac_satisfied(ttp, campaign)
@@ -381,20 +368,6 @@ pub fn ttp_rbac_satisfied(ttp: &armory::Ttp, campaign: &Campaign) -> bool {
             .values::<K8sCredential>()
             .filter(|credential| credential.active)
             .any(|credential| entitlements_satisfy(ttp, &credential.entitlements))
-}
-
-/// Gate actions that explicitly operate through the process' active
-/// kubeconfig. This prevents a knowledge-only seeded/discovered credential
-/// from accidentally running through a different identity.
-pub fn ttp_active_kubeconfig_satisfied(ttp: &armory::Ttp, active: bool) -> bool {
-    match ttp
-        .requires
-        .get("activeKubeconfig")
-        .and_then(Value::as_bool)
-    {
-        Some(true) => active,
-        _ => true,
-    }
 }
 
 /// Gate actions that require a live shell session on the selected target.
@@ -581,32 +554,27 @@ mod tests {
     }
 
     #[test]
-    fn pod_target_can_require_campaign_active_kubeconfig() {
+    fn pod_target_requires_a_realizable_auth_identity_without_action_special_case() {
         let mut campaign = empty_campaign();
         let pod = ran_domain::Pod::new("target", "default");
         let pod_id = pod.entity_id().0;
         campaign.entities.insert_typed(pod);
-        let mut credential = K8sCredential::new("https://cluster.example").with_name("operator");
-        credential.active = true;
-        campaign.entities.insert_typed(credential);
-
         let mut requires = serde_json::Map::new();
         requires.insert("kind".to_string(), json!("Pod"));
-        requires.insert("activeKubeconfig".to_string(), json!(true));
         let ttp = Ttp {
             requires,
             procedures: vec![armory::Procedure::new(
                 "kubectl",
-                "kubectl exec -n default target -- true",
+                "kubectl ${K8S_AUTH} exec -n default target -- true",
             )],
-            ..Ttp::new(
-                "valid-accounts-kubeconfig",
-                "Valid Accounts",
-                "Initial Access",
-            )
+            ..Ttp::new("pod-exec", "Pod exec", "Initial Access")
         };
         let context = resolve_target_context(&campaign, &pod_id).expect("Pod target context");
+        assert!(!ttp_applicable_for_target(&ttp, &campaign, &context));
 
+        let mut credential = K8sCredential::new("https://cluster.example").with_name("operator");
+        credential.active = true;
+        campaign.entities.insert_typed(credential);
         assert!(ttp_applicable_for_target(&ttp, &campaign, &context));
     }
 
@@ -939,7 +907,7 @@ mod tests {
     }
 
     #[test]
-    fn active_kubeconfig_precondition_rejects_knowledge_only_credentials() {
+    fn authentication_capability_rejects_knowledge_only_credentials() {
         let mut c = empty_campaign();
         let mut credential = K8sCredential::new("https://cluster.example");
         let id = credential.entity_id().0;
@@ -949,8 +917,10 @@ mod tests {
         ttp.status = "enabled".to_string();
         ttp.requires
             .insert("kind".to_string(), json!("K8sCredential"));
-        ttp.requires
-            .insert("activeKubeconfig".to_string(), json!(true));
+        ttp.procedures = vec![armory::Procedure::new(
+            "inspect",
+            "k8sSelfSubjectRulesReview(default)",
+        )];
 
         let tc = resolve_target_context(&c, &id).expect("credential should resolve");
         assert!(!ttp_applicable_for_target(&ttp, &c, &tc));

--- a/crates/utility-ai/src/considerations.rs
+++ b/crates/utility-ai/src/considerations.rs
@@ -532,7 +532,6 @@ mod tests {
             is_system: true,
             access_level: AccessLevel::Exec,
             has_token: false,
-            active_kubeconfig: false,
             active_session: false,
         }
     }

--- a/docs/book/src/agents/authoring.md
+++ b/docs/book/src/agents/authoring.md
@@ -64,6 +64,12 @@ and declare
 Local control procedures that use the already-active Kubernetes client without
 referencing `${K8S_AUTH}` do not declare the parameter.
 
+Preconditions describe semantic world state; they must not describe which
+credential happens to back Ran's active client. Authenticate As selects the
+identity, and action preparation separately verifies that Ran can realize it.
+Only active `K8sCredential` entities and ServiceAccounts with captured tokens
+are executable; discovered kubeconfigs remain knowledge-only.
+
 ## Procedure contract
 
 Every procedure must have at least one of:

--- a/docs/book/src/extending/procedures.md
+++ b/docs/book/src/extending/procedures.md
@@ -76,6 +76,21 @@ ServiceAccount `--token` flag or `--kubeconfig "$KUBECONFIG"`.
 Local control procedures that directly use the active Kubernetes client are
 exempt when they do not reference `${K8S_AUTH}`.
 
+Keep these concerns separate when authoring an action:
+
+- `preconditions` describe semantic campaign facts, such as target kind, RBAC,
+  reachability, or credential availability.
+- `K8S_AUTH` and **Authenticate As** select the identity used for the request.
+- Runtime preparation verifies that Ran has an adapter for that identity. A
+  captured ServiceAccount requires a token-capable request or kubectl command;
+  a kubeconfig identity must be the credential backing Ran's active client.
+- `effects` describe facts learned or established only after successful,
+  verified execution.
+
+Do not encode active-client wiring as a prerequisite. Discovered kubeconfig
+entities remain knowledge only: they are not offered as authentication
+identities and cannot be executed unless they back Ran's active client.
+
 ## Structured HTTP request
 
 Use `http_request:` for arbitrary HTTP calls:

--- a/frontend/src/lib/api/gen_types.ts
+++ b/frontend/src/lib/api/gen_types.ts
@@ -673,7 +673,6 @@ export interface components {
             kind?: string;
             rbacPermissions?: components["schemas"]["RBACPermission"][];
             accessLevel?: string;
-            activeKubeconfig?: boolean;
             activeSession?: boolean;
             exists?: string[];
         };

--- a/scripts/dev-workspace.zsh
+++ b/scripts/dev-workspace.zsh
@@ -1,17 +1,34 @@
 #!/bin/zsh
 set -eu
 
-workspace_path="${CONDUCTOR_WORKSPACE_PATH:-$PWD}"
-root_path="${CONDUCTOR_ROOT_PATH:-$workspace_path}"
-backend_port="${CONDUCTOR_PORT:-8080}"
+# Portable runner contract:
+#   RAN_WORKSPACE_PATH  worktree to run (defaults to this script's repository)
+#   RAN_ROOT_PATH       primary checkout holding ixi-config.yaml (auto-detected)
+#   RAN_KUBECONFIG      kubeconfig to use (defaults to RAN_ROOT_PATH/ixi-config.yaml)
+#   RAN_DEV_PORT        backend port; Vite uses the following port
+script_dir="${0:A:h}"
+workspace_path="${RAN_WORKSPACE_PATH:-${script_dir:h}}"
+
+if [[ -n "${RAN_ROOT_PATH:-}" ]]; then
+  root_path="$RAN_ROOT_PATH"
+else
+  git_common_dir="$(git -C "$workspace_path" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+  if [[ -n "$git_common_dir" && "${git_common_dir:t}" == ".git" ]]; then
+    root_path="${git_common_dir:h}"
+  else
+    root_path="$workspace_path"
+  fi
+fi
+
+backend_port="${RAN_DEV_PORT:-8080}"
 
 if [[ "$backend_port" != <-> ]] || (( backend_port < 1 || backend_port >= 65535 )); then
-  print -u2 "CONDUCTOR_PORT must be an integer between 1 and 65534"
+  print -u2 "RAN_DEV_PORT must be an integer between 1 and 65534"
   exit 1
 fi
 
 vite_port=$((backend_port + 1))
-root_kubeconfig="$root_path/ixi-config.yaml"
+root_kubeconfig="${RAN_KUBECONFIG:-$root_path/ixi-config.yaml}"
 workspace_kubeconfig="$workspace_path/ixi-config.yaml"
 
 if [[ ! -r "$root_kubeconfig" ]]; then
@@ -20,7 +37,7 @@ if [[ ! -r "$root_kubeconfig" ]]; then
   exit 1
 fi
 
-if [[ "$root_path" != "$workspace_path" ]]; then
+if [[ "$root_kubeconfig" != "$workspace_kubeconfig" ]]; then
   ln -sfn "$root_kubeconfig" "$workspace_kubeconfig"
 fi
 


### PR DESCRIPTION
## Summary

- remove `activeKubeconfig` from armory prerequisites, applicability state, and API types
- make Kubernetes applicability depend generically on an eligible `K8sAuth` identity with matching RBAC and a realizable adapter
- remove the `valid-accounts-kubeconfig` action-ID exception from applicability
- prevent knowledge-only kubeconfigs and active-client/ServiceAccount adapter mismatches from executing
- document the prerequisite/authentication/capability/effect separation
- make `dev-workspace.zsh` orchestration-neutral through Ran-owned environment variables and Git worktree discovery

## Safety properties

- discovered kubeconfigs remain campaign knowledge but cannot be selected for execution
- only the kubeconfig backing Ran's active client is eligible
- ServiceAccounts require a captured token and a token-capable execution path
- effects are still applied only after verified successful execution

## Validation

- `cargo test -p armory`
- `cargo test -p campaign`
- `cargo test -p api`
- focused regressions for knowledge-only kubeconfigs and active-client/ServiceAccount mismatch
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`
- `zsh -n scripts/dev-workspace.zsh`

`cargo test -p utility-ai` currently does not compile because three existing test fixtures omit the required `ExecutionRecord.discovered_entities` field; production workspace checking succeeds.
