### PR TITLE
Disable procedures when execution tools are absent

### DIFF
--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -1456,25 +1456,31 @@ fn command_not_found_in_output_with_exit_zero_marks_binary_absent_and_fails_step
 }
 
 #[test]
-fn command_not_found_does_not_overwrite_known_present_binary() {
+fn grounded_http_tool_failure_overrides_stale_known_present_binary() {
     use ran_domain::BinaryPresence;
     let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev-cluster"));
     let mut pod = Pod::new("demo", "default");
-    pod.system.set_binary("nmap", "/usr/bin/nmap");
+    pod.system.set_binary("wget", "/usr/bin/wget");
     let target_id = pod.entity_id().0.clone();
     campaign.entities.insert_typed(pod);
 
-    let cmd = nmap_exec_ttp(&target_id);
+    let mut cmd = nmap_exec_ttp(&target_id);
+    // Grounded http_request variants retain the concrete implementation in
+    // `tool` after the structured request has been materialized.
+    cmd.procedure.tool = Some("wget".to_string());
+    cmd.procedure.command = "wget -qO- https://example.test".to_string();
     let event = command_not_found_event();
 
     campaign.on_ttp_executed(&cmd, &event).unwrap();
 
-    // Present should be preserved — a single failure doesn't override confirmed presence
+    // A command-not-found result is newer direct evidence than an earlier
+    // inventory result and must disable this procedure until installation is
+    // observed again.
     let sys = campaign.get_system_entity(&target_id).unwrap();
     assert_eq!(
-        sys.entity().system().has_binary("nmap"),
-        BinaryPresence::Present("/usr/bin/nmap".to_string()),
-        "confirmed Present should not be overwritten by a command-not-found failure"
+        sys.entity().system().has_binary("wget"),
+        BinaryPresence::Absent,
+        "command-not-found should override stale Present evidence"
     );
 }
 

--- a/crates/campaign/src/external_parser.rs
+++ b/crates/campaign/src/external_parser.rs
@@ -202,11 +202,13 @@ pub fn apply_system_field_updates(
     for (name, path) in &updates.binaries {
         let should_write = match sys.has_binary(name) {
             BinaryPresence::Unknown => true,
-            BinaryPresence::Absent => true,
+            BinaryPresence::Absent => !path.is_empty(),
             BinaryPresence::Present(existing) => {
-                // Allow precision upgrades (e.g. "nmap" -> "/usr/bin/nmap")
-                // but do not overwrite a concrete absolute path with a weaker value.
-                is_more_precise_binary_path(&existing, path)
+                // A command-not-found result is direct, current evidence that a
+                // previously discovered binary is no longer available. Keep
+                // this reversible: a later non-empty update (for example after
+                // installing the package) replaces Absent above.
+                path.is_empty() || is_more_precise_binary_path(&existing, path)
             }
         };
 
@@ -290,5 +292,20 @@ mod tests {
             sys.has_binary("nmap"),
             ran_domain::BinaryPresence::Present("/usr/bin/nmap".to_string())
         );
+    }
+
+    #[test]
+    fn binary_update_replaces_stale_presence_with_negative_evidence() {
+        let mut sys = ran_domain::SystemInfo::default();
+        sys.set_binary("wget", "/usr/bin/wget");
+
+        let updates = SystemFieldUpdates {
+            binaries: HashMap::from([("wget".to_string(), String::new())]),
+            ..Default::default()
+        };
+
+        let changed = apply_system_field_updates(&mut sys, &updates);
+        assert_eq!(changed, 1);
+        assert_eq!(sys.has_binary("wget"), ran_domain::BinaryPresence::Absent);
     }
 }

--- a/frontend/src/lib/modals/ActionParamsModal.svelte
+++ b/frontend/src/lib/modals/ActionParamsModal.svelte
@@ -201,6 +201,26 @@
 		return undefined;
 	}
 
+	function defaultExecutionSystemId(targetId: string, systems: Entity[]): string {
+		if (systems.some(system => system.id === targetId)) return targetId;
+
+		// Identity-targeted actions execute on a system linked to that identity.
+		// Mirror that graph relationship in the modal so procedure availability is
+		// checked against the pod where the command will physically run.
+		const linkedSystem = systems.find(system =>
+			Array.from(campaignState.relations.values()).some(relation =>
+				relation.source === system.id &&
+				relation.destination === targetId &&
+				relation.kind === 'uses'
+			)
+		);
+		if (linkedSystem) return linkedSystem.id;
+
+		// With a single foothold there is no routing ambiguity, and retaining an
+		// empty selection would prevent tool readiness from being evaluated.
+		return systems.length === 1 ? systems[0].id : '';
+	}
+
 	let selectedNamespace = $derived.by(() => {
 		const nsArg = args.find(arg => arg.Type === 'Namespace');
 		return nsArg ? nsArg.Value : '';
@@ -429,13 +449,12 @@
 			// Also reset procedureId when TTP changes
 			procedureId = ttpProcedures?.[0]?.id || '';
 
-			// Default execution system: use the target itself when it is already
-			// compromised (direct access). For everything else leave it empty —
-			// the backend resolves the path via the knowledge graph.
+			// Select the physical execution system as well as the semantic target.
+			// This is especially important for ServiceAccount actions: the backend
+			// executes them on a linked pod, whose binary facts control procedure
+			// availability.
 			const systems = campaignState.getCompromisedSystems();
-			selectedExecSystemId = systems.some(s => s.id === currentTargetId)
-				? currentTargetId
-				: '';
+			selectedExecSystemId = defaultExecutionSystemId(currentTargetId, systems);
 
 			console.log(args);
 			console.groupEnd();
@@ -625,6 +644,12 @@
 		return path !== '' && path !== '❌';
 	}
 
+	function unavailableToolReason(tool: string): string | undefined {
+		return executingSystemHasTool(tool)
+			? undefined
+			: `Disabled because '${tool}' is known to be absent from the selected execution system`;
+	}
+
 	function procedureToolName(procedure: { id: string; tool?: string }): string {
 		return procedure.tool || procedure.id;
 	}
@@ -749,6 +774,7 @@
 						<option
 							value={procedure.id}
 							disabled={!executingSystemHasTool(procedureToolName(procedure))}
+							title={unavailableToolReason(procedureToolName(procedure))}
 							>{procedureToolName(procedure)}{!executingSystemHasTool(procedureToolName(procedure)) ? ' ❌' : ''}
 						</option>
 					{/each}


### PR DESCRIPTION
## Summary
- let command-not-found evidence override stale binary-presence facts while allowing later installation facts to restore availability
- resolve ServiceAccount actions to their linked execution pod when evaluating procedure tool availability
- disable unavailable grounded HTTP procedures and explain the reason in a tooltip
- add regressions for grounded HTTP tools that disappear after being observed

## Testing
- `cargo fmt --check`
- `cargo test -p campaign command_not_found`
- `cargo test -p campaign external_parser::tests`
- repository pre-commit Rust checks

Frontend `svelte-check` was not run because frontend dependencies are not installed in this worktree (`svelte-kit: command not found`).