### PR TITLE
Fix ExecutionRecord test fixtures

### DIFF
--- a/crates/planner/src/exporter.rs
+++ b/crates/planner/src/exporter.rs
@@ -370,6 +370,7 @@ mod tests {
             completed_at_ms: 0,
             is_cleanup: false,
             reasoning: String::new(),
+            discovered_entities: vec![],
         }
     }
 }

--- a/crates/utility-ai/src/considerations.rs
+++ b/crates/utility-ai/src/considerations.rs
@@ -751,6 +751,7 @@ mod tests {
             completed_at_ms: 0,
             is_cleanup: false,
             reasoning: String::new(),
+            discovered_entities: vec![],
         }
     }
 

--- a/crates/utility-ai/src/replay.rs
+++ b/crates/utility-ai/src/replay.rs
@@ -265,6 +265,7 @@ mod tests {
             completed_at_ms: 0,
             is_cleanup: false,
             reasoning: String::new(),
+            discovered_entities: vec![],
         }
     }
 

--- a/crates/utility-ai/src/scorer.rs
+++ b/crates/utility-ai/src/scorer.rs
@@ -254,6 +254,7 @@ mod tests {
             completed_at_ms: 0,
             is_cleanup: false,
             reasoning: String::new(),
+            discovered_entities: vec![],
         }
     }
 


### PR DESCRIPTION
## Summary

Fix the Rust CI failure exposed after #40 by initializing the required `ExecutionRecord.discovered_entities` field in all remaining explicit test fixtures:

- utility AI considerations
- utility AI replay
- utility AI scorer
- planner exporter

## Validation

- `cargo fmt --all -- --check`
- `cargo test --workspace --locked`
