### PR TITLE
Model application services and discovered endpoints

### DIFF
--- a/crates/api/src/state_conversions.rs
+++ b/crates/api/src/state_conversions.rs
@@ -11,6 +11,7 @@ pub(crate) fn campaign_to_campaign_state(
     kubetier: &kubetier::Catalog,
 ) -> CampaignState {
     let mut entities = HashMap::new();
+    let hosted_services = hosted_app_services(campaign);
 
     for entity in campaign.get_entities() {
         let id = entity.entity_id().0;
@@ -41,6 +42,7 @@ pub(crate) fn campaign_to_campaign_state(
             "provenance".to_string(),
             provenance_value(campaign.entity_provenance(&entity.entity_id())),
         );
+        attach_hosted_services(&mut data, &id, &hosted_services);
 
         entities.insert(id, data);
     }
@@ -163,6 +165,12 @@ fn bootstrap_effect(entity_id: EntityId, entity_name: &str, entity_kind: &str) -
 
 pub(crate) fn campaign_to_graph(campaign: &Campaign, kubetier: &kubetier::Catalog) -> Graph {
     let entities = campaign.get_entities();
+    let hosted_services = hosted_app_services(campaign);
+    let endpoint_ids: HashSet<String> = entities
+        .iter()
+        .filter(|entity| entity.entity_kind() == "AppService")
+        .map(|entity| entity.entity_id().0)
+        .collect();
     let namespace_ids: HashSet<String> = entities
         .iter()
         .filter(|e| e.entity_kind() == "Namespace")
@@ -182,6 +190,9 @@ pub(crate) fn campaign_to_graph(campaign: &Campaign, kubetier: &kubetier::Catalo
     let mut parent_nodes: HashMap<String, String> = HashMap::new();
     let mut edges: Vec<GraphEdge> = Vec::new();
     for r in campaign.get_relations() {
+        if endpoint_ids.contains(&r.source_id) || endpoint_ids.contains(&r.target_id) {
+            continue;
+        }
         match r.name.as_str() {
             "manages-node" | "owns" => {
                 parent_nodes.insert(r.target_id.clone(), r.source_id.clone());
@@ -225,6 +236,9 @@ pub(crate) fn campaign_to_graph(campaign: &Campaign, kubetier: &kubetier::Catalo
     let mut nodes = Vec::with_capacity(campaign.entity_count());
 
     for entity in entities {
+        if entity.entity_kind() == "AppService" {
+            continue;
+        }
         let id = entity.entity_id().0;
         let kind = entity.entity_kind().to_string();
         // Determine compound-node parent. Explicit relation-based parents take
@@ -255,6 +269,7 @@ pub(crate) fn campaign_to_graph(campaign: &Campaign, kubetier: &kubetier::Catalo
         let mut entity_payload = serialize_campaign_entity_map(&entity);
         if let Some(ref mut payload) = entity_payload {
             prune_entity_payload_for_ui(entity.entity_kind(), payload, kubetier);
+            attach_hosted_services(payload, &id, &hosted_services);
         }
         nodes.push(GraphNode {
             id: id.clone(),
@@ -285,6 +300,55 @@ pub(crate) fn campaign_to_graph(campaign: &Campaign, kubetier: &kubetier::Catalo
     }
 }
 
+fn hosted_app_services(campaign: &Campaign) -> HashMap<String, Vec<Value>> {
+    let mut endpoint_payloads = HashMap::new();
+    for entity in campaign.get_entities() {
+        if !matches!(entity, CampaignEntityRef::AppService(_)) {
+            continue;
+        }
+        let id = entity.entity_id().0;
+        let mut payload = serialize_campaign_entity_map(&entity).unwrap_or_default();
+        payload.insert("id".to_string(), Value::String(id.clone()));
+        payload.insert(
+            "kind".to_string(),
+            Value::String(entity.entity_kind().to_string()),
+        );
+        endpoint_payloads.insert(id, Value::Object(payload.into_iter().collect()));
+    }
+
+    let mut hosted: HashMap<String, Vec<Value>> = HashMap::new();
+    for relation in campaign.get_relations() {
+        if relation.name != "hosts-service" {
+            continue;
+        }
+        if let Some(payload) = endpoint_payloads.get(&relation.target_id) {
+            hosted
+                .entry(relation.source_id)
+                .or_default()
+                .push(payload.clone());
+        }
+    }
+    for services in hosted.values_mut() {
+        services.sort_by(|a, b| a["id"].as_str().cmp(&b["id"].as_str()));
+    }
+    hosted
+}
+
+fn attach_hosted_services(
+    payload: &mut HashMap<String, Value>,
+    entity_id: &str,
+    hosted_services: &HashMap<String, Vec<Value>>,
+) {
+    let Some(services) = hosted_services.get(entity_id) else {
+        return;
+    };
+    payload.insert(
+        "appServiceCount".to_string(),
+        Value::from(services.len() as u64),
+    );
+    payload.insert("appServices".to_string(), Value::Array(services.clone()));
+}
+
 fn serialize_entity_map<T: serde::Serialize>(entity: &T) -> Option<HashMap<String, Value>> {
     match serde_json::to_value(entity).ok()? {
         Value::Object(map) => Some(map.into_iter().collect()),
@@ -297,6 +361,7 @@ pub(crate) fn serialize_campaign_entity_map(
 ) -> Option<HashMap<String, Value>> {
     match entity {
         CampaignEntityRef::OperatorHost(e) => serialize_entity_map(e),
+        CampaignEntityRef::AppService(e) => serialize_entity_map(e),
         CampaignEntityRef::C2Server(e) => serialize_entity_map(e),
         CampaignEntityRef::Cluster(e) => serialize_entity_map(e),
         CampaignEntityRef::Node(e) => serialize_entity_map(e),
@@ -591,6 +656,20 @@ mod tests {
 
         assert_eq!(data.get("can"), Some(&serde_json::json!([])));
         assert!(!data.contains_key("entitlements_reviewed"));
+    }
+
+    #[test]
+    fn hosted_app_services_are_attached_to_the_host_payload() {
+        let services = vec![serde_json::json!({
+            "id": "app-service/tcp/10.0.0.8/6379",
+            "port": 6379,
+            "product": "redis"
+        })];
+        let hosted = HashMap::from([("ns/default/pod/redis".to_string(), services.clone())]);
+        let mut payload = HashMap::new();
+        attach_hosted_services(&mut payload, "ns/default/pod/redis", &hosted);
+        assert_eq!(payload.get("appServiceCount"), Some(&Value::from(1)));
+        assert_eq!(payload.get("appServices"), Some(&Value::Array(services)));
     }
 
     #[test]

--- a/crates/campaign/src/campaign/entity_refs.rs
+++ b/crates/campaign/src/campaign/entity_refs.rs
@@ -1,5 +1,5 @@
 use ran_domain::{
-    C2Server, ConfigMap, CronJob, DaemonSet, Deployment, Entity, EntityId, GCPBucket,
+    AppService, C2Server, ConfigMap, CronJob, DaemonSet, Deployment, Entity, EntityId, GCPBucket,
     GCPServiceAccount, Job, K8sCluster, K8sCredential, K8sGateway, K8sHTTPRoute, K8sIngress,
     K8sNode, K8sRole, K8sRoleBinding, K8sSecret, K8sService, Namespace, OperatorHost, Pod,
     ReplicaSet, ServiceAccount, StatefulSet, SystemEntity, UnknownSystem,
@@ -7,6 +7,7 @@ use ran_domain::{
 
 pub enum CampaignEntityRef<'a> {
     OperatorHost(&'a OperatorHost),
+    AppService(&'a AppService),
     C2Server(&'a C2Server),
     Cluster(&'a K8sCluster),
     Node(&'a K8sNode),
@@ -88,6 +89,7 @@ impl<'a> CampaignEntityRef<'a> {
     delegate_entity_methods!(
         OperatorHost,
         C2Server,
+        AppService,
         Cluster,
         Node,
         Namespace,

--- a/crates/campaign/src/campaign/entity_store.rs
+++ b/crates/campaign/src/campaign/entity_store.rs
@@ -2,7 +2,7 @@ use std::any::{Any, TypeId};
 use std::collections::HashMap;
 
 use ran_domain::{
-    C2Server, ConfigMap, CronJob, DaemonSet, Deployment, Entity, EntityId, GCPBucket,
+    AppService, C2Server, ConfigMap, CronJob, DaemonSet, Deployment, Entity, EntityId, GCPBucket,
     GCPServiceAccount, Job, K8sCluster, K8sCredential, K8sGateway, K8sHTTPRoute, K8sIngress,
     K8sNode, K8sRole, K8sRoleBinding, K8sSecret, K8sService, Merge, Namespace, OperatorHost, Pod,
     ReplicaSet, ServiceAccount, StatefulSet, UnknownSystem,
@@ -274,6 +274,7 @@ impl Default for EntityStore {
     fn default() -> Self {
         let mut s = Self::new();
         s.register::<OperatorHost>("operator_hosts", |t| CampaignEntityRef::OperatorHost(t));
+        s.register::<AppService>("app_services", |t| CampaignEntityRef::AppService(t));
         s.register::<C2Server>("c2_servers", |t| CampaignEntityRef::C2Server(t));
         s.register::<K8sCluster>("clusters", |t| CampaignEntityRef::Cluster(t));
         s.register::<K8sNode>("nodes", |t| CampaignEntityRef::Node(t));
@@ -359,5 +360,25 @@ impl<'de> Deserialize<'de> for EntityStore {
         }
 
         d.deserialize_map(Visitor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ran_domain::Transport;
+
+    #[test]
+    fn app_service_slot_round_trips_and_defaults_when_absent() {
+        let mut store = EntityStore::default();
+        let service = AppService::new("10.0.0.5", 6379, Transport::Tcp).unwrap();
+        let id = service.entity_id();
+        store.insert_typed(service);
+        let json = serde_json::to_string(&store).unwrap();
+        let restored: EntityStore = serde_json::from_str(&json).unwrap();
+        assert!(restored.contains::<AppService>(&id));
+
+        let old: EntityStore = serde_json::from_str("{}").unwrap();
+        assert!(old.get::<AppService>().is_empty());
     }
 }

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -1846,6 +1846,7 @@ fn prepare_action_wraps_kubelet_sink_with_ran_ws_envelope() {
     target.containers.push(Container {
         name: "main".to_string(),
         image: "argocd/controller".to_string(),
+        ports: vec![],
         volume_mounts: vec![],
     });
     let target_id = target.entity_id().0.clone();
@@ -1917,6 +1918,7 @@ fn prepare_action_builds_kubelet_sink_command_when_outer_envelope_missing() {
     target.containers.push(Container {
         name: "main".to_string(),
         image: "argocd/controller".to_string(),
+        ports: vec![],
         volume_mounts: vec![],
     });
     let target_id = target.entity_id().0.clone();

--- a/crates/campaign/src/output_parsers/k8s.rs
+++ b/crates/campaign/src/output_parsers/k8s.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 
 use ran_domain::{
-    ConfigMap, Deployment, K8sGateway, K8sGatewayListener, K8sHTTPBackend, K8sHTTPRoute,
-    K8sIngress, K8sIngressPath, K8sIngressRule, K8sIngressTLS, K8sNode, K8sParentRef, K8sRole,
-    K8sRoleBinding, K8sSecret, K8sService, K8sServicePort, Mount, NameConfidence, Namespace,
-    OwnerRef, Pod, PodPhase, RbacPermission, RbacScopeKind, RbacScopeSource, RbacSubject,
-    ServiceAccount,
+    AppService, ConfigMap, ContainerPort, Deployment, EndpointState, Entity, HostsService,
+    K8sGateway, K8sGatewayListener, K8sHTTPBackend, K8sHTTPRoute, K8sIngress, K8sIngressPath,
+    K8sIngressRule, K8sIngressTLS, K8sNode, K8sParentRef, K8sRole, K8sRoleBinding, K8sSecret,
+    K8sService, K8sServicePort, Mount, NameConfidence, Namespace, OwnerRef, Pod, PodPhase,
+    RbacPermission, RbacScopeKind, RbacScopeSource, RbacSubject, ServiceAccount, Transport,
 };
 
 use super::ParserOutput;
@@ -105,6 +105,22 @@ mod k8s_json {
         pub security_context: Option<ContainerSecCtx>,
         #[serde(rename = "volumeMounts", default)]
         pub volume_mounts: Vec<ContainerVolumeMount>,
+        #[serde(default)]
+        pub ports: Vec<DeclaredContainerPort>,
+    }
+
+    #[derive(Deserialize, Default)]
+    pub struct DeclaredContainerPort {
+        #[serde(default)]
+        pub name: Option<String>,
+        #[serde(rename = "containerPort", default)]
+        pub container_port: u32,
+        #[serde(default = "default_port_protocol")]
+        pub protocol: String,
+    }
+
+    fn default_port_protocol() -> String {
+        "TCP".to_string()
     }
 
     #[derive(Deserialize, Default)]
@@ -238,9 +254,23 @@ mod k8s_json {
 
     // --- Deployment ---
 
+    #[derive(Deserialize, Default)]
+    pub struct DeploymentTemplate {
+        #[serde(default)]
+        pub spec: PodSpec,
+    }
+
+    #[derive(Deserialize, Default)]
+    pub struct DeploymentSpec {
+        #[serde(default)]
+        pub template: DeploymentTemplate,
+    }
+
     #[derive(Deserialize)]
     pub struct DeploymentItem {
         pub metadata: Meta,
+        #[serde(default)]
+        pub spec: DeploymentSpec,
     }
 
     #[derive(Deserialize)]
@@ -762,6 +792,7 @@ fn parse_k8s_pod_list(
             pod.containers.push(ran_domain::Container {
                 name: c.name.clone(),
                 image: c.image.clone(),
+                ports: declared_container_ports(&c.ports),
                 volume_mounts,
             });
         }
@@ -805,6 +836,44 @@ fn parse_k8s_pod_list(
             }
         }
 
+        let pod_id = pod.entity_id().0.clone();
+        if let Some(pod_ip) = pod.system.ips.first().copied() {
+            let mut emitted = std::collections::HashSet::new();
+            for port in item
+                .spec
+                .containers
+                .iter()
+                .flat_map(|container| &container.ports)
+            {
+                let Ok(port_number) = u16::try_from(port.container_port) else {
+                    continue;
+                };
+                if port_number == 0 {
+                    continue;
+                }
+                let transport = k8s_port_transport(&port.protocol);
+                if !emitted.insert((port_number, transport.as_str())) {
+                    continue;
+                }
+                let Ok(mut service) = AppService::new(pod_ip.to_string(), port_number, transport)
+                else {
+                    continue;
+                };
+                service.state = EndpointState::Unknown;
+                service.port_name = port
+                    .name
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|name| !name.is_empty())
+                    .map(str::to_string);
+                let service_id = service.entity_id().0.clone();
+                facts.new_entities.push(Box::new(service));
+                facts
+                    .new_relations
+                    .push(Box::new(HostsService::new(pod_id.clone(), service_id)));
+            }
+        }
+
         facts.new_entities.push(Box::new(pod));
 
         // Ensure the namespace exists in the graph.
@@ -815,6 +884,31 @@ fn parse_k8s_pod_list(
 
     let count = facts.new_entities.len();
     ParserOutput::SuccessWithFacts(facts, format!("parsed {} pod(s) from PodList", count))
+}
+
+fn k8s_port_transport(protocol: &str) -> Transport {
+    match protocol.to_ascii_lowercase().as_str() {
+        "tcp" => Transport::Tcp,
+        "udp" => Transport::Udp,
+        "sctp" => Transport::Sctp,
+        _ => Transport::Unknown,
+    }
+}
+
+fn declared_container_ports(ports: &[k8s_json::DeclaredContainerPort]) -> Vec<ContainerPort> {
+    ports
+        .iter()
+        .filter_map(|port| {
+            let port_number = u16::try_from(port.container_port)
+                .ok()
+                .filter(|port| *port != 0)?;
+            Some(ContainerPort {
+                name: port.name.clone().filter(|name| !name.trim().is_empty()),
+                port: port_number,
+                protocol: port.protocol.to_ascii_uppercase(),
+            })
+        })
+        .collect()
 }
 
 fn parse_k8s_node_list(
@@ -961,9 +1055,21 @@ fn parse_k8s_deployment_list(
         if name.is_empty() {
             continue;
         }
-        facts
-            .new_entities
-            .push(Box::new(Deployment::new(name.clone(), ns.clone())));
+        let mut deployment = Deployment::new(name.clone(), ns.clone());
+        deployment.containers = item
+            .spec
+            .template
+            .spec
+            .containers
+            .iter()
+            .map(|container| ran_domain::Container {
+                name: container.name.clone(),
+                image: container.image.clone(),
+                ports: declared_container_ports(&container.ports),
+                volume_mounts: Vec::new(),
+            })
+            .collect();
+        facts.new_entities.push(Box::new(deployment));
 
         if !ns.is_empty() {
             facts.new_entities.push(Box::new(Namespace::new(ns)));
@@ -1576,6 +1682,74 @@ fn parse_k8s_http_route_list(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pod_named_port_creates_unknown_endpoint_candidate() {
+        let output = r#"{
+            "items": [{
+                "metadata": {"name": "redis-0", "namespace": "default"},
+                "spec": {"containers": [{
+                    "name": "redis", "image": "redis:7",
+                    "ports": [{"name": "client", "containerPort": 6379, "protocol": "TCP"}]
+                }]},
+                "status": {"phase": "Running", "podIP": "10.0.0.8"}
+            }]
+        }"#;
+        let ParserOutput::SuccessWithFacts(facts, _) =
+            parse_k8s_pod_list(output, "", &HashMap::new())
+        else {
+            panic!("expected pod facts");
+        };
+        let service = facts
+            .new_entities
+            .iter()
+            .find_map(|entity| entity.as_any().downcast_ref::<AppService>())
+            .unwrap();
+        assert_eq!(service.port, 6379);
+        assert_eq!(service.port_name.as_deref(), Some("client"));
+        assert_eq!(service.product, None);
+        assert_eq!(service.state, EndpointState::Unknown);
+        assert!(facts
+            .new_relations
+            .iter()
+            .any(|relation| relation.relation_name() == "hosts-service"));
+        assert!(!facts
+            .new_relations
+            .iter()
+            .any(|relation| relation.relation_name() == "can-reach"));
+    }
+
+    #[test]
+    fn deployment_named_port_stays_on_template_without_endpoint() {
+        let output = r#"{
+            "items": [{
+                "metadata": {"name": "web", "namespace": "default"},
+                "spec": {"template": {"spec": {"containers": [{
+                    "name": "web", "image": "nginx",
+                    "ports": [{"name": "http", "containerPort": 8080}]
+                }]}}}
+            }]
+        }"#;
+        let ParserOutput::SuccessWithFacts(facts, _) =
+            parse_k8s_deployment_list(output, "", &HashMap::new())
+        else {
+            panic!("expected deployment facts");
+        };
+        let deployment = facts
+            .new_entities
+            .iter()
+            .find_map(|entity| entity.as_any().downcast_ref::<Deployment>())
+            .unwrap();
+        assert_eq!(
+            deployment.containers[0].ports[0].name.as_deref(),
+            Some("http")
+        );
+        assert_eq!(deployment.containers[0].ports[0].port, 8080);
+        assert!(facts
+            .new_entities
+            .iter()
+            .all(|entity| entity.as_any().downcast_ref::<AppService>().is_none()));
+    }
 
     #[test]
     fn namespace_list_emits_namespace_entities_with_labels() {

--- a/crates/campaign/src/output_parsers/mod.rs
+++ b/crates/campaign/src/output_parsers/mod.rs
@@ -613,6 +613,7 @@ fn parse_deploy_pod(cmd: &ExecTtp) -> ParserOutput {
     pod.containers.push(Container {
         name: pod_name.to_string(),
         image: image.to_string(),
+        ports: Vec::new(),
         volume_mounts: host_mount.iter().cloned().collect(),
     });
 

--- a/crates/campaign/src/output_parsers/network.rs
+++ b/crates/campaign/src/output_parsers/network.rs
@@ -1,7 +1,11 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv4Addr};
+use std::time::{SystemTime, UNIX_EPOCH};
 
-use ran_domain::{CanReach, Entity, Pod, UnknownSystem};
+use ran_domain::{
+    AppService, CanReach, Confidence, EndpointState, Entity, HostsService, Pod, Transport,
+    UnknownSystem,
+};
 
 use super::ParserOutput;
 use crate::FactsUpdate;
@@ -90,10 +94,12 @@ pub(super) fn parse_nmap(stdout: &str, source_id: &str, cidr: Option<&str>) -> P
 
     let mut facts = FactsUpdate::default();
     let source_ns = source_namespace(source_id);
-    for (ip, hostname) in &hosts {
-        let Ok(ip_addr) = ip.parse::<IpAddr>() else {
-            continue;
-        };
+    let observed_at_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| u64::try_from(duration.as_millis()).ok());
+    for host in &hosts {
+        let ip_addr = host.address;
 
         // Private discoveries should stay in the scanner's network segment when
         // a CIDR context is available.
@@ -101,14 +107,38 @@ pub(super) fn parse_nmap(stdout: &str, source_id: &str, cidr: Option<&str>) -> P
             continue;
         }
 
-        let discovered = classify_discovered_host(ip_addr, hostname.as_deref(), source_ns);
+        let discovered = classify_discovered_host(ip_addr, host.hostname.as_deref(), source_ns);
         let entity_id = discovered.entity_id().0.clone();
         facts.new_entities.push(discovered);
 
         if !source_id.is_empty() {
             facts
                 .new_relations
-                .push(Box::new(CanReach::new(source_id, entity_id)));
+                .push(Box::new(CanReach::new(source_id, entity_id.clone())));
+        }
+        for port in &host.ports {
+            let Ok(mut service) = AppService::new(ip_addr.to_string(), port.port, port.transport)
+            else {
+                continue;
+            };
+            service.state = port.state;
+            service.product = port.product.clone();
+            service.version = port.version.clone();
+            service.cpes = port.cpes.clone();
+            service.banner = port.banner.clone();
+            service.confidence = Confidence::Yes;
+            service.observed_at_ms = observed_at_ms;
+            let service_id = service.entity_id().0.clone();
+            facts.new_entities.push(Box::new(service));
+            facts.new_relations.push(Box::new(HostsService::new(
+                entity_id.clone(),
+                service_id.clone(),
+            )));
+            if !source_id.is_empty() && port.state == EndpointState::Open {
+                facts
+                    .new_relations
+                    .push(Box::new(CanReach::new(source_id, service_id)));
+            }
         }
     }
 
@@ -122,6 +152,52 @@ pub(super) fn parse_nmap(stdout: &str, source_id: &str, cidr: Option<&str>) -> P
         facts,
         format!("discovered {} live host(s) via nmap", hosts.len()),
     )
+}
+
+#[derive(Debug)]
+struct NmapHostObservation {
+    address: IpAddr,
+    hostname: Option<String>,
+    ports: Vec<NmapPortObservation>,
+}
+
+#[derive(Debug)]
+struct NmapPortObservation {
+    port: u16,
+    transport: Transport,
+    state: EndpointState,
+    product: Option<String>,
+    version: Option<String>,
+    cpes: Vec<String>,
+    banner: Option<String>,
+}
+
+fn parse_transport(value: &str) -> Transport {
+    match value.to_ascii_lowercase().as_str() {
+        "tcp" => Transport::Tcp,
+        "udp" => Transport::Udp,
+        "sctp" => Transport::Sctp,
+        _ => Transport::Unknown,
+    }
+}
+
+fn parse_endpoint_state(value: &str) -> EndpointState {
+    match value.to_ascii_lowercase().as_str() {
+        "open" => EndpointState::Open,
+        "closed" => EndpointState::Closed,
+        "filtered" | "open|filtered" | "closed|filtered" => EndpointState::Filtered,
+        _ => EndpointState::Unknown,
+    }
+}
+
+fn normalized_text(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_ascii_lowercase())
+}
+
+fn trimmed_text(value: &str) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 fn source_namespace(source_id: &str) -> Option<&str> {
@@ -236,8 +312,8 @@ fn derive_cluster_pod_identity(hostname: &str, ip_kebab: &str) -> Option<(String
 
 /// Parse nmap greppable (`-oG`) output.
 ///
-/// Returns `(ip, Option<hostname>)` for each live host.
-fn parse_nmap_grep(stdout: &str) -> Vec<(String, Option<String>)> {
+/// Returns a structured observation for each live host.
+fn parse_nmap_grep(stdout: &str) -> Vec<NmapHostObservation> {
     let mut hosts = Vec::new();
 
     for line in stdout.lines() {
@@ -269,7 +345,39 @@ fn parse_nmap_grep(stdout: &str) -> Vec<(String, Option<String>)> {
         // Host is considered live when `Status: Up` or `Ports:` is present.
         let is_up = line.contains("Status: Up") || line.contains("Ports:");
         if is_up {
-            hosts.push((ip_str.to_string(), hostname));
+            let ports = line
+                .split_once("Ports:")
+                .map(|(_, value)| value.split("Ignored State:").next().unwrap_or(value))
+                .into_iter()
+                .flat_map(|value| value.split(','))
+                .filter_map(|entry| {
+                    let cols: Vec<&str> = entry.trim().split('/').collect();
+                    let port = cols
+                        .first()?
+                        .trim()
+                        .parse::<u16>()
+                        .ok()
+                        .filter(|p| *p != 0)?;
+                    let state = parse_endpoint_state(cols.get(1).copied().unwrap_or(""));
+                    let transport = parse_transport(cols.get(2).copied().unwrap_or(""));
+                    let service = normalized_text(cols.get(4).copied().unwrap_or(""));
+                    let version = cols.get(6).and_then(|v| trimmed_text(v));
+                    Some(NmapPortObservation {
+                        port,
+                        transport,
+                        state,
+                        product: service,
+                        version,
+                        cpes: Vec::new(),
+                        banner: None,
+                    })
+                })
+                .collect();
+            hosts.push(NmapHostObservation {
+                address: ip_str.parse().unwrap(),
+                hostname,
+                ports,
+            });
         }
     }
 
@@ -282,38 +390,74 @@ fn parse_nmap_grep(stdout: &str) -> Vec<(String, Option<String>)> {
 /// - `Nmap scan report for 10.0.0.5`
 /// - `Nmap scan report for redis.default.svc.cluster.local (10.0.0.6)`
 ///
-/// Returns `(ip, Option<hostname>)`.
-fn parse_nmap_normal(stdout: &str) -> Vec<(String, Option<String>)> {
+/// Returns structured host and port observations.
+fn parse_nmap_normal(stdout: &str) -> Vec<NmapHostObservation> {
     let mut hosts = Vec::new();
-
+    let mut current: Option<NmapHostObservation> = None;
+    let mut in_ports = false;
     for line in stdout.lines() {
         let line = line.trim();
-        let Some(rest) = line.strip_prefix("Nmap scan report for ") else {
+        if let Some(rest) = line.strip_prefix("Nmap scan report for ") {
+            if let Some(host) = current.take() {
+                hosts.push(host);
+            }
+            let (address, hostname) = if let Some((host, tail)) = rest.rsplit_once(" (") {
+                (
+                    tail.strip_suffix(')').and_then(|v| v.trim().parse().ok()),
+                    Some(host.trim().to_string()),
+                )
+            } else {
+                (rest.trim().parse().ok(), None)
+            };
+            current = address.map(|address| NmapHostObservation {
+                address,
+                hostname,
+                ports: Vec::new(),
+            });
+            in_ports = false;
             continue;
-        };
-
-        // Form: "hostname (ip)"
-        if let Some((host, tail)) = rest.rsplit_once(" (") {
-            if let Some(ip) = tail.strip_suffix(')') {
-                let ip = ip.trim();
-                if ip.parse::<IpAddr>().is_ok() {
-                    let hostname = host.trim();
-                    let hostname = if hostname.is_empty() || hostname == ip {
-                        None
-                    } else {
-                        Some(hostname.to_string())
-                    };
-                    hosts.push((ip.to_string(), hostname));
-                    continue;
-                }
+        }
+        if line.starts_with("PORT") && line.contains("STATE") && line.contains("SERVICE") {
+            in_ports = true;
+            continue;
+        }
+        if in_ports
+            && (line.is_empty()
+                || line.starts_with("Service detection")
+                || line.starts_with("MAC Address")
+                || line.starts_with("Nmap done"))
+        {
+            in_ports = false;
+        }
+        if in_ports {
+            let mut cols = line.split_whitespace();
+            let Some(port_proto) = cols.next() else {
+                continue;
+            };
+            let Some((port, proto)) = port_proto.split_once('/') else {
+                continue;
+            };
+            let Some(port) = port.parse::<u16>().ok().filter(|p| *p != 0) else {
+                continue;
+            };
+            let state = parse_endpoint_state(cols.next().unwrap_or(""));
+            let product = normalized_text(cols.next().unwrap_or(""));
+            let version = trimmed_text(&cols.collect::<Vec<_>>().join(" "));
+            if let Some(host) = current.as_mut() {
+                host.ports.push(NmapPortObservation {
+                    port,
+                    transport: parse_transport(proto),
+                    state,
+                    product,
+                    version,
+                    cpes: Vec::new(),
+                    banner: None,
+                });
             }
         }
-
-        // Form: "ip"
-        let candidate = rest.trim();
-        if candidate.parse::<IpAddr>().is_ok() {
-            hosts.push((candidate.to_string(), None));
-        }
+    }
+    if let Some(host) = current {
+        hosts.push(host);
     }
 
     hosts
@@ -321,21 +465,26 @@ fn parse_nmap_normal(stdout: &str) -> Vec<(String, Option<String>)> {
 
 /// Parse nmap XML (`-oX`) output using simple line-by-line string scanning.
 ///
-/// Returns `(ip, Option<hostname>)` for each host with `state="up"`.
-fn parse_nmap_xml(stdout: &str) -> Vec<(String, Option<String>)> {
+/// Returns structured observations for each host with `state="up"`.
+fn parse_nmap_xml(stdout: &str) -> Vec<NmapHostObservation> {
     let mut hosts = Vec::new();
 
     // Split on `<host` to process one block per host.
     for block in stdout.split("<host") {
         // Check if this host is up — either `<host state="up"` or a child
         // `<status state="up"` element.
-        let host_up = block.contains("state=\"up\"");
+        let host_up = element_tags(block, "status")
+            .any(|tag| extract_attr(tag, "state").as_deref() == Some("up"));
         if !host_up {
             continue;
         }
 
-        // Extract IPv4 address.
-        let ip = extract_xml_attr(block, "address", "addr", Some("addrtype"), Some("ipv4"));
+        let ip = element_tags(block, "address").find_map(|tag| {
+            let kind = extract_attr(tag, "addrtype")?;
+            matches!(kind.as_str(), "ipv4" | "ipv6")
+                .then(|| extract_attr(tag, "addr"))
+                .flatten()
+        });
         let Some(ip) = ip else {
             continue;
         };
@@ -346,10 +495,74 @@ fn parse_nmap_xml(stdout: &str) -> Vec<(String, Option<String>)> {
         // Extract PTR hostname (first `<hostname` with `type="PTR"`).
         let hostname = extract_xml_attr(block, "hostname", "name", Some("type"), Some("PTR"));
 
-        hosts.push((ip, hostname));
+        let ports = block
+            .split("<port ")
+            .skip(1)
+            .filter_map(|port_block| {
+                let tag = port_block.split_once('>')?.0;
+                let port = extract_attr(tag, "portid")?
+                    .parse::<u16>()
+                    .ok()
+                    .filter(|p| *p != 0)?;
+                let transport = parse_transport(&extract_attr(tag, "protocol").unwrap_or_default());
+                let state = port_block
+                    .find("<state ")
+                    .and_then(|start| port_block[start..].split_once('>').map(|v| v.0))
+                    .and_then(|tag| extract_attr(tag, "state"))
+                    .map(|v| parse_endpoint_state(&v))
+                    .unwrap_or(EndpointState::Unknown);
+                let service_tag = port_block
+                    .find("<service ")
+                    .and_then(|start| port_block[start..].split_once('>').map(|v| v.0));
+                let product = service_tag
+                    .and_then(|tag| {
+                        extract_attr(tag, "product").or_else(|| extract_attr(tag, "name"))
+                    })
+                    .and_then(|v| normalized_text(&v));
+                let version = service_tag
+                    .and_then(|tag| extract_attr(tag, "version"))
+                    .and_then(|v| trimmed_text(&v));
+                let extrainfo = service_tag.and_then(|tag| extract_attr(tag, "extrainfo"));
+                let cpes = port_block
+                    .split("<cpe>")
+                    .skip(1)
+                    .filter_map(|v| v.split_once("</cpe>").map(|x| x.0.trim().to_string()))
+                    .collect();
+                Some(NmapPortObservation {
+                    port,
+                    transport,
+                    state,
+                    product,
+                    version,
+                    cpes,
+                    banner: extrainfo,
+                })
+            })
+            .collect();
+        hosts.push(NmapHostObservation {
+            address: ip.parse().unwrap(),
+            hostname,
+            ports,
+        });
     }
 
     hosts
+}
+
+fn extract_attr(tag: &str, attr: &str) -> Option<String> {
+    let needle = format!("{attr}=\"");
+    let start = tag.find(&needle)? + needle.len();
+    let end = tag[start..].find('"')?;
+    Some(tag[start..start + end].to_string())
+}
+
+fn element_tags<'a>(block: &'a str, element: &str) -> std::vec::IntoIter<&'a str> {
+    let prefix = format!("<{element}");
+    block
+        .match_indices(&prefix)
+        .filter_map(move |(start, _)| block[start..].split_once('>').map(|v| v.0))
+        .collect::<Vec<_>>()
+        .into_iter()
 }
 
 /// Extract an attribute value from a simple XML element.
@@ -485,7 +698,7 @@ fn parse_rdns_csv(stdout: &str, _stderr: &str, _args: &HashMap<String, String>) 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ran_domain::{CanReach, Entity, Pod};
+    use ran_domain::{AppService, CanReach, Entity, HostsService, Pod};
 
     // --- nmap ---
 
@@ -532,6 +745,68 @@ mod tests {
             .downcast_ref::<Pod>()
             .unwrap();
         assert_eq!(pod.entity_name(), "redis.default.svc.cluster.local");
+        let service = facts
+            .new_entities
+            .iter()
+            .find_map(|e| e.as_any().downcast_ref::<AppService>())
+            .unwrap();
+        assert_eq!(service.port, 6379);
+        assert_eq!(service.state, EndpointState::Open);
+        assert!(facts
+            .new_relations
+            .iter()
+            .any(|r| r.as_any().is::<HostsService>()));
+        assert!(facts.new_relations.iter().any(|r| {
+            r.as_any()
+                .downcast_ref::<CanReach>()
+                .is_some_and(|reach| reach.target_id == service.entity_id())
+        }));
+    }
+
+    #[test]
+    fn parse_nmap_standard_service_version() {
+        let stdout = "Nmap scan report for 10.0.0.8\nHost is up\nPORT     STATE SERVICE VERSION\n6379/tcp open  redis   Redis key-value store 7.2.4\n";
+        let ParserOutput::SuccessWithFacts(facts, _) = parse_nmap(stdout, "src", None) else {
+            panic!()
+        };
+        let service = facts
+            .new_entities
+            .iter()
+            .find_map(|e| e.as_any().downcast_ref::<AppService>())
+            .unwrap();
+        assert_eq!(service.product.as_deref(), Some("redis"));
+        assert_eq!(
+            service.version.as_deref(),
+            Some("Redis key-value store 7.2.4")
+        );
+    }
+
+    #[test]
+    fn parse_nmap_xml_service_metadata_and_closed_connectivity() {
+        let stdout = r#"<nmaprun><host><status state="up"/><address addr="10.0.0.9" addrtype="ipv4"/><ports>
+<port protocol="tcp" portid="6379"><state state="open"/><service name="redis" product="Redis" version="6.0" extrainfo="test"><cpe>cpe:/a:redis:redis:6.0</cpe></service></port>
+<port protocol="tcp" portid="6380"><state state="closed"/></port></ports></host></nmaprun>"#;
+        let ParserOutput::SuccessWithFacts(facts, _) = parse_nmap(stdout, "src", None) else {
+            panic!()
+        };
+        let services: Vec<_> = facts
+            .new_entities
+            .iter()
+            .filter_map(|e| e.as_any().downcast_ref::<AppService>())
+            .collect();
+        assert_eq!(services.len(), 2);
+        assert_eq!(services[0].product.as_deref(), Some("redis"));
+        assert_eq!(services[0].cpes, ["cpe:/a:redis:redis:6.0"]);
+        assert_eq!(
+            facts
+                .new_relations
+                .iter()
+                .filter(|r| {
+                    r.relation_name() == "can-reach" && r.target_id().0.starts_with("app-service/")
+                })
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/crates/domain/entities.rs
+++ b/crates/domain/entities.rs
@@ -210,6 +210,7 @@ impl Entity for K8sCluster {
 #[derive(Delegate, Debug, Clone, Serialize, Deserialize)]
 #[delegate(Entity)]
 pub enum GraphEntity {
+    AppService(AppService),
     C2(C2Server),
     Cluster(K8sCluster),
     Node(K8sNode),
@@ -223,6 +224,113 @@ pub enum GraphEntity {
     StatefulSet(StatefulSet),
     DaemonSet(DaemonSet),
     Job(Job),
+}
+
+// ---------------------------------------------------------------------------
+// Observed application endpoint
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Transport {
+    Tcp,
+    Udp,
+    Sctp,
+    Unknown,
+}
+
+impl Transport {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Tcp => "tcp",
+            Self::Udp => "udp",
+            Self::Sctp => "sctp",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EndpointState {
+    Open,
+    Closed,
+    Filtered,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppService {
+    pub address: String,
+    pub port: u16,
+    pub transport: Transport,
+    pub state: EndpointState,
+    #[serde(default)]
+    pub port_name: Option<String>,
+    pub product: Option<String>,
+    pub version: Option<String>,
+    #[serde(default)]
+    pub cpes: Vec<String>,
+    pub banner: Option<String>,
+    pub confidence: Confidence,
+    pub observed_at_ms: Option<u64>,
+}
+
+impl AppService {
+    pub fn new(address: impl AsRef<str>, port: u16, transport: Transport) -> Result<Self, String> {
+        if port == 0 {
+            return Err("app-service port must be non-zero".to_string());
+        }
+        let address = normalize_app_service_address(address.as_ref())?;
+        Ok(Self {
+            address,
+            port,
+            transport,
+            state: EndpointState::Unknown,
+            port_name: None,
+            product: None,
+            version: None,
+            cpes: Vec::new(),
+            banner: None,
+            confidence: Confidence::Unknown,
+            observed_at_ms: None,
+        })
+    }
+}
+
+fn normalize_app_service_address(address: &str) -> Result<String, String> {
+    let address = address.trim();
+    if address.is_empty() || address.contains('/') || address.chars().any(char::is_whitespace) {
+        return Err(format!("invalid app-service address: {address:?}"));
+    }
+    if let Ok(ip) = address.parse::<IpAddr>() {
+        return Ok(ip.to_string());
+    }
+    let dns = address.trim_end_matches('.').to_ascii_lowercase();
+    if dns.is_empty() {
+        return Err(format!("invalid app-service address: {address:?}"));
+    }
+    Ok(dns)
+}
+
+impl Entity for AppService {
+    fn entity_id(&self) -> EntityId {
+        EntityId::new(format!(
+            "app-service/{}/{}/{}",
+            self.transport.as_str(),
+            self.address,
+            self.port
+        ))
+    }
+    fn entity_name(&self) -> &str {
+        &self.address
+    }
+    fn entity_kind(&self) -> &str {
+        "AppService"
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -701,12 +809,15 @@ impl Entity for ConfigMap {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Deployment {
     pub meta: K8sMeta,
+    #[serde(default)]
+    pub containers: Vec<Container>,
 }
 
 impl Deployment {
     pub fn new(name: impl Into<String>, namespace: impl Into<String>) -> Self {
         Deployment {
             meta: K8sMeta::namespaced(name, namespace),
+            containers: Vec::new(),
         }
     }
 
@@ -1691,9 +1802,92 @@ fn merge_confidence(existing: &mut Confidence, incoming: Confidence) {
     }
 }
 
+fn merge_containers(existing: &mut Vec<Container>, incoming: &[Container]) {
+    for container in incoming {
+        let Some(current) = existing.iter_mut().find(|item| item.name == container.name) else {
+            existing.push(container.clone());
+            continue;
+        };
+
+        if current.image.is_empty() && !container.image.is_empty() {
+            current.image = container.image.clone();
+        }
+        for port in &container.ports {
+            if let Some(current_port) = current
+                .ports
+                .iter_mut()
+                .find(|item| item.port == port.port && item.protocol == port.protocol)
+            {
+                if current_port.name.is_none() {
+                    current_port.name = port.name.clone();
+                }
+            } else {
+                current.ports.push(port.clone());
+            }
+        }
+        for mount in &container.volume_mounts {
+            if !current
+                .volume_mounts
+                .iter()
+                .any(|item| item.mount_point == mount.mount_point)
+            {
+                current.volume_mounts.push(mount.clone());
+            }
+        }
+    }
+}
+
 impl Merge for UnknownSystem {
     fn merge_from(&mut self, incoming: &Self) {
         self.system.merge_from(&incoming.system);
+    }
+}
+
+impl Merge for AppService {
+    fn merge_from(&mut self, incoming: &Self) {
+        let incoming_is_newer = match (self.observed_at_ms, incoming.observed_at_ms) {
+            (Some(current), Some(new)) => new >= current,
+            (None, Some(_)) => true,
+            _ => false,
+        };
+        if incoming_is_newer {
+            self.state = incoming.state;
+            self.observed_at_ms = incoming.observed_at_ms;
+            if incoming.port_name.is_some() {
+                self.port_name = incoming.port_name.clone();
+            }
+            if incoming.product.is_some() {
+                self.product = incoming.product.clone();
+            }
+            if incoming.version.is_some() {
+                self.version = incoming.version.clone();
+            }
+            if incoming.banner.is_some() {
+                self.banner = incoming.banner.clone();
+            }
+            if incoming.confidence != Confidence::Unknown {
+                self.confidence = incoming.confidence;
+            }
+        } else {
+            if self.port_name.is_none() {
+                self.port_name = incoming.port_name.clone();
+            }
+            if self.product.is_none() {
+                self.product = incoming.product.clone();
+            }
+            if self.version.is_none() {
+                self.version = incoming.version.clone();
+            }
+            if self.banner.is_none() {
+                self.banner = incoming.banner.clone();
+            }
+            merge_confidence(&mut self.confidence, incoming.confidence);
+        }
+        for cpe in &incoming.cpes {
+            if !self.cpes.contains(cpe) {
+                self.cpes.push(cpe.clone());
+            }
+        }
     }
 }
 
@@ -1792,11 +1986,7 @@ impl Merge for Pod {
             incoming.automount_service_account_token,
         );
 
-        for c in &incoming.containers {
-            if !self.containers.iter().any(|ec| ec.name == c.name) {
-                self.containers.push(c.clone());
-            }
-        }
+        merge_containers(&mut self.containers, &incoming.containers);
         for m in &incoming.volume_mounts {
             if !self
                 .volume_mounts
@@ -1862,6 +2052,7 @@ impl Merge for ConfigMap {
 impl Merge for Deployment {
     fn merge_from(&mut self, incoming: &Self) {
         merge_k8s_meta(&mut self.meta, &incoming.meta);
+        merge_containers(&mut self.containers, &incoming.containers);
     }
 }
 
@@ -2001,6 +2192,35 @@ mod tests {
     use super::*;
     use crate::identity::{JwToken, ServiceAccountToken};
     use crate::rbac::RbacPermission;
+
+    #[test]
+    fn app_service_normalizes_endpoint_identity() {
+        let ipv6 = AppService::new("2001:0DB8:0:0::1", 443, Transport::Tcp).unwrap();
+        assert_eq!(ipv6.entity_id().0, "app-service/tcp/2001:db8::1/443");
+        let dns = AppService::new("Redis.DEFAULT.SVC.", 6379, Transport::Tcp).unwrap();
+        assert_eq!(dns.entity_id().0, "app-service/tcp/redis.default.svc/6379");
+        assert!(AppService::new("bad/address", 80, Transport::Tcp).is_err());
+        assert!(AppService::new("host", 0, Transport::Tcp).is_err());
+    }
+
+    #[test]
+    fn app_service_merge_respects_observation_time_and_enriches() {
+        let mut current = AppService::new("10.0.0.1", 6379, Transport::Tcp).unwrap();
+        current.state = EndpointState::Open;
+        current.product = Some("redis".into());
+        current.observed_at_ms = Some(20);
+        let mut older = AppService::new("10.0.0.1", 6379, Transport::Tcp).unwrap();
+        older.state = EndpointState::Closed;
+        older.port_name = Some("client".into());
+        older.version = Some("7.2".into());
+        older.cpes.push("cpe:/a:redis:redis:7.2".into());
+        older.observed_at_ms = Some(10);
+        current.merge_from(&older);
+        assert_eq!(current.state, EndpointState::Open);
+        assert_eq!(current.port_name.as_deref(), Some("client"));
+        assert_eq!(current.version.as_deref(), Some("7.2"));
+        assert_eq!(current.cpes.len(), 1);
+    }
 
     #[test]
     fn service_account_token_preserved_after_entitlements_merge() {

--- a/crates/domain/mod.rs
+++ b/crates/domain/mod.rs
@@ -8,22 +8,23 @@ pub mod types;
 // Re-export the most commonly used types so callers can do
 // `use ran_domain::{Pod, Namespace, ServiceAccount}` without long paths.
 pub use entities::{
-    C2Server, ConfigMap, CronJob, DaemonSet, Deployment, Entity, GCPBucket, GCPServiceAccount,
-    GcpAccessToken, GraphEntity, Job, K8sCluster, K8sCredential, K8sGateway, K8sGatewayListener,
-    K8sHTTPBackend, K8sHTTPRoute, K8sIngress, K8sIngressPath, K8sIngressRule, K8sIngressTLS,
-    K8sNode, K8sParentRef, K8sRole, K8sRoleBinding, K8sSecret, K8sService, K8sServicePort, Merge,
-    Namespace, OperatorHost, Pod, PodPhase, PodSecurityAdmission, PssLevel, RbacSubject,
-    ReplicaSet, ServiceAccount, StatefulSet, SystemEntity, UnknownSystem,
+    AppService, C2Server, ConfigMap, CronJob, DaemonSet, Deployment, EndpointState, Entity,
+    GCPBucket, GCPServiceAccount, GcpAccessToken, GraphEntity, Job, K8sCluster, K8sCredential,
+    K8sGateway, K8sGatewayListener, K8sHTTPBackend, K8sHTTPRoute, K8sIngress, K8sIngressPath,
+    K8sIngressRule, K8sIngressTLS, K8sNode, K8sParentRef, K8sRole, K8sRoleBinding, K8sSecret,
+    K8sService, K8sServicePort, Merge, Namespace, OperatorHost, Pod, PodPhase,
+    PodSecurityAdmission, PssLevel, RbacSubject, ReplicaSet, ServiceAccount, StatefulSet,
+    SystemEntity, Transport, UnknownSystem,
 };
 pub use identity::{JwToken, ServiceAccountToken};
 pub use rbac::{RbacPermission, RbacScopeKind, RbacScopeSource};
 pub use relation::{C2Channel, Relation};
 pub use relations::{
-    AuthenticatesTo, BindsTo, CanReach, ContainerEscape, Contains, Grants, KubeletExecSink,
-    KubeletExecSource, ManagesNode, Owns, PodExec, RceCanExec, RelationSummary, RunsOn,
-    SessionChannel, Uses,
+    AuthenticatesTo, BindsTo, CanReach, ContainerEscape, Contains, Grants, HostsService,
+    KubeletExecSink, KubeletExecSource, ManagesNode, Owns, PodExec, RceCanExec, RelationSummary,
+    RunsOn, SessionChannel, Uses,
 };
 pub use types::{
-    AccessLevel, BinaryPresence, Confidence, Container, EntityId, K8sMeta, Mount, NameConfidence,
-    OutputTransformKind, OwnerRef, Process, SessionInfo, SessionStatus, SystemInfo,
+    AccessLevel, BinaryPresence, Confidence, Container, ContainerPort, EntityId, K8sMeta, Mount,
+    NameConfidence, OutputTransformKind, OwnerRef, Process, SessionInfo, SessionStatus, SystemInfo,
 };

--- a/crates/domain/relations.rs
+++ b/crates/domain/relations.rs
@@ -2,6 +2,40 @@ use serde::{Deserialize, Serialize};
 
 use crate::{relation::C2Channel, EntityId, OutputTransformKind, Relation};
 
+macro_rules! structural_relation {
+    ($name:ident, $relation_name:literal) => {
+        #[derive(Debug, Clone, Serialize, Deserialize)]
+        pub struct $name {
+            pub source_id: EntityId,
+            pub target_id: EntityId,
+        }
+        impl $name {
+            pub fn new(source_id: impl Into<String>, target_id: impl Into<String>) -> Self {
+                Self {
+                    source_id: EntityId::new(source_id),
+                    target_id: EntityId::new(target_id),
+                }
+            }
+        }
+        impl Relation for $name {
+            fn relation_name(&self) -> &str {
+                $relation_name
+            }
+            fn source_id(&self) -> &EntityId {
+                &self.source_id
+            }
+            fn target_id(&self) -> &EntityId {
+                &self.target_id
+            }
+            fn as_any(&self) -> &dyn std::any::Any {
+                self
+            }
+        }
+    };
+}
+
+structural_relation!(HostsService, "hosts-service");
+
 // ---------------------------------------------------------------------------
 // Contains
 // ---------------------------------------------------------------------------
@@ -803,5 +837,27 @@ impl RelationSummary {
             return None;
         }
         Some((namespace, pod_name))
+    }
+}
+
+#[cfg(test)]
+mod app_service_relation_tests {
+    use super::*;
+
+    #[test]
+    fn endpoint_relations_are_structural_summaries() {
+        for relation in [
+            RelationSummary::from_relation(&HostsService::new(
+                "system/a",
+                "app-service/tcp/host/80",
+            )),
+            RelationSummary::from_relation(&CanReach::new("system/b", "app-service/tcp/host/80")),
+        ] {
+            assert!(!relation.is_exec_channel);
+            assert!(matches!(
+                relation.name.as_str(),
+                "hosts-service" | "can-reach"
+            ));
+        }
     }
 }

--- a/crates/domain/types.rs
+++ b/crates/domain/types.rs
@@ -405,7 +405,20 @@ pub struct Container {
     pub name: String,
     pub image: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ports: Vec<ContainerPort>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub volume_mounts: Vec<Mount>,
+}
+
+/// A port declared on a Kubernetes container. This is configuration, not
+/// evidence that the endpoint is listening.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ContainerPort {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(rename = "containerPort")]
+    pub port: u16,
+    pub protocol: String,
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/app_services_and_service_packs.md
+++ b/docs/app_services_and_service_packs.md
@@ -58,6 +58,7 @@ pub struct AppService {
     pub port: u16,
     pub transport: Transport,       // Tcp | Udp | Sctp | Unknown
     pub state: EndpointState,       // Open | Closed | Filtered | Unknown
+    pub port_name: Option<String>,  // observed configuration name, e.g. "http"
     pub product: Option<String>,    // canonical name, e.g. "redis"
     pub version: Option<String>,
     pub cpes: Vec<String>,
@@ -88,12 +89,12 @@ strings.
 
 ```text
 System        --hosts-service--> AppService
-System        --can-connect----> AppService
+System        --can-reach------> AppService
 K8sService    --routes-to-------> AppService
 ```
 
 - `hosts-service` identifies the system believed to run the endpoint.
-- `can-connect` is source- and endpoint-specific network reachability. It does
+- `can-reach` targeting an `AppService` is source- and endpoint-specific network reachability. It does
   not confer execution and must not implement `C2Channel`.
 - `routes-to` associates configured Kubernetes service ports with observed
   backend endpoints when selectors, EndpointSlices, or probes provide enough
@@ -120,6 +121,12 @@ types, but the model should preserve the source of each material observation.
 Port numbers and names may produce candidates, but should not independently
 satisfy a strict product prerequisite unless the TTP explicitly accepts low
 confidence.
+
+A Kubernetes container port name is preserved as `port_name`; it is not copied
+into `product`. For a Pod with a concrete IP, a declared container port creates
+an `AppService` candidate with `state: Unknown` and no endpoint `can-reach`
+relation. A Deployment template retains its declared ports on its containers
+but does not create an addressable `AppService` until correlated with a Pod.
 
 Capabilities and vulnerabilities must be namespaced and independently
 evidenced:
@@ -152,7 +159,7 @@ preconditions:
 
 All declared fields are conjunctive. Missing observed fields do not match.
 `reachableFrom: execution-source` means that at least one viable execution
-source has a `can-connect` relation to the matching endpoint.
+source has a `can-reach` relation to the matching endpoint.
 
 Applicability evaluation should return the matching endpoint as a **witness**,
 not just a boolean. Grounding then obtains `TARGET`, `PORT`, transport, and any
@@ -322,7 +329,7 @@ execution creates the existing `rce.can-exec(source, target)` relation.
 
 - Add `AppService`, merge semantics, serialization, API conversion, and
   graph styling.
-- Add `hosts-service` and `can-connect` relations.
+- Add `hosts-service` and endpoint-targeted `can-reach` relations.
 - Extend nmap parsing to retain open ports without yet requiring product data.
 - Keep existing `can-reach` output for compatibility.
 
@@ -410,12 +417,13 @@ later phase will consume.
    cannot contain `/`; reject rather than silently rewriting an invalid value.
 6. An `AppService` is a graph entity, not a `SystemEntity`, and never carries an
    access level or execution session.
-7. `hosts-service` and `can-connect` are non-execution relations. Neither may
+7. `hosts-service` and `can-reach` are non-execution relations. Neither may
    implement `C2Channel` or create an executable graph path.
 8. Retain existing host-level `can-reach` facts for backward compatibility.
-9. App-service nodes are serialized through the existing graph API. The UI may
-   initially render them as ordinary nodes; automatic collapsing is desirable
-   but is not an acceptance criterion for Phase 1.
+9. App-service facts remain first-class campaign entities, but the default
+   human graph projection collapses them into a service summary on the hosting
+   system. Endpoint nodes and their incident edges are omitted from that
+   projection to avoid duplicating host reachability visually.
 10. Entity merge behavior is monotonic for identity and descriptive fields:
     newer non-empty product/version/banner/CPE observations enrich or replace
     weaker values. `observed_at_ms` takes the newest timestamp. Endpoint state
@@ -430,6 +438,7 @@ pub struct AppService {
     pub port: u16,
     pub transport: Transport,
     pub state: EndpointState,
+    pub port_name: Option<String>,
     pub product: Option<String>,
     pub version: Option<String>,
     pub cpes: Vec<String>,
@@ -468,7 +477,7 @@ Add typed relations in `crates/domain/relations.rs`:
 
 ```rust
 HostsService::new(system_id, app_service_id) // "hosts-service"
-CanConnect::new(source_id, app_service_id)   // "can-connect"
+CanReach::new(source_id, app_service_id)     // "can-reach"
 ```
 
 Both relations use ordinary zero-cost structural graph edges and are exported
@@ -505,8 +514,8 @@ For each accepted host:
 3. For each parsed port, emit an `AppService`.
 4. Emit system-to-service `hosts-service`.
 5. If `source_id` is present and the endpoint state is `Open`, emit
-   source-to-service `can-connect`.
-6. Do not emit `can-connect` for closed, filtered, or unknown ports.
+   source-to-service `can-reach`.
+6. Do not emit endpoint-targeted `can-reach` for closed, filtered, or unknown ports.
 
 Support all three currently accepted nmap families:
 
@@ -562,17 +571,19 @@ The implementation is complete only when all of the following are covered:
 3. Entity merge keeps one endpoint identity and enriches product/version/CPE.
 4. Newer endpoint state wins; an older observation cannot overwrite it.
 5. Campaign state serializes and deserializes the new entity-store slot.
-6. `hosts-service` and `can-connect` round-trip as relation summaries and are
+6. `hosts-service` and endpoint-targeted `can-reach` round-trip as relation summaries and are
    never execution channels.
 7. Nmap greppable input `6379/open/tcp` produces an open TCP app service.
 8. Standard `-sV` output produces product and version when present.
 9. Nmap XML produces product, version, CPE, and endpoint relations.
 10. A host with two open ports produces two distinct app services.
 11. Closed or filtered ports are retained as observations but do not create
-    `can-connect`.
+    endpoint-targeted `can-reach`.
 12. Host-only scans preserve current discovery and reachability behavior.
 13. CIDR filtering excludes both the out-of-scope host and its app services.
-14. The campaign graph/API includes an `AppService` node with its entity data.
+14. Campaign state includes `AppService` entity data, while the default graph
+    projection exposes hosted services on the system payload without separate
+    endpoint nodes.
 15. Existing domain, campaign, API, and frontend tests still pass.
 
 ### Explicit non-goals

--- a/frontend/src/routes/components/edge_categories.test.ts
+++ b/frontend/src/routes/components/edge_categories.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { isInformational } from './edge_categories';
 
 describe('isInformational', () => {
-	it('classifies authentication context without treating execution edges as informational', () => {
+	it('classifies contextual and reachability facts without treating execution edges as informational', () => {
 		expect(isInformational('authenticates-to')).toBe(true);
+		expect(isInformational('can-reach')).toBe(true);
+		expect(isInformational('k8s.can-exec')).toBe(false);
 		expect(isInformational('controls')).toBe(false);
 	});
 });

--- a/frontend/src/routes/components/edge_categories.ts
+++ b/frontend/src/routes/components/edge_categories.ts
@@ -18,7 +18,8 @@ export const INFORMATIONAL_EDGES: ReadonlySet<string> = new Set([
 	'has-session',
 	'operates',
 	'references',
-	'authenticates-to'
+	'authenticates-to',
+	'can-reach'
 ]);
 
 /** Check whether a relation name is informational. */

--- a/frontend/src/routes/components/elk_layout.ts
+++ b/frontend/src/routes/components/elk_layout.ts
@@ -37,6 +37,7 @@ export const NODE_LAYER: Record<string, number> = {
   // Cluster entry points
   Ingress: 3,
   Service: 3,
+  AppService: 4,
   // Workloads
   Pod: 4,
   Container: 4,

--- a/frontend/src/routes/components/entityInfo.svelte
+++ b/frontend/src/routes/components/entityInfo.svelte
@@ -173,7 +173,7 @@
 	}
 
 	// Fields handled explicitly in the header — skip from the generic loop
-	const HEADER_FIELDS = new Set(['id', 'name', 'namespace', 'kind', 'entityId', 'parent', 'entity', 'compromised', 'provenance']);
+	const HEADER_FIELDS = new Set(['id', 'name', 'namespace', 'kind', 'entityId', 'parent', 'entity', 'compromised', 'provenance', 'appServiceCount']);
 
 	function shouldShowField(label: string, data: any): boolean {
 		if (HEADER_FIELDS.has(label)) return false;
@@ -528,6 +528,37 @@
 							</li>
 						{/each}
 					</ul>
+				</details>
+			{:else if label === 'appServices' && Array.isArray(data)}
+				<details class="mb-1" class:field-changed={highlightedFields[label]}>
+					<summary class="cursor-pointer">
+						<span class="font-bold">Services</span>
+						<span class="text-xs text-surface-500">({data.length})</span>
+					</summary>
+					<div class="mt-1 space-y-1 pl-4">
+						{#each data as service}
+							<details>
+								<summary class="cursor-pointer">
+									<span class="font-mono font-semibold">{service.port}/{service.transport}</span>
+									{#if service.port_name}
+										<span class="ml-1 text-surface-500">· {service.port_name}</span>
+									{/if}
+									{#if service.product && service.product !== service.port_name}
+										<span class="ml-1 text-surface-500">· {service.product}?</span>
+									{/if}
+								</summary>
+								<dl class="grid grid-cols-[auto_1fr] gap-x-2 pl-4 text-xs">
+									<dt class="font-semibold">Address</dt><dd class="font-mono">{service.address}</dd>
+									<dt class="font-semibold">Endpoint</dt><dd class="font-mono">{service.port}/{service.transport}</dd>
+									<dt class="font-semibold">State</dt><dd class="capitalize">{service.state}</dd>
+									{#if service.port_name}<dt class="font-semibold">Name</dt><dd>{service.port_name}</dd>{/if}
+									{#if service.product}<dt class="font-semibold">Assume</dt><dd>{service.product}{#if service.version} {service.version}{/if}</dd>{/if}
+									{#if service.banner}<dt class="font-semibold">Banner</dt><dd>{service.banner}</dd>{/if}
+									{#if service.cpes?.length}<dt class="font-semibold">CPE</dt><dd>{service.cpes.join(', ')}</dd>{/if}
+								</dl>
+							</details>
+						{/each}
+					</div>
 				</details>
 			{:else if Array.isArray(data) && data.length > 0}
 				{#if data.length === 1}

--- a/frontend/src/routes/components/graph_style.ts
+++ b/frontend/src/routes/components/graph_style.ts
@@ -2,6 +2,7 @@ import type cytoscape from "cytoscape";
 
 // the '{' prefix indicates a compound node that should not have an icon, if it's expanded
 const kind_svg_map = {
+	AppService: 'k8s/ep.svg',
 	Ingress: 'k8s/ing.svg',
 	Pod: 'k8s/pod.svg',
 	Container: 'k8s/crio.svg',


### PR DESCRIPTION
## Summary

- add first-class application-service entities keyed by address, transport, and port
- parse Nmap endpoint observations and associate private-subnet results with their hosting systems
- reuse informational `can-reach` relations for confirmed open endpoints and keep those edges dotted/gray
- collapse endpoint nodes from the default human graph while exposing services as structured entity details
- preserve Kubernetes named container ports as configuration facts; concrete pod IPs create unknown endpoint candidates without implying reachability

## UI behavior

- use `port/transport` as the primary service identity
- show configured port names as facts
- show inferred products separately with `?` and an expanded `Assume` field

## Verification

- `cargo test -p ran-domain -p campaign -p api --no-fail-fast`
- `pnpm exec vitest run src/routes/components/edge_categories.test.ts`
- `git diff --check`