### PR TITLE
Keep IP-only Nmap discoveries outside scanner namespaces

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1027,6 +1027,13 @@ components:
           type: object
           additionalProperties:
             type: string
+        executionTimeoutSeconds:
+          type: integer
+          format: int64
+          minimum: 1
+          maximum: 3600
+          default: 60
+          description: Maximum wall-clock time allowed for the complete command.
         reasoning:
           type: string
           description: >

--- a/armory/TTPs/Discovery/nmap_host_scan.yaml
+++ b/armory/TTPs/Discovery/nmap_host_scan.yaml
@@ -19,10 +19,6 @@ parameters:
     type: int
     description: the number of concurrent threads to use
     default: 10
-  TIMEOUT:
-    type: int
-    description: the timeout duration for each request
-    default: 3
 procedures:
   - key: nmap
     tool: nmap

--- a/crates/api/src/api_handlers.rs
+++ b/crates/api/src/api_handlers.rs
@@ -125,6 +125,8 @@ pub(crate) struct ExecuteActionCmdPayload {
     #[serde(rename = "procedureId")]
     pub(crate) procedure_id: Option<String>,
     pub(crate) args: Option<HashMap<String, String>>,
+    #[serde(rename = "executionTimeoutSeconds")]
+    pub(crate) execution_timeout_seconds: Option<u64>,
     /// Optional free-text rationale for this step, recorded on the resulting
     /// execution record. Strongly encouraged when driving the campaign
     /// programmatically so the timeline explains itself.
@@ -451,6 +453,13 @@ pub(crate) async fn execute_action_handler<S: ApiService>(
     State(service): State<S>,
     axum::Json(cmd): axum::Json<ExecuteActionCmdPayload>,
 ) -> Result<axum::Json<ExecuteActionAck>, ApiError> {
+    let mut args = cmd.args.unwrap_or_default();
+    if let Some(seconds) = cmd.execution_timeout_seconds {
+        args.insert(
+            "__EXECUTION_TIMEOUT_SECONDS".to_string(),
+            seconds.to_string(),
+        );
+    }
     let execution = service
         .execute_action(campaign::ExecuteActionRequest {
             action_id: cmd.action_id,
@@ -458,7 +467,7 @@ pub(crate) async fn execute_action_handler<S: ApiService>(
             auth_identity_id: cmd.auth_identity_id,
             target_id: cmd.target_id,
             procedure_id: cmd.procedure_id,
-            args: cmd.args.unwrap_or_default(),
+            args,
             reasoning: cmd.reasoning,
         })
         .await?;

--- a/crates/api/src/mcp.rs
+++ b/crates/api/src/mcp.rs
@@ -274,6 +274,9 @@ impl<S: ApiService> RanMcpHandler<S> {
         let target_id = req_str(args, "target_id")?.to_owned();
         let exec_system_id = opt_str(args, "exec_system_id").map(str::to_owned);
         let procedure_id = opt_str(args, "procedure_id").map(str::to_owned);
+        let execution_timeout_seconds = args
+            .get("execution_timeout_seconds")
+            .and_then(Value::as_u64);
 
         // Validate that target_id is a known entity in the campaign graph.
         // This prevents silent failures when the agent passes a workload/deployment
@@ -294,7 +297,7 @@ impl<S: ApiService> RanMcpHandler<S> {
             )));
         }
 
-        let extra_args: std::collections::HashMap<String, String> = args
+        let mut extra_args: std::collections::HashMap<String, String> = args
             .get("args")
             .and_then(Value::as_object)
             .map(|m| {
@@ -303,6 +306,12 @@ impl<S: ApiService> RanMcpHandler<S> {
                     .collect()
             })
             .unwrap_or_default();
+        if let Some(seconds) = execution_timeout_seconds {
+            extra_args.insert(
+                "__EXECUTION_TIMEOUT_SECONDS".to_string(),
+                seconds.to_string(),
+            );
+        }
 
         let reasoning = opt_str(args, "reasoning")
             .map(str::to_owned)
@@ -332,10 +341,15 @@ impl<S: ApiService> RanMcpHandler<S> {
         }))
     }
 
-    /// Poll execution records until the given cmd_id appears or timeout (60s).
+    /// Poll execution records until the given cmd_id appears or the requested timeout.
     async fn tool_wait_for_result(&self, args: &Value) -> Result<CallToolResult, McpError> {
         let cmd_id = req_str(args, "cmd_id")?.to_owned();
-        let deadline = Instant::now() + Duration::from_secs(60);
+        let timeout_seconds = args
+            .get("timeout_seconds")
+            .and_then(Value::as_u64)
+            .unwrap_or(60)
+            .clamp(1, 3600);
+        let deadline = Instant::now() + Duration::from_secs(timeout_seconds + 5);
 
         loop {
             let campaign = self.api.get_campaign().await.map_err(api_err)?;
@@ -372,7 +386,7 @@ impl<S: ApiService> RanMcpHandler<S> {
 
             if Instant::now() >= deadline {
                 return Err(internal(format!(
-                    "timeout: cmd `{cmd_id}` not completed within 60s"
+                    "timeout: cmd `{cmd_id}` not completed within {timeout_seconds}s"
                 )));
             }
 
@@ -648,6 +662,7 @@ fn tool_defs() -> Vec<Tool> {
                     "exec_system_id": { "type": "string", "description": "ID of the system to run the command from (optional)" },
                     "auth_identity_id": { "type": "string", "description": "Value of the TTP's K8S_AUTH parameter. Required for Kubernetes procedures; select an eligible captured ServiceAccount or active K8sCredential." },
                     "procedure_id": { "type": "string", "description": "Specific procedure variant to use (optional)" },
+                    "execution_timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 3600, "default": 60, "description": "Maximum wall-clock time for the command" },
                     "args": { "type": "object", "description": "TTP parameter overrides (key-value string pairs)", "additionalProperties": { "type": "string" } },
                     "reasoning": { "type": "string", "description": "STRONGLY ENCOURAGED. Your rationale for running this action at this point in the assessment: what you expect it to reveal or achieve, why this target, and how it follows from prior findings. Recorded on the execution record for audit and replay. Provide it on every call unless truly trivial." }
                 }
@@ -655,12 +670,13 @@ fn tool_defs() -> Vec<Tool> {
         ),
         Tool::new(
             "wait_for_result",
-            "Block until a previously enqueued action completes (up to 60s). Returns stdout, stderr, and success status.",
+            "Block until a previously enqueued action completes. Returns stdout, stderr, and success status.",
             schema(json!({
                 "type": "object",
                 "required": ["cmd_id"],
                 "properties": {
-                    "cmd_id": { "type": "string", "description": "Command ID returned by execute_action" }
+                    "cmd_id": { "type": "string", "description": "Command ID returned by execute_action" },
+                    "timeout_seconds": { "type": "integer", "minimum": 1, "maximum": 3600, "default": 60, "description": "How long to wait for the result" }
                 }
             })),
         ),

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -2161,6 +2161,7 @@ pub async fn trigger(cfg: TriggerConfig) -> Result<()> {
 
     let cmd_id = exec.id.clone();
     let grounded_command = exec.procedure.command.clone();
+    let timeout_seconds = exec.execution_timeout_seconds.max(1);
 
     println!("Triggering {} on {}", cfg.action_id, pod_id);
     println!("Command: {}", grounded_command);
@@ -2170,12 +2171,14 @@ pub async fn trigger(cfg: TriggerConfig) -> Result<()> {
         .await
         .map_err(|e| anyhow::anyhow!("failed to dispatch action: {}", e))?;
 
-    // Phase 1: wait up to 60s for TtpExecuted with our cmd_id.
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(60);
+    // Phase 1: wait for the command's configured execution deadline.
+    // Leave a small delivery grace after the backend deadline so its timeout
+    // result can reach the event bus instead of racing this outer waiter.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(timeout_seconds + 5);
     let result = loop {
         let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
         if remaining.is_zero() {
-            anyhow::bail!("timed out waiting for action result after 60s");
+            anyhow::bail!("timed out waiting for action result after {timeout_seconds}s");
         }
         match tokio::time::timeout(remaining, event_rx.recv()).await {
             Ok(Ok(CampaignEvent::TtpExecuted {
@@ -2193,7 +2196,7 @@ pub async fn trigger(cfg: TriggerConfig) -> Result<()> {
             }
             Ok(Ok(_)) => continue,
             Ok(Err(_)) | Err(_) => {
-                anyhow::bail!("timed out waiting for action result after 60s");
+                anyhow::bail!("timed out waiting for action result after {timeout_seconds}s");
             }
         }
     };

--- a/crates/c2/src/builtin.rs
+++ b/crates/c2/src/builtin.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use k8s::{Client, PodExecOutput};
@@ -59,72 +60,14 @@ impl BuiltinC2 {
                 "builtin c2 executing command through pod exec"
             );
 
-            match self
-                .pod_exec_client
-                .exec_pod_command(namespace, pod_name, &cmd.procedure.command)
-                .await
-            {
-                Ok(output) if output.exit_code == 0 => {
-                    let stdout = output.stdout.trim().to_string();
-                    let stderr = output.stderr.trim().to_string();
-
-                    // Keep stdout and stderr as separate entries so downstream
-                    // output parsers can consume clean stdout JSON/table data.
-                    // Preserve stdout at index 0 when stderr is present.
-                    let mut results = Vec::new();
-                    if !stdout.is_empty() {
-                        results.push(stdout);
-                    }
-                    if !stderr.is_empty() {
-                        if results.is_empty() {
-                            results.push(String::new());
-                        }
-                        results.push(stderr);
-                    }
-
-                    return TtpExecuted {
-                        id: cmd.id.clone(),
-                        success: true,
-                        results,
-                        exit_code: 0,
-                        fail_reason: String::new(),
-                        session_connected: None,
-                    };
-                }
-                Ok(output) => {
-                    let mut results = Vec::new();
-                    if !output.stdout.trim().is_empty() {
-                        results.push(output.stdout.trim().to_string());
-                    }
-                    if !output.stderr.trim().is_empty() {
-                        results.push(output.stderr.trim().to_string());
-                    }
-                    let fail_reason =
-                        derive_fail_reason(&output.stderr, &output.stdout, output.exit_code);
-                    warn!(
-                        cmd_id = %cmd.id,
-                        target_id = %cmd.target_id,
-                        exit_code = output.exit_code,
-                        stderr = %output.stderr.trim(),
-                        "builtin c2 pod exec command failed"
-                    );
-                    return TtpExecuted {
-                        id: cmd.id.clone(),
-                        success: false,
-                        results,
-                        exit_code: output.exit_code,
-                        fail_reason,
-                        session_connected: None,
-                    };
-                }
-                Err(err) => {
-                    let reason = err.to_string();
-                    warn!(
-                        cmd_id = %cmd.id,
-                        target_id = %cmd.target_id,
-                        error = %reason,
-                        "builtin c2 pod exec infrastructure failure"
-                    );
+            let timeout_seconds = cmd.execution_timeout_seconds.max(1);
+            let execution =
+                self.pod_exec_client
+                    .exec_pod_command(namespace, pod_name, &cmd.procedure.command);
+            match tokio::time::timeout(Duration::from_secs(timeout_seconds), execution).await {
+                Err(_) => {
+                    let reason = format!("pod exec command timed out after {timeout_seconds}s");
+                    warn!(cmd_id = %cmd.id, target_id = %cmd.target_id, %timeout_seconds, "{}", reason);
                     return TtpExecuted {
                         id: cmd.id.clone(),
                         success: false,
@@ -134,6 +77,78 @@ impl BuiltinC2 {
                         session_connected: None,
                     };
                 }
+                Ok(result) => match result {
+                    Ok(output) if output.exit_code == 0 => {
+                        let stdout = output.stdout.trim().to_string();
+                        let stderr = output.stderr.trim().to_string();
+
+                        // Keep stdout and stderr as separate entries so downstream
+                        // output parsers can consume clean stdout JSON/table data.
+                        // Preserve stdout at index 0 when stderr is present.
+                        let mut results = Vec::new();
+                        if !stdout.is_empty() {
+                            results.push(stdout);
+                        }
+                        if !stderr.is_empty() {
+                            if results.is_empty() {
+                                results.push(String::new());
+                            }
+                            results.push(stderr);
+                        }
+
+                        return TtpExecuted {
+                            id: cmd.id.clone(),
+                            success: true,
+                            results,
+                            exit_code: 0,
+                            fail_reason: String::new(),
+                            session_connected: None,
+                        };
+                    }
+                    Ok(output) => {
+                        let mut results = Vec::new();
+                        if !output.stdout.trim().is_empty() {
+                            results.push(output.stdout.trim().to_string());
+                        }
+                        if !output.stderr.trim().is_empty() {
+                            results.push(output.stderr.trim().to_string());
+                        }
+                        let fail_reason =
+                            derive_fail_reason(&output.stderr, &output.stdout, output.exit_code);
+                        warn!(
+                            cmd_id = %cmd.id,
+                            target_id = %cmd.target_id,
+                            exit_code = output.exit_code,
+                            stderr = %output.stderr.trim(),
+                            "builtin c2 pod exec command failed"
+                        );
+                        return TtpExecuted {
+                            id: cmd.id.clone(),
+                            success: false,
+                            results,
+                            exit_code: output.exit_code,
+                            fail_reason,
+                            session_connected: None,
+                        };
+                    }
+                    Err(err) => {
+                        let reason = err.to_string();
+                        warn!(
+                            cmd_id = %cmd.id,
+                            target_id = %cmd.target_id,
+                            error = %reason,
+                            "builtin c2 pod exec infrastructure failure"
+                        );
+                        return TtpExecuted {
+                            id: cmd.id.clone(),
+                            success: false,
+                            results: vec![reason.clone()],
+                            exit_code: 1,
+                            fail_reason: reason,
+                            session_connected: None,
+                        };
+                    }
+                },
             }
         }
 
@@ -390,6 +405,7 @@ mod tests {
         ExecTtp {
             id: "cmd-1".to_string(),
             started_at_ms: 0,
+            execution_timeout_seconds: crate::DEFAULT_EXECUTION_TIMEOUT_SECONDS,
             ttp: Ttp {
                 description: "test".to_string(),
                 ..Ttp::new("T0001", "Test TTP", "Execution")

--- a/crates/c2/src/executor.rs
+++ b/crates/c2/src/executor.rs
@@ -813,6 +813,7 @@ mod tests {
         ExecTtp {
             id: "cmd-fallback".to_string(),
             started_at_ms: 0,
+            execution_timeout_seconds: crate::DEFAULT_EXECUTION_TIMEOUT_SECONDS,
             ttp: Ttp {
                 description: "test".to_string(),
                 ..Ttp::new("T0001", "Test TTP", "Execution")

--- a/crates/c2/src/lib.rs
+++ b/crates/c2/src/lib.rs
@@ -7,4 +7,5 @@ pub use executor::{C2Backend, C2EventBus, C2Handle, C2Manager};
 pub use shell_session::ShellSession;
 pub use types::{
     C2Event, ExecTtp, OutputTransform, SessionConnectedData, TtpExecuted, BUILTIN_C2_ID,
+    DEFAULT_EXECUTION_TIMEOUT_SECONDS,
 };

--- a/crates/c2/src/shell_session.rs
+++ b/crates/c2/src/shell_session.rs
@@ -238,13 +238,19 @@ impl C2Backend for ShellSession {
             }
         };
 
-        match tokio::time::timeout(Duration::from_secs(60), read_fut).await {
+        let timeout_seconds = cmd.execution_timeout_seconds.max(1);
+        match tokio::time::timeout(Duration::from_secs(timeout_seconds), read_fut).await {
             Ok(Ok((code, out))) => {
                 exit_code = code;
                 output = out;
             }
             Ok(Err(e)) => return exec_error(&cmd.id, e),
-            Err(_) => return exec_error(&cmd.id, "shell command timed out after 60s".to_string()),
+            Err(_) => {
+                return exec_error(
+                    &cmd.id,
+                    format!("shell command timed out after {timeout_seconds}s"),
+                )
+            }
         }
 
         let stdout = output.trim_end().to_string();
@@ -406,6 +412,7 @@ mod tests {
         ExecTtp {
             id: "test-cmd-1".to_string(),
             started_at_ms: 0,
+            execution_timeout_seconds: crate::DEFAULT_EXECUTION_TIMEOUT_SECONDS,
             ttp: Ttp::new("T0001", "Test", "Execution"),
             procedure: Procedure::new("proc-1", command),
             args: HashMap::new(),

--- a/crates/c2/src/types.rs
+++ b/crates/c2/src/types.rs
@@ -6,6 +6,11 @@ use serde::{Deserialize, Serialize};
 
 /// The backend ID for the built-in Ran C2.
 pub const BUILTIN_C2_ID: &str = "c2/ran";
+pub const DEFAULT_EXECUTION_TIMEOUT_SECONDS: u64 = 60;
+
+fn default_execution_timeout_seconds() -> u64 {
+    DEFAULT_EXECUTION_TIMEOUT_SECONDS
+}
 
 /// Alias to the domain-owned output-transform enum.
 pub type OutputTransform = OutputTransformKind;
@@ -32,6 +37,9 @@ pub struct ExecTtp {
     pub auth_identity_id: Option<String>,
     /// Unix timestamp (milliseconds) when the command was dispatched.
     pub started_at_ms: u64,
+    /// Maximum wall-clock time allowed for this command to complete.
+    #[serde(default = "default_execution_timeout_seconds")]
+    pub execution_timeout_seconds: u64,
     /// Output post-processing required before parsers run.
     /// `None` means the raw output can be parsed directly.
     #[serde(default)]

--- a/crates/campaign/src/analyzers.rs
+++ b/crates/campaign/src/analyzers.rs
@@ -13,8 +13,9 @@ use crate::{Campaign, FactsUpdate, PendingView};
 // Built-in analyzers
 // ---------------------------------------------------------------------------
 
-/// For every new `Pod`, ensure the namespace entity exists and wire a
-/// `contains` relation from the Namespace to the Pod.
+/// For every new `Pod`, wire it to its known namespace. Namespace-unknown
+/// placeholders are attached directly to the sole known cluster until a later
+/// authoritative observation resolves their identity.
 pub struct PodNamespaceAnalyzer;
 
 impl InferenceRule for PodNamespaceAnalyzer {
@@ -29,12 +30,16 @@ impl InferenceRule for PodNamespaceAnalyzer {
             let Some(pod) = entity.as_any().downcast_ref::<Pod>() else {
                 continue;
             };
-            let Some(ns_name) = pod.namespace() else {
+            let Some(ns_name) = pod.namespace().filter(|ns| !ns.is_empty()) else {
+                let clusters = view.collect::<K8sCluster>();
+                if let [cluster] = clusters.as_slice() {
+                    inferred.new_relations.push(Box::new(Contains::new(
+                        cluster.entity_id().0,
+                        pod.entity_id().0,
+                    )));
+                }
                 continue;
             };
-            if ns_name.is_empty() {
-                continue;
-            }
 
             let (ns_id, new_ns) = view.ensure_namespace(ns_name);
             if let Some(ns) = new_ns {
@@ -1937,7 +1942,7 @@ mod tests {
     }
 
     #[test]
-    fn pod_without_namespace_is_ignored() {
+    fn pod_without_namespace_is_contained_by_cluster() {
         let campaign = test_campaign();
 
         // Build a pod with no namespace
@@ -1949,7 +1954,13 @@ mod tests {
         let rules = default_rules();
         update = run_rules_fixpoint(&campaign, &rules, update);
 
-        assert!(update.new_relations.is_empty());
+        let pod_id = EntityId::new("ns//pod/bare-pod");
+        let rel = update.new_relations.iter().find(|r| {
+            r.is::<Contains>()
+                && r.source_id().0 == "k8s/cluster/test-cluster"
+                && r.target_id() == &pod_id
+        });
+        assert!(rel.is_some(), "expected cluster→pod contains relation");
     }
 
     #[test]

--- a/crates/campaign/src/campaign/execution.rs
+++ b/crates/campaign/src/campaign/execution.rs
@@ -40,6 +40,16 @@ fn validate_request(request: &ExecuteActionRequest) -> Result<(), ExecuteActionE
             "actionId and targetId are required".to_string(),
         ));
     }
+    if let Some(value) = request.args.get("__EXECUTION_TIMEOUT_SECONDS") {
+        let valid = value
+            .parse::<u64>()
+            .is_ok_and(|seconds| (1..=3600).contains(&seconds));
+        if !valid {
+            return Err(ExecuteActionError::InvalidInput(
+                "executionTimeoutSeconds must be between 1 and 3600".to_string(),
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -676,13 +686,18 @@ impl Campaign {
     /// conflicting.
     pub fn prepare_action(
         &mut self,
-        request: ExecuteActionRequest,
+        mut request: ExecuteActionRequest,
         armory: &Armory,
     ) -> Result<ExecTtp, ExecuteActionError> {
         // Stage 1: validate inputs and look up static data.
         validate_request(&request)?;
         self.assert_target_exists(&request.target_id)?;
         let reasoning = request.reasoning.unwrap_or_default();
+        let execution_timeout_seconds = request
+            .args
+            .remove("__EXECUTION_TIMEOUT_SECONDS")
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(c2::DEFAULT_EXECUTION_TIMEOUT_SECONDS);
         let (ttp, args) = resolve_ttp_and_defaults(&request.action_id, request.args, armory)?;
         let mut exec = self.prepare_action_with_ttp(
             request.target_id,
@@ -694,6 +709,7 @@ impl Campaign {
             armory,
         )?;
         exec.reasoning = reasoning;
+        exec.execution_timeout_seconds = execution_timeout_seconds;
         Ok(exec)
     }
 
@@ -1016,6 +1032,7 @@ impl Campaign {
             exec_system_id: route.backend_id,
             auth_identity_id,
             started_at_ms: current_time_millis(),
+            execution_timeout_seconds: c2::DEFAULT_EXECUTION_TIMEOUT_SECONDS,
             output_transform: route.output_transform,
             is_cleanup: false,
             reasoning: String::new(),

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -34,6 +34,7 @@ fn sample_exec_ttp(target_id: &str, effects: Vec<&str>) -> ExecTtp {
         exec_system_id: String::new(),
         auth_identity_id: None,
         started_at_ms: 0,
+        execution_timeout_seconds: c2::DEFAULT_EXECUTION_TIMEOUT_SECONDS,
         output_transform: None,
         is_cleanup: false,
         reasoning: String::new(),
@@ -696,6 +697,41 @@ fn action_request(target_id: &str, exec_system_id: Option<&str>) -> ExecuteActio
         args: HashMap::new(),
         reasoning: None,
     }
+}
+
+#[test]
+fn prepare_action_applies_custom_execution_timeout() {
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+    let armory = Armory::from_ttps(vec![Ttp {
+        procedures: vec![Procedure::new("local", "noop")],
+        ..Ttp::new("test-ttp", "Test TTP", "Execution")
+    }]);
+    let mut request = action_request("k8s/cluster/dev", None);
+    request
+        .args
+        .insert("__EXECUTION_TIMEOUT_SECONDS".to_string(), "300".to_string());
+
+    let exec = campaign.prepare_action(request, &armory).unwrap();
+
+    assert_eq!(exec.execution_timeout_seconds, 300);
+    assert!(!exec.args.contains_key("__EXECUTION_TIMEOUT_SECONDS"));
+}
+
+#[test]
+fn prepare_action_rejects_out_of_range_execution_timeout() {
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+    let armory = minimal_armory("test-ttp");
+    let mut request = action_request("k8s/cluster/dev", None);
+    request.args.insert(
+        "__EXECUTION_TIMEOUT_SECONDS".to_string(),
+        "3601".to_string(),
+    );
+
+    assert!(matches!(
+        campaign.prepare_action(request, &armory),
+        Err(ExecuteActionError::InvalidInput(message))
+            if message.contains("executionTimeoutSeconds")
+    ));
 }
 
 fn insert_test_auth_service_account(campaign: &mut Campaign) -> String {
@@ -1378,6 +1414,7 @@ fn nmap_exec_ttp(target_id: &str) -> ExecTtp {
         exec_system_id: target_id.to_string(),
         auth_identity_id: None,
         started_at_ms: 0,
+        execution_timeout_seconds: c2::DEFAULT_EXECUTION_TIMEOUT_SECONDS,
         output_transform: None,
         is_cleanup: false,
         reasoning: String::new(),

--- a/crates/campaign/src/failure_analyzers.rs
+++ b/crates/campaign/src/failure_analyzers.rs
@@ -437,6 +437,7 @@ mod tests {
             exec_system_id: String::new(),
             auth_identity_id: None,
             started_at_ms: 0,
+            execution_timeout_seconds: c2::DEFAULT_EXECUTION_TIMEOUT_SECONDS,
             output_transform: None,
             is_cleanup: false,
             reasoning: String::new(),

--- a/crates/campaign/src/output_parsers/mod.rs
+++ b/crates/campaign/src/output_parsers/mod.rs
@@ -701,6 +701,7 @@ mod tests {
             exec_system_id: String::new(),
             auth_identity_id: None,
             started_at_ms: 0,
+            execution_timeout_seconds: c2::DEFAULT_EXECUTION_TIMEOUT_SECONDS,
             output_transform: None,
             is_cleanup: false,
             reasoning: String::new(),

--- a/crates/campaign/src/output_parsers/network.rs
+++ b/crates/campaign/src/output_parsers/network.rs
@@ -93,7 +93,6 @@ pub(super) fn parse_nmap(stdout: &str, source_id: &str, cidr: Option<&str>) -> P
     }
 
     let mut facts = FactsUpdate::default();
-    let source_ns = source_namespace(source_id);
     let observed_at_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .ok()
@@ -107,7 +106,7 @@ pub(super) fn parse_nmap(stdout: &str, source_id: &str, cidr: Option<&str>) -> P
             continue;
         }
 
-        let discovered = classify_discovered_host(ip_addr, host.hostname.as_deref(), source_ns);
+        let discovered = classify_discovered_host(ip_addr, host.hostname.as_deref());
         let entity_id = discovered.entity_id().0.clone();
         facts.new_entities.push(discovered);
 
@@ -200,15 +199,6 @@ fn trimmed_text(value: &str) -> Option<String> {
     (!value.is_empty()).then(|| value.to_string())
 }
 
-fn source_namespace(source_id: &str) -> Option<&str> {
-    let parts: Vec<&str> = source_id.splitn(4, '/').collect();
-    if parts.len() == 4 && parts[0] == "ns" && parts[2] == "pod" && !parts[1].is_empty() {
-        Some(parts[1])
-    } else {
-        None
-    }
-}
-
 fn parse_cidr_v4(cidr: &str) -> Option<(Ipv4Addr, u8)> {
     let (base, prefix) = cidr.split_once('/')?;
     let base = base.trim().parse::<Ipv4Addr>().ok()?;
@@ -250,11 +240,7 @@ fn is_ip_in_scope(ip: IpAddr, cidr: Option<&str>) -> bool {
     ipv4_in_cidr(ipv4, base, prefix)
 }
 
-fn classify_discovered_host(
-    ip: IpAddr,
-    hostname: Option<&str>,
-    source_ns: Option<&str>,
-) -> Box<dyn Entity> {
+fn classify_discovered_host(ip: IpAddr, hostname: Option<&str>) -> Box<dyn Entity> {
     let ip_str = ip.to_string();
     let ip_kebab = ip_str.replace('.', "-");
 
@@ -271,8 +257,11 @@ fn classify_discovered_host(
             .filter(|h| !h.trim().is_empty())
             .map(|h| h.to_string())
             .unwrap_or_else(|| format!("pod-{}", ip_kebab));
-        let ns = source_ns.unwrap_or("");
-        let mut pod = Pod::new(name, ns);
+        let mut pod = Pod::new(name, "");
+        // The scanner's namespace says where the observation came from, not
+        // where the observed IP lives. Keep the placeholder unqualified until
+        // DNS or authoritative Kubernetes data supplies a namespace.
+        pod.meta.namespace = None;
         pod.system.ips.push(ip);
         return Box::new(pod);
     }
@@ -876,8 +865,24 @@ mod tests {
             .as_any()
             .downcast_ref::<Pod>()
             .unwrap();
-        assert_eq!(pod.namespace(), Some("dungeon"));
+        assert_eq!(pod.namespace(), None);
         assert!(pod.system.ips.iter().any(|ip| ip.to_string() == "10.0.0.5"));
+    }
+
+    #[test]
+    fn parse_nmap_ip_only_host_does_not_inherit_scanner_namespace() {
+        let stdout = "Nmap scan report for 10.0.0.137\nHost is up (0.00080s latency).\nAll 100 scanned ports on 10.0.0.137 are in ignored states.\n";
+        let ParserOutput::SuccessWithFacts(facts, _) =
+            parse_nmap(stdout, "ns/dungeon/pod/scanner", None)
+        else {
+            panic!("expected SuccessWithFacts");
+        };
+        let pod = facts.new_entities[0]
+            .as_any()
+            .downcast_ref::<Pod>()
+            .unwrap();
+        assert_eq!(pod.namespace(), None);
+        assert_eq!(pod.entity_name(), "pod-10-0-0-137");
     }
 
     #[test]

--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -20,11 +20,38 @@ use crate::edge::EdgeData;
 /// - **NoSelfEdge** — source and target must differ (hard reject).
 /// - **PodSingleNode** — a pod may carry at most one `runs-on` edge; an
 ///   incoming one replaces the old one (K8s rescheduling is valid).
+/// - **SingleContainer** — an entity may have at most one incoming `contains`
+///   edge; a more specific parent replaces its previous parent.
 #[derive(Debug, Clone)]
 pub struct KnowledgeGraph {
     pub(crate) graph: StableGraph<EntityId, EdgeData>,
     /// `O(1)` lookup from entity id to its node index.
     pub(crate) index: HashMap<EntityId, NodeIndex>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::edge::edge_data_for;
+
+    #[test]
+    fn contains_replaces_the_previous_parent() {
+        let mut graph = KnowledgeGraph::new();
+        let cluster = EntityId::new("k8s/cluster/dev");
+        let namespace = EntityId::new("ns/prod");
+        let pod = EntityId::new("ns/prod/pod/api");
+
+        graph.insert_edge(&cluster, &pod, edge_data_for("contains", None, None));
+        graph.insert_edge(&namespace, &pod, edge_data_for("contains", None, None));
+
+        let contains: Vec<_> = graph
+            .to_relation_summaries()
+            .into_iter()
+            .filter(|relation| relation.name == "contains" && relation.target_id == pod.0)
+            .collect();
+        assert_eq!(contains.len(), 1);
+        assert_eq!(contains[0].source_id, namespace.0);
+    }
 }
 
 impl Default for KnowledgeGraph {
@@ -125,6 +152,8 @@ impl KnowledgeGraph {
     /// - **NoSelfEdge**: returns `None` if `src == tgt`.
     /// - **PodSingleNode**: any existing `runs-on` edge from `src` is removed
     ///   before the new one is added (K8s rescheduling is valid).
+    /// - **SingleContainer**: a new `contains` edge replaces any existing
+    ///   containment parent of `tgt`.
     ///
     /// Parallel edges (same `src`/`tgt`, different `relation_name`) are allowed.
     pub fn insert_edge(
@@ -146,6 +175,18 @@ impl KnowledgeGraph {
                 .graph
                 .edges_directed(src_idx, Direction::Outgoing)
                 .filter(|e| e.weight().relation_name == "runs-on")
+                .map(|e| e.id())
+                .collect();
+            for idx in stale {
+                self.graph.remove_edge(idx);
+            }
+        }
+
+        if data.relation_name == "contains" {
+            let stale: Vec<EdgeIndex> = self
+                .graph
+                .edges_directed(tgt_idx, Direction::Incoming)
+                .filter(|e| e.weight().relation_name == "contains")
                 .map(|e| e.id())
                 .collect();
             for idx in stale {

--- a/crates/utility-ai/src/replay.rs
+++ b/crates/utility-ai/src/replay.rs
@@ -207,6 +207,7 @@ fn reconstruct_cmd(rec: &ExecutionRecord, armory: &[Ttp]) -> Option<ExecTtp> {
         exec_system_id: rec.exec_system_id.clone(),
         auth_identity_id: rec.auth_identity_id.clone(),
         started_at_ms: rec.started_at_ms,
+        execution_timeout_seconds: c2::DEFAULT_EXECUTION_TIMEOUT_SECONDS,
         // Stored `results` are already post-unwrap, so no transform on replay.
         output_transform: None,
         is_cleanup: rec.is_cleanup,

--- a/frontend/src/lib/api/gen_types.ts
+++ b/frontend/src/lib/api/gen_types.ts
@@ -649,6 +649,12 @@ export interface components {
             args?: {
                 [key: string]: string;
             };
+            /**
+             * Format: int64
+             * @description Maximum wall-clock time allowed for the complete command.
+             * @default 60
+             */
+            executionTimeoutSeconds: number;
             /** @description Free-text rationale for choosing this action at this point in the assessment — why this TTP against this target now. Optional, but strongly encouraged when driving the campaign programmatically: it is stored on the resulting execution record so the timeline is self-explaining and auditable. */
             reasoning?: string;
         };

--- a/frontend/src/lib/modals/ActionParamsModal.svelte
+++ b/frontend/src/lib/modals/ActionParamsModal.svelte
@@ -12,7 +12,7 @@
 		targetId: string;
 		ttp: TTP;
 		argContext: Record<string, any>;
-		onExecute: (ttpId: string, execSystemId: string, authIdentityId: string, procedureId: string, args: Record<string, string>) => void;
+		onExecute: (ttpId: string, execSystemId: string, authIdentityId: string, procedureId: string, args: Record<string, string>, executionTimeoutSeconds: number) => void;
 		onCancel: () => void;
 	}
 	let { targetId = $bindable(), ttp, argContext, onExecute, onCancel }: ParamProps = $props();
@@ -49,6 +49,7 @@
 	let eligibleAuthIdentities = $state<AuthIdentity[]>([]);
 	let selectedAuthIdentityId = $state('');
 	let formElement: HTMLFormElement | undefined = $state();
+	let executionTimeoutSeconds = $state(60);
 
 	const compromisedSystems = $derived(campaignState.getCompromisedSystems());
 	const execSystemOptions = $derived<ComboboxOption[]>(
@@ -59,6 +60,11 @@
 	const selectedExecSystem = $derived(
 		compromisedSystems.find(e => e.id === selectedExecSystemId)
 	);
+	const hasAdvancedSettings = $derived.by(() => {
+		const procedure = ttp.procedures?.find(candidate => candidate.id === procedureId)
+			?? ttp.procedures?.[0];
+		return !!procedure?.command?.trim() && !procedure.isLocalCommand;
+	});
 	$effect(() => {
 		const actionId = ttp?.id;
 		const selectedTargetId = targetId;
@@ -615,7 +621,7 @@
 			{} as { [key: string]: string }
 		);
 
-		onExecute(ttp.id, selectedExecSystemId, authIdentityId, procedureId, argsDict);
+		onExecute(ttp.id, selectedExecSystemId, authIdentityId, procedureId, argsDict, executionTimeoutSeconds);
 	}
 
 	function executingSystemHasTool(tool: string): boolean {
@@ -840,6 +846,24 @@
 		/> -->
 	</div>
 {/each}
+			{/if}
+			{#if hasAdvancedSettings}
+			<details class="mt-4 text-xs">
+				<summary class="cursor-pointer font-normal opacity-60 hover:opacity-100">Advanced settings</summary>
+				<label class="label mt-3" for="executionTimeoutSeconds">
+					<span class="label-text text-xs md:text-sm lg:text-base">Execution timeout (seconds)</span>
+					<input
+						id="executionTimeoutSeconds"
+						class="input mt-2 text-xs md:text-sm lg:text-base"
+						type="number"
+						min="1"
+						max="3600"
+						required
+						bind:value={executionTimeoutSeconds}
+					/>
+					<span class="text-xs opacity-70">Maximum time allowed for the complete command. Default: 60 seconds.</span>
+				</label>
+			</details>
 			{/if}
 	</article>
 	<footer class="flex justify-end gap-4 flex-shrink-0 pt-4">

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -483,14 +483,14 @@
 		}
 	});
 
-	async function onExecuteTTP(ttpId: string, execSystemId: string, authIdentityId: string, procedureId: string, args: Record<string, string>) {
+	async function onExecuteTTP(ttpId: string, execSystemId: string, authIdentityId: string, procedureId: string, args: Record<string, string>, executionTimeoutSeconds: number) {
 		const ttp = campaignState.getTtpById(ttpId);
 		const targetName = campaignState.getEntityById(selectedObjectId)?.name ?? selectedObjectId;
 
 		closeModal();
 
 		try {
-			const result = await ExecuteAction({ actionId: ttpId, execSystemId, authIdentityId: authIdentityId || undefined, targetId: selectedObjectId, procedureId, args });
+			const result = await ExecuteAction({ actionId: ttpId, execSystemId, authIdentityId: authIdentityId || undefined, targetId: selectedObjectId, procedureId, args, executionTimeoutSeconds });
 			const cmdId = (result as any)?.cmdId ?? crypto.randomUUID();
 			const differsFromTarget = execSystemId && execSystemId !== selectedObjectId;
 			timeline.addTtpAction({


### PR DESCRIPTION
## Summary
- keep IP-only Nmap pod placeholders unqualified and attach them directly to the cluster until authoritative namespace data arrives
- replace cluster containment when a placeholder is reconciled into its namespace
- add a configurable per-execution timeout under a subdued Advanced settings disclosure
- apply execution timeouts to persistent shell sessions and one-shot pod exec, and align CLI/MCP wait deadlines

## Validation
- `cargo test --workspace --quiet`
- `npm run build` (frontend)

Existing unrelated frontend accessibility warnings remain during the build.