### PR TITLE
Improve armory resizing and workload graph expansion

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -147,6 +147,22 @@
 		document.body.style.cursor = 'col-resize';
 	}
 
+	function onArmoryResizeKeydown(event: KeyboardEvent) {
+		const step = event.shiftKey ? 48 : 16;
+		const { min, max } = getResponsiveConstraints();
+
+		if (event.key === 'ArrowLeft') {
+			armoryWidth = Math.max(min, armoryWidth - step);
+		} else if (event.key === 'ArrowRight') {
+			armoryWidth = Math.min(max, armoryWidth + step);
+		} else {
+			return;
+		}
+
+		event.preventDefault();
+		saveArmoryPreferences();
+	}
+
 	function handleMouseMove(e: MouseEvent) {
 		if (!isResizing) return;
 		
@@ -632,11 +648,22 @@
 
 		<!-- Resize handle -->
 		{#if !armoryCollapsed}
-			<button
-				class="w-px shrink-0 cursor-col-resize border-0 p-0 bg-surface-200-800 hover:bg-primary-500 transition-colors"
-				onmousedown={startResize}
-				aria-label="Resize armory panel"
-			></button>
+			<div class="relative w-px shrink-0 bg-surface-200-800">
+				<div
+					class="absolute -left-1 top-0 z-10 h-full w-2 cursor-col-resize group"
+					role="slider"
+					aria-orientation="horizontal"
+					aria-label="Resize armory panel"
+					aria-valuemin={getResponsiveConstraints().min}
+					aria-valuemax={getResponsiveConstraints().max}
+					aria-valuenow={Math.round(armoryWidth)}
+					tabindex="0"
+					onmousedown={startResize}
+					onkeydown={onArmoryResizeKeydown}
+				>
+					<div class="absolute inset-y-0 left-1/2 w-0.5 -translate-x-1/2 bg-transparent group-hover:bg-primary-500 transition-colors"></div>
+				</div>
+			</div>
 		{/if}
 
 		<!-- Collapse/Expand button -->

--- a/frontend/src/routes/components/graph.svelte
+++ b/frontend/src/routes/components/graph.svelte
@@ -36,6 +36,7 @@
 	};
 	type Pos = { x: number; y: number };
 	type PosMap = Record<string, Pos>;
+	type ExpansionSnapshot = { right: number; visibleNodeIds: string[] };
 
 	let {
 		class: className = '',
@@ -96,6 +97,9 @@
 	let previousNodeIds: Set<string> = new Set();
 	let previousWorkloadCompoundIds: Set<string> = new Set();
 	let layoutParams: LayoutParams = $state({ ...DEFAULT_LAYOUT_PARAMS });
+	const expansionSnapshots = new Map<string, ExpansionSnapshot>();
+	let isRestoringCollapsedState = false;
+	const EXPANSION_GUTTER = 32;
 
 	function runElkLayout() {
 		if (!cy || cy.nodes().length === 0) return;
@@ -206,8 +210,13 @@
 			saveCollapsedNodes();
 		});
 
+		cy.on('expandcollapse.beforeexpand', (event) => {
+			if (!isRestoringCollapsedState) captureExpansionSnapshot(event.target);
+		});
+
 		cy.on('expandcollapse.afterexpand', (event) => {
 			handleAfterExpand(event.target);
+			if (!isRestoringCollapsedState) shiftNodesForExpansion(event.target);
 			saveCollapsedNodes();
 		});
 
@@ -301,6 +310,25 @@
 					// "element already exists" or "invalid ID" errors from the plugin's meta-nodes.
 					const collapsedNodes: string[] = [];
 					const ecApi = (window as any).cyExpandCollapseAPI;
+					let addedNodeIds = new Set<string>();
+					const recollapseNodes = () => {
+						if (!ecApi || collapsedNodes.length === 0) return;
+						new Set(collapsedNodes).forEach(id => {
+							const node = cy.getElementById(id);
+							if (node.length > 0 && node.isParent()) {
+								// The collapse plugin restores children by applying the parent's
+								// later movement delta. Seed newly added children at their parent
+								// so they follow that delta instead of restoring from (0, 0).
+								node.children().forEach((child: any) => {
+									if (!addedNodeIds.has(child.id())) return;
+									const position = node.position();
+									child.position(position);
+									positions[child.id()] = position;
+								});
+								try { ecApi.collapse(node); } catch (_) {}
+							}
+						});
+					};
 					// On initial mount, seed with IDs persisted from the previous navigation
 					let hasStoredCollapseState = false;
 					if (previousNodeIds.size === 0 && browser) {
@@ -321,10 +349,15 @@
 						});
 					}
 					if (ecApi) {
-						cy.nodes('.cy-expand-collapse-collapsed-node').forEach((n: any) => {
-							collapsedNodes.push(n.id());
-							try { ecApi.expand(n); } catch (_) {}
-						});
+						isRestoringCollapsedState = true;
+						try {
+							cy.nodes('.cy-expand-collapse-collapsed-node').forEach((n: any) => {
+								collapsedNodes.push(n.id());
+								try { ecApi.expand(n); } catch (_) {}
+							});
+						} finally {
+							isRestoringCollapsedState = false;
+						}
 					}
 
 					// Snapshot element IDs AFTER expansion so restored children are included
@@ -336,6 +369,7 @@
 					// Compute diffs: what to add, what to remove (guard against empty IDs)
 					const newEdgeIds = new Set<string>(edges.filter((e: any) => e.data.id).map((e: any) => e.data.id as string));
 					const nodesToAdd = nodes.filter((n: any) => n.data.id && !cyNodeIdSet.has(n.data.id as string));
+					addedNodeIds = new Set(nodesToAdd.map((node: any) => node.data.id as string));
 					const edgesToAdd = edges.filter((e: any) => e.data.id && !cyEdgeIdSet.has(e.data.id as string));
 
 					// Remove elements no longer in the graph
@@ -429,15 +463,7 @@
 					// extension preserves their style while they are hidden inside a workload.
 					applyCompromisedStyle(cy);
 
-					// Re-collapse nodes that were previously collapsed
-					if (ecApi && collapsedNodes.length > 0) {
-						new Set(collapsedNodes).forEach(id => {
-							const node = cy.getElementById(id);
-							if (node.length > 0 && node.isParent()) {
-								try { ecApi.collapse(node); } catch (_) {}
-							}
-						});
-					}
+					recollapseNodes();
 
 					// Only re-layout if there are new nodes or nodes were removed
 					if (hasNewNodes || hasFewerNodes || previousNodeIds.size === 0) {
@@ -892,6 +918,45 @@
 		// Re-apply informational edge filtering after expanding
 		hideRedundantInformationalEdges(cy);
 		applyCompromisedStyle(cy);
+	}
+
+	function captureExpansionSnapshot(node: any) {
+		const bounds = node.boundingBox();
+		expansionSnapshots.set(node.id(), {
+			right: bounds.x2,
+			visibleNodeIds: cy.nodes(':visible').map((n: any) => n.id())
+		});
+	}
+
+	function shiftNodesForExpansion(node: any) {
+		const snapshot = expansionSnapshots.get(node.id());
+		expansionSnapshots.delete(node.id());
+		if (!snapshot) return;
+
+		const addedWidth = node.boundingBox().x2 - snapshot.right;
+		if (addedWidth <= 0) return;
+
+		const shift = addedWidth + EXPANSION_GUTTER;
+		const candidates = snapshot.visibleNodeIds
+			.map((id) => cy.getElementById(id))
+			.filter((candidate: any) =>
+				candidate.length > 0 &&
+				candidate.visible() &&
+				candidate.id() !== node.id() &&
+				candidate.boundingBox().x1 >= snapshot.right
+			);
+		const candidateIds = new Set(candidates.map((candidate: any) => candidate.id()));
+		const nodesToShift = candidates.filter((candidate: any) =>
+			candidate.ancestors().every((ancestor: any) => !candidateIds.has(ancestor.id()))
+		);
+
+		cy.batch(() => {
+			nodesToShift.forEach((candidate: any) => {
+				const position = candidate.position();
+				candidate.position({ x: position.x + shift, y: position.y });
+			});
+		});
+		savePositions();
 	}
 
 	function syncWorkloadCompromisedState(cy: cytoscape.Core, graphNodes: Node[]) {

--- a/frontend/src/routes/components/graph_style.test.ts
+++ b/frontend/src/routes/components/graph_style.test.ts
@@ -40,4 +40,15 @@ describe('getK8sCredentialIcon', () => {
 		expect(dimmedStyle?.style.opacity).toBe(0.48);
 		expect(dimmedStyle?.style['text-opacity']).toBe(0.38);
 	});
+
+	it('hides a deployment icon while its compound is expanded', () => {
+		const styles = getGraphStyle() as Array<{ selector: string; style: Record<string, unknown> }>;
+		const deploymentIcon = styles.find((rule) => rule.selector === "node[kind='Deployment']");
+		const expandedCompound = styles.find((rule) =>
+			rule.selector.includes("node[kind='Deployment']:parent")
+		);
+
+		expect(deploymentIcon?.style['background-image']).toEqual(['/k8s/deploy.svg']);
+		expect(expandedCompound?.style['background-image']).toBe('none');
+	});
 });

--- a/frontend/src/routes/components/graph_style.ts
+++ b/frontend/src/routes/components/graph_style.ts
@@ -1,13 +1,13 @@
 import type cytoscape from "cytoscape";
+import { WORKLOAD_KINDS } from './workload_compounds';
 
-// the '{' prefix indicates a compound node that should not have an icon, if it's expanded
-const kind_svg_map = {
+const KIND_SVG_MAP = {
 	AppService: 'k8s/ep.svg',
 	Ingress: 'k8s/ing.svg',
 	Pod: 'k8s/pod.svg',
 	Container: 'k8s/crio.svg',
-	Daemonset: '{k8s/daemontset.svg',
-	Deployment: '{k8s/deploy.svg',
+	Daemonset: 'k8s/daemontset.svg',
+	Deployment: 'k8s/deploy.svg',
 	AbstractWorkload: 'k8s/deploy.svg',
 	ControlPlane: 'k8s/control-plane.svg',
 	ClusterNode: 'k8s/node.svg',
@@ -16,18 +16,18 @@ const kind_svg_map = {
 	ClusterRole: 'k8s/c-role.svg',
 	Service: 'k8s/svc.svg',
 	ConfigMap: 'k8s/cm.svg',
-	CronJob: '{k8s/cronjob.svg',
-	Job: '{k8s/job.svg',
+	CronJob: 'k8s/cronjob.svg',
+	Job: 'k8s/job.svg',
 	Group: 'k8s/group.svg',
 	RoleBinding: 'k8s/rb.svg',
 	ClusterRoleBinding: 'k8s/crb.svg',
 	Secret: 'k8s/secret.svg',
 	ServiceAccount: 'k8s/sa.svg',
-	Statefulset: '{k8s/sts.svg',
+	Statefulset: 'k8s/sts.svg',
 	User: 'k8s/user.svg',
 	Volume: 'k8s/vol.svg',
 	KubeApiServer: 'k8s/api.svg',
-	MicroService: '{k8s/pod_unlabeled.svg',
+	MicroService: 'k8s/pod_unlabeled.svg',
 	GCPBucket: 'gcp/storage.svg',
 	GCPServiceAccount: 'gcp/iam.svg',
 	GCPServiceAccountToken: 'gcp/iam.svg',
@@ -35,39 +35,43 @@ const kind_svg_map = {
 	GCPMetadataServer: 'gcp/compute_engine.svg',
 	UnknownSystem: 'system-dark.svg',
 
-	Cluster: '{k8s/k8s.svg',
-	Namespace: '{k8s/ns.svg'
+	Cluster: 'k8s/k8s.svg',
+	Namespace: 'k8s/ns.svg'
 };
+
+// Compounds show an icon only while collapsed. Once a compound is expanded,
+// its children provide the visual identity for the group.
+const COMPOUND_KINDS = new Set([
+	...WORKLOAD_KINDS,
+	'CronJob',
+	'Cluster',
+	'Namespace',
+	'MicroService'
+]);
+const expandedCompoundSelector = [...COMPOUND_KINDS]
+	.map((kind) => `node[kind='${kind}']:parent`)
+	.join(', ');
 
 export function getK8sCredentialIcon(isDark: boolean): string {
 	return isDark ? '/k8s/account-key-dark.svg' : '/k8s/account-key-light.svg';
 }
 
-function mapKindIcons(obj: Object) {
-	let new_entries = Object.entries(obj).map(([kind, img]) => {
-		let [icon, isCompound] = img.startsWith('{') ? [img.substring(1), true] : [img, false];
-		let kind_selector = `node[kind='${kind}']`;
-		let selector = isCompound
-			? `${kind_selector}.abstract, ${kind_selector}:childless`
-			: kind_selector;
+function mapKindIcons(obj: Record<string, string>) {
+	return Object.entries(obj).map(([kind, icon]) => {
 		return {
-			selector: selector,
+			selector: `node[kind='${kind}']`,
 			style: {
 				'background-image': [`/${icon}`]//, 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100%" height="100%" fill="red" fill-opacity="0.4"/></svg>'],
 			}
 		};
 	});
-
-	return new_entries;
-};
-
+}
 
 export function getGraphStyle(isDark: boolean = false) {
 	// Cytoscape does not accept the Mona theme's native oklch() color value.
 	const primary = '#600FED';
 	const textColor = isDark ? 'white' : 'black';
 	const selectedTextColor = textColor;
-
 
 	const graph_style = [
 		{
@@ -96,6 +100,12 @@ export function getGraphStyle(isDark: boolean = false) {
 				'border-style': 'dashed',
 				'background-color': 'steelblue',
 				'background-opacity': 0.2
+			}
+		},
+		{
+			selector: expandedCompoundSelector,
+			style: {
+				'background-image': 'none'
 			}
 		},
 		{
@@ -444,7 +454,7 @@ export function getGraphStyle(isDark: boolean = false) {
 			}
 		}
 	];
-	return [...mapKindIcons(kind_svg_map), ...graph_style] as any;
+	return [...mapKindIcons(KIND_SVG_MAP), ...graph_style] as any;
 }
 
 const redTintSvg = 'data:image/svg+xml,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100%" height="100%" fill="red" fill-opacity="0.4"/></svg>');


### PR DESCRIPTION
## Summary
- improve the armory resize handle with a wider hover target and keyboard resizing
- hide workload compound icons while expanded
- preserve child positions and shift downstream nodes locally when expanding compounds

## Verification
- `pnpm run check`
- `pnpm test` (63 tests passed)
- `git diff --check`