### PR TITLE
Save execution history as a reusable plan

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -527,6 +527,45 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
+  /api/plans/export:
+    get:
+      summary: Export the execution history as a plan
+      description: Builds a reusable plan YAML from completed campaign actions, in execution order. Cleanup actions are omitted.
+      operationId: exportPlan
+      parameters:
+        - name: include_failed
+          in: query
+          required: false
+          description: Include failed actions as well as successful actions.
+          schema:
+            type: boolean
+            default: false
+        - name: name
+          in: query
+          required: false
+          description: Human-readable name stored in the exported plan.
+          schema:
+            type: string
+        - name: description
+          in: query
+          required: false
+          description: Description stored in the exported plan.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Exported plan YAML
+          content:
+            application/yaml:
+              schema:
+                type: string
+        '500':
+          description: Failed to export the plan
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
 webhooks:
   armory-loaded:
     post:

--- a/crates/api/build.rs
+++ b/crates/api/build.rs
@@ -176,7 +176,12 @@ pub trait ApiService: Clone + Send + Sync + 'static {
 
     async fn get_plan_status(&self, plan_id: &str) -> Result<serde_json::Value, ApiError>;
 
-    async fn export_plan(&self, include_failed: bool) -> Result<String, ApiError>;
+    async fn export_plan(
+        &self,
+        include_failed: bool,
+        name: Option<String>,
+        description: Option<String>,
+    ) -> Result<String, ApiError>;
 
     /// List pre-defined plans available in the configured plans directory.
     async fn list_plans(&self) -> Result<Vec<serde_json::Value>, ApiError>;

--- a/crates/api/src/api_handlers.rs
+++ b/crates/api/src/api_handlers.rs
@@ -857,12 +857,20 @@ pub(crate) async fn plan_status_handler<S: ApiService>(
 pub(crate) async fn export_plan_handler<S: ApiService>(
     State(service): State<S>,
     axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
-) -> Result<String, ApiError> {
+) -> Result<([(axum::http::HeaderName, &'static str); 1], String), ApiError> {
     let include_failed = params
         .get("include_failed")
         .map(|v| v == "true")
         .unwrap_or(false);
-    service.export_plan(include_failed).await
+    let name = params.get("name").cloned();
+    let description = params.get("description").cloned();
+    let yaml = service
+        .export_plan(include_failed, name, description)
+        .await?;
+    Ok((
+        [(axum::http::header::CONTENT_TYPE, "application/yaml")],
+        yaml,
+    ))
 }
 
 #[derive(serde::Deserialize)]

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -720,13 +720,27 @@ impl ApiService for AppState {
         }))
     }
 
-    async fn export_plan(&self, include_failed: bool) -> Result<String, ApiError> {
+    async fn export_plan(
+        &self,
+        include_failed: bool,
+        name: Option<String>,
+        description: Option<String>,
+    ) -> Result<String, ApiError> {
         let campaign = self
             .campaign
             .read()
             .map_err(|_| ApiError::internal("campaign lock poisoned"))?;
         let opts = planner::ExportOptions { include_failed };
-        let plan = planner::export_plan(&campaign.execution_records, &opts);
+        let mut plan = planner::export_plan(&campaign.execution_records, &opts);
+        if let Some(name) = name
+            .map(|name| name.trim().to_string())
+            .filter(|name| !name.is_empty())
+        {
+            plan.name = name;
+        }
+        if let Some(description) = description.map(|value| value.trim().to_string()) {
+            plan.description = (!description.is_empty()).then_some(description);
+        }
         let yaml = serde_yaml::to_string(&plan).map_err(|e| ApiError::internal(e.to_string()))?;
         Ok(yaml)
     }

--- a/crates/planner/src/exporter.rs
+++ b/crates/planner/src/exporter.rs
@@ -96,36 +96,28 @@ fn step_id_from_record(ttp_id: &str, index: usize) -> String {
 }
 
 pub fn export_plan(records: &[ExecutionRecord], opts: &ExportOptions) -> PlanDefinition {
-    let successful: Vec<&ExecutionRecord> = records
+    let selected: Vec<&ExecutionRecord> = records
         .iter()
-        .filter(|r| r.success && !r.is_cleanup)
+        .filter(|record| !record.is_cleanup && (record.success || opts.include_failed))
         .collect();
+    let mut steps: Vec<StepDefinition> = Vec::with_capacity(selected.len());
 
-    let failed: Vec<&ExecutionRecord> = if opts.include_failed {
-        records
-            .iter()
-            .filter(|r| !r.success && !r.is_cleanup)
-            .collect()
-    } else {
-        vec![]
-    };
-
-    let mut steps: Vec<StepDefinition> = Vec::new();
-    let mut success_step_ids: Vec<String> = Vec::new();
-
-    // Build success chain (linear, each depends on previous)
-    for (i, rec) in successful.iter().enumerate() {
+    // Preserve execution order. When failures are included, completion (rather
+    // than success) allows replay to continue to the next recorded action.
+    for (i, rec) in selected.iter().enumerate() {
         let step_id = step_id_from_record(&rec.ttp_id, i);
         let fuzz = fuzzify_entity_id(&rec.target_id);
 
-        let depends_on = if i == 0 {
-            vec![]
-        } else {
+        let depends_on = steps.last().map_or_else(Vec::new, |previous| {
             vec![Dependency::Step {
-                step: success_step_ids[i - 1].clone(),
-                require: Require::Success,
+                step: previous.id.clone(),
+                require: if opts.include_failed {
+                    Require::Completion
+                } else {
+                    Require::Success
+                },
             }]
-        };
+        });
 
         let kind = capitalize(entity_kind_from_id(&rec.target_id));
         let namespace = entity_namespace_from_id(&rec.target_id).map(str::to_string);
@@ -150,60 +142,7 @@ pub fn export_plan(records: &[ExecutionRecord], opts: &ExportOptions) -> PlanDef
             retry: RetryStrategy::NextProcedure,
             depends_on,
             expect: None,
-            note: None,
-        });
-        success_step_ids.push(step_id);
-    }
-
-    // Add failed steps as side branches
-    let failed_start = steps.len();
-    for (fi, rec) in failed.iter().enumerate() {
-        let step_id = step_id_from_record(&rec.ttp_id, failed_start + fi);
-        let fuzz = fuzzify_entity_id(&rec.target_id);
-
-        // Find last successful record that appears before this failed one
-        let record_pos = records.iter().position(|r| r.id == rec.id).unwrap_or(0);
-        let last_success_step_id = records[..record_pos]
-            .iter()
-            .rev()
-            .find(|r| r.success && !r.is_cleanup)
-            .and_then(|r| {
-                let idx = successful.iter().position(|s| s.id == r.id)?;
-                success_step_ids.get(idx).cloned()
-            });
-
-        let depends_on = match last_success_step_id {
-            Some(sid) => vec![Dependency::Step {
-                step: sid,
-                require: Require::Success,
-            }],
-            None => vec![],
-        };
-
-        let kind = capitalize(entity_kind_from_id(&rec.target_id));
-        let namespace = entity_namespace_from_id(&rec.target_id).map(str::to_string);
-
-        steps.push(StepDefinition {
-            id: step_id,
-            action: rec.ttp_id.clone(),
-            target: TargetQuery {
-                kind,
-                namespace,
-                name: fuzz.pattern,
-                select: None,
-                ..Default::default()
-            },
-            exec_target: None,
-            authenticate_as: rec.auth_identity_id.as_ref().map(|id| TargetQuery {
-                id: Some(id.clone()),
-                ..Default::default()
-            }),
-            args: rec.args.clone(),
-            procedure: Some(rec.procedure_id.clone()).filter(|s| !s.is_empty()),
-            retry: RetryStrategy::NextProcedure,
-            depends_on,
-            expect: None,
-            note: Some("recorded: failed".into()),
+            note: (!rec.success).then(|| "recorded: failed".into()),
         });
     }
 
@@ -295,7 +234,7 @@ mod tests {
     }
 
     #[test]
-    fn export_include_failed_adds_side_branches() {
+    fn export_include_failed_preserves_execution_order() {
         let records = vec![
             make_record(
                 "cmd-1",
@@ -324,24 +263,12 @@ mod tests {
         };
         let plan = export_plan(&records, &opts);
         assert_eq!(plan.steps.len(), 3);
-        // The failed step depends on cmd-1's step (same predecessor as cmd-3), not on cmd-3
-        let failed_step = plan
-            .steps
-            .iter()
-            .find(|s| s.note.as_deref() == Some("recorded: failed"))
-            .unwrap();
-        assert!(failed_step.depends_on.iter().any(|d| {
-            matches!(d, crate::model::Dependency::Step { step, .. } if step == "step_0_k8s_exec_into_pod")
+        assert_eq!(plan.steps[1].action, "container.exploit-cve");
+        assert_eq!(plan.steps[1].note.as_deref(), Some("recorded: failed"));
+        assert!(plan.steps[2].depends_on.iter().any(|d| {
+            matches!(d, crate::model::Dependency::Step { step, require: crate::model::Require::Completion }
+                if step == &plan.steps[1].id)
         }));
-        // Nothing depends on the failed step
-        let failed_id = failed_step.id.clone();
-        for step in &plan.steps {
-            for dep in &step.depends_on {
-                if let crate::model::Dependency::Step { step: dep_id, .. } = dep {
-                    assert_ne!(dep_id, &failed_id, "something depends on failed step");
-                }
-            }
-        }
     }
 
     fn make_record(

--- a/frontend/src/lib/api/gen_types.ts
+++ b/frontend/src/lib/api/gen_types.ts
@@ -413,6 +413,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/plans/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Export the execution history as a plan
+         * @description Builds a reusable plan YAML from completed campaign actions, in execution order. Cleanup actions are omitted.
+         */
+        get: operations["exportPlan"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export interface webhooks {
     "armory-loaded": {
@@ -1618,6 +1638,42 @@ export interface operations {
             };
             /** @description Plan not found in the plans directory */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Error"];
+                };
+            };
+        };
+    };
+    exportPlan: {
+        parameters: {
+            query?: {
+                /** @description Include failed actions as well as successful actions. */
+                include_failed?: boolean;
+                /** @description Human-readable name stored in the exported plan. */
+                name?: string;
+                /** @description Description stored in the exported plan. */
+                description?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Exported plan YAML */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/yaml": string;
+                };
+            };
+            /** @description Failed to export the plan */
+            500: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/lib/components/app_menu.svelte
+++ b/frontend/src/lib/components/app_menu.svelte
@@ -4,16 +4,31 @@
     import { showToast, toaster } from '$lib/components/toaster';
     import { saveFile } from '$lib/io';
     import PlanPickerModal from '$lib/modals/PlanPickerModal.svelte';
+	import {
+		buildPlanDownload,
+		defaultPlanDescription,
+		defaultPlanName,
+		planFilename
+	} from '$lib/planDownload';
     import { getRanAPI } from '$lib/ran_api';
     import { timeline } from '$lib/stores/timelineStore.svelte';
     import type { PlanSummary } from '$lib/api';
 	import Icon from '@iconify/svelte';
 	import { Dialog, Menu, Portal } from '@skeletonlabs/skeleton-svelte';
+	import { tick } from 'svelte';
 
     const campaignState = getCampaignState();
     const ranAPI = getRanAPI();
 
     let showPlanPicker = $state(false);
+	let showSavePlan = $state(false);
+	let planName = $state('');
+	let planFileName = $state('');
+	let planFileNameOverridden = $state(false);
+	let planDescription = $state('');
+	let planIncludeFailed = $state(false);
+	let planSaving = $state(false);
+	let planNameInput: HTMLInputElement;
     let plansLoading = $state(false);
     let plans = $state<PlanSummary[]>([]);
 
@@ -42,6 +57,46 @@
         }
     }
 
+	async function savePlan() {
+		const name = planName.trim();
+		if (!name) return;
+		planSaving = true;
+		try {
+			const download = buildPlanDownload(
+				await ranAPI.ExportPlan(planIncludeFailed, name, planDescription),
+				name,
+				new Date(),
+				planFileName
+			);
+			saveFile(download.data, download.filename, download.mimeType);
+			showToast(
+				'Plan saved',
+				planIncludeFailed
+					? 'Successful and failed actions were exported in execution order.'
+					: 'Successful actions were exported in execution order.',
+				'success'
+			);
+			showSavePlan = false;
+		} catch (error) {
+			showToast('Failed to save plan', (error as Error).message, 'error');
+		} finally {
+			planSaving = false;
+		}
+	}
+
+	async function openSavePlan() {
+		const now = new Date();
+		planName = defaultPlanName(now);
+		planFileName = planFilename(planName);
+		planFileNameOverridden = false;
+		planDescription = defaultPlanDescription(now);
+		planIncludeFailed = false;
+		showSavePlan = true;
+		await tick();
+		planNameInput.focus();
+		planNameInput.select();
+	}
+
     function onMenuClick(event: { value: string }) {
         let { value } = event;
 
@@ -53,6 +108,9 @@
             case 'load_plan':
                 openPlanPicker();
                 break;
+			case 'save_plan':
+				openSavePlan();
+				break;
             case 'save_flow':
                 campaignState
                     .GetFlow()
@@ -92,6 +150,9 @@
                     <Menu.Item value="load_plan">
                         <Menu.ItemText>Load Plan</Menu.ItemText>
                     </Menu.Item>
+					<Menu.Item value="save_plan">
+						<Menu.ItemText>Save Plan</Menu.ItemText>
+					</Menu.Item>
                 </Menu.ItemGroup>
                 <Menu.Separator />
                 <Menu.ItemGroup>
@@ -120,4 +181,72 @@
             </Dialog.Content>
         </Dialog.Positioner>
     </Portal>
+</Dialog>
+
+<Dialog open={showSavePlan} onOpenChange={(e) => (showSavePlan = e.open)}>
+	<Portal>
+		<Dialog.Backdrop class="fixed inset-0 z-50 bg-surface-50-950/50" />
+		<Dialog.Positioner class="fixed inset-0 z-50 flex items-center justify-center">
+			<Dialog.Content class="card bg-surface-100-900 w-full max-w-sm space-y-4 p-5 shadow-xl">
+				<form
+					class="space-y-4"
+					onsubmit={(event) => {
+						event.preventDefault();
+						savePlan();
+					}}
+				>
+					<div>
+						<h2 class="text-lg font-semibold">Save Plan</h2>
+						<p class="text-surface-500 text-sm">Actions will be saved in execution order.</p>
+					</div>
+					<label class="block space-y-1">
+						<span class="text-sm font-medium">Plan name</span>
+						<input
+							class="input w-full"
+							type="text"
+							bind:this={planNameInput}
+							value={planName}
+							oninput={(event) => {
+								planName = event.currentTarget.value;
+								if (!planFileNameOverridden) planFileName = planFilename(planName);
+							}}
+							placeholder="My assessment plan"
+							required
+						/>
+					</label>
+					<label class="block space-y-1">
+						<span class="text-sm font-medium">Filename</span>
+						<input
+							class="input w-full"
+							type="text"
+							value={planFileName}
+							oninput={(event) => {
+								planFileName = event.currentTarget.value;
+								planFileNameOverridden = true;
+							}}
+							required
+						/>
+					</label>
+					<label class="block space-y-1">
+						<span class="text-sm font-medium">Description</span>
+						<textarea class="textarea w-full" rows="3" bind:value={planDescription}></textarea>
+					</label>
+					<label class="flex items-center gap-2 text-sm">
+						<input class="checkbox" type="checkbox" bind:checked={planIncludeFailed} />
+						<span>Include failed actions</span>
+					</label>
+					<div class="flex justify-end gap-2">
+						<button class="btn preset-tonal" type="button" onclick={() => (showSavePlan = false)}>Cancel</button>
+						<button
+							class="btn preset-filled-primary-500"
+							type="submit"
+							disabled={!planName.trim() || !planFileName.trim() || planSaving}
+						>
+							{planSaving ? 'Saving…' : 'Save'}
+						</button>
+					</div>
+				</form>
+			</Dialog.Content>
+		</Dialog.Positioner>
+	</Portal>
 </Dialog>

--- a/frontend/src/lib/planDownload.test.ts
+++ b/frontend/src/lib/planDownload.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	buildPlanDownload,
+	defaultPlanDescription,
+	defaultPlanName,
+	planFilename
+} from './planDownload';
+
+describe('buildPlanDownload', () => {
+	it('keeps plan YAML intact and creates a portable filename', () => {
+		const yaml = 'id: exported-plan\nsteps: []\n';
+		expect(buildPlanDownload(yaml, undefined, new Date('2026-08-24T09:10:11.123Z'))).toEqual({
+			data: yaml,
+			filename: 'execution-2026-08-24t09-10-11-123z.plan.yaml',
+			mimeType: 'application/yaml'
+		});
+	});
+
+	it('uses a filesystem-safe plan name', () => {
+		expect(buildPlanDownload('', 'My First / Plan').filename).toBe('my-first-plan.plan.yaml');
+	});
+
+	it('derives and normalizes plan filenames', () => {
+		expect(planFilename('My First / Plan')).toBe('my-first-plan.plan.yaml');
+		expect(buildPlanDownload('', 'Ignored', new Date(), 'Custom File').filename).toBe(
+			'custom-file.plan.yaml'
+		);
+	});
+
+	it('provides a timestamped default plan name', () => {
+		expect(defaultPlanName(new Date('2026-08-24T09:10:11.123Z'))).toBe(
+			'execution_2026-08-24T09-10-11-123Z'
+		);
+	});
+
+	it('provides a timestamped default description', () => {
+		expect(defaultPlanDescription(new Date('2026-08-24T09:10:11.123Z'))).toBe(
+			'Plan exported from campaign execution history on 2026-08-24T09:10:11.123Z.'
+		);
+	});
+});

--- a/frontend/src/lib/planDownload.ts
+++ b/frontend/src/lib/planDownload.ts
@@ -1,0 +1,40 @@
+export function defaultPlanName(now = new Date()) {
+	return `execution_${now.toISOString().replace(/[:.]/g, '-')}`;
+}
+
+export function defaultPlanDescription(now = new Date()) {
+	return `Plan exported from campaign execution history on ${now.toISOString()}.`;
+}
+
+export function planFilename(name: string) {
+	const safeName = name
+		.trim()
+		.replace(/\.plan\.ya?ml$/i, '')
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, '-')
+		.replace(/^-|-$/g, '');
+	return `${safeName || 'execution'}.plan.yaml`;
+}
+
+export function buildPlanDownload(
+	yaml: string,
+	name?: string,
+	now = new Date(),
+	filename?: string
+) {
+	return {
+		data: yaml,
+		filename: planFilename(filename || name || defaultPlanName(now)),
+		mimeType: 'application/yaml'
+	};
+}
+
+export function downloadPlan(yaml: string, name?: string) {
+	const download = buildPlanDownload(yaml, name);
+	const url = URL.createObjectURL(new Blob([download.data], { type: download.mimeType }));
+	const anchor = document.createElement('a');
+	anchor.href = url;
+	anchor.download = download.filename;
+	anchor.click();
+	URL.revokeObjectURL(url);
+}

--- a/frontend/src/lib/ran_api.ts
+++ b/frontend/src/lib/ran_api.ts
@@ -326,6 +326,15 @@ export class RanAPI {
 		if (error) throw new Error(error.error || 'Failed to load plan');
 		return data;
 	}
+
+	async ExportPlan(includeFailed = false, name?: string, description?: string): Promise<string> {
+		const { data, error } = await this.restClient.GET('/api/plans/export', {
+			params: { query: { include_failed: includeFailed, name, description } },
+			parseAs: 'text'
+		});
+		if (error) throw new Error('Failed to export plan');
+		return data;
+	}
 }
 
 // Singleton instance


### PR DESCRIPTION
## Summary
- export campaign execution history as reusable plan YAML
- add a Save Plan dialog with editable name, filename, description, and failed-action inclusion
- preserve execution order and expose the export endpoint through OpenAPI

## Verification
- `cargo test -p planner exporter --locked`
- `cargo check -p api -p app --locked`
- `pnpm --prefix frontend test -- --run`
- `pnpm --prefix frontend build`
- pre-commit formatting and clippy checks