### PR TITLE
feat: read local kubeconfig via TTP instead of auto-seeding

### DIFF
--- a/armory/TTPs/CredentialAccess/read_local_kubeconfig.yaml
+++ b/armory/TTPs/CredentialAccess/read_local_kubeconfig.yaml
@@ -1,0 +1,22 @@
+id: read-local-kubeconfig
+name: Read Local Kubeconfig
+description: Read the kubeconfig from the machine running Ran to obtain its Kubernetes identity
+tactic: Credential Access
+techniques: ["Unsecured Credentials: Credentials In Files", "T1552.001"]
+preconditions:
+  kind: OperatorHost
+parameters:
+  PATH:
+    type: string
+    description: Explicit kubeconfig path; defaults to the path Ran was configured with
+    required: false
+    default: ""
+procedures:
+  - key: read-kubeconfig
+    command: c2.read_local_kubeconfig(${PATH})
+    isLocal: true
+effects:
+  - file:local-kubeconfig
+references:
+  - "https://attack.mitre.org/techniques/T1552/001/"
+  - "https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/"

--- a/crates/api/src/state_conversions.rs
+++ b/crates/api/src/state_conversions.rs
@@ -701,6 +701,7 @@ mod tests {
                     cluster_id,
                     provenance: origins,
                 }],
+                ..Default::default()
             },
         );
 
@@ -866,6 +867,7 @@ mod tests {
                     cluster_id,
                     provenance: BTreeSet::from([KnowledgeProvenance::Action]),
                 }],
+                ..Default::default()
             },
         );
 

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1169,10 +1169,31 @@ fn deduplicate_initial_clusters(
     aliases
 }
 
-fn build_initial_knowledge(
-    active: &ResolvedKubeconfig,
-    seeds: &[SeedKnowledgeConfig],
-) -> Result<InitialKnowledge> {
+/// Best-effort hostname of the machine running Ran, used as the display name of
+/// the operator-host entity so it is obvious which host holds the kubeconfig.
+/// Falls back to the `HOSTNAME`/`HOST` environment variables, then `None` (the
+/// campaign then uses a generic label).
+fn local_hostname() -> Option<String> {
+    let clean = |raw: String| {
+        let name = raw.trim().to_string();
+        (!name.is_empty()).then_some(name)
+    };
+
+    if let Ok(output) = std::process::Command::new("hostname").output() {
+        if output.status.success() {
+            if let Some(name) = clean(String::from_utf8_lossy(&output.stdout).into_owned()) {
+                return Some(name);
+            }
+        }
+    }
+
+    std::env::var("HOSTNAME")
+        .ok()
+        .and_then(&clean)
+        .or_else(|| std::env::var("HOST").ok().and_then(&clean))
+}
+
+fn build_initial_knowledge(seeds: &[SeedKnowledgeConfig]) -> Result<InitialKnowledge> {
     let mut initial = InitialKnowledge::default();
     let mut cluster_aliases: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
@@ -1212,32 +1233,6 @@ fn build_initial_knowledge(
             });
         }
     }
-
-    let active_cluster = K8sCluster::new(&active.cluster_name)
-        .with_context_name(Some(active.context_name.clone()))
-        .with_server(active.server.clone());
-    let active_cluster_idx = if let Some((idx, existing)) = initial
-        .clusters
-        .iter_mut()
-        .enumerate()
-        .find(|(_, entry)| clusters_match(&entry.cluster, &active_cluster))
-    {
-        if existing.cluster.server.is_none() {
-            existing.cluster.server = active_cluster.server.clone();
-        }
-        if existing.cluster.context_name.is_none() {
-            existing.cluster.context_name = active_cluster.context_name.clone();
-        }
-        existing.provenance.insert(KnowledgeProvenance::Operator);
-        idx
-    } else {
-        let idx = initial.clusters.len();
-        initial.clusters.push(InitialClusterKnowledge {
-            cluster: active_cluster,
-            provenance: single_origin(KnowledgeProvenance::Operator),
-        });
-        idx
-    };
 
     for seed in seeds {
         let SeedKnowledgeConfig::Credential(config) = seed else {
@@ -1312,34 +1307,11 @@ fn build_initial_knowledge(
         }
     }
 
-    let active_cluster_id = initial.clusters[active_cluster_idx].cluster.entity_id();
-    let cluster_aliases = deduplicate_initial_clusters(&mut initial);
-    let active_cluster_id = cluster_aliases
-        .get(&active_cluster_id)
-        .cloned()
-        .unwrap_or(active_cluster_id);
-
-    let active_name = active
-        .user_name
-        .as_deref()
-        .unwrap_or(&active.context_name)
-        .to_string();
-    let mut active_credential = credential_from_resolved(active, active_name);
-    active_credential.active = true;
-    if let Some(existing) = initial
-        .kubeconfigs
-        .iter_mut()
-        .find(|entry| credentials_match(&entry.credential, &active_credential))
-    {
-        existing.provenance.insert(KnowledgeProvenance::Operator);
-        existing.credential.active = true;
-    } else {
-        initial.kubeconfigs.push(InitialKubeconfigKnowledge {
-            credential: active_credential,
-            cluster_id: active_cluster_id,
-            provenance: single_origin(KnowledgeProvenance::Operator),
-        });
-    }
+    // Ran's own kubeconfig is no longer seeded here as the active identity.
+    // It is discovered at runtime via the Read Local Kubeconfig TTP, which
+    // targets the operator host and emits the active credential + cluster.
+    // Only scenario seeds (declared above) contribute initial knowledge.
+    deduplicate_initial_clusters(&mut initial);
 
     Ok(initial)
 }
@@ -1369,11 +1341,13 @@ users:
 "#;
 
     #[test]
-    fn seeded_active_kubeconfig_deduplicates_and_merges_provenance() {
+    fn seeded_kubeconfig_credential_registers_as_knowledge_only() {
+        // Ran's own kubeconfig is no longer auto-seeded as the active identity;
+        // it is discovered at runtime via the Read Local Kubeconfig TTP. Only
+        // scenario seeds contribute initial knowledge, and they are never active.
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("config");
         std::fs::write(&path, KUBECONFIG).unwrap();
-        let active = resolve_kubeconfig(&path, None).unwrap();
         let seeds = vec![
             SeedKnowledgeConfig::Cluster(SeedClusterConfig {
                 id: "target-cluster".into(),
@@ -1392,14 +1366,17 @@ users:
             }),
         ];
 
-        let initial = build_initial_knowledge(&active, &seeds).unwrap();
+        let initial = build_initial_knowledge(&seeds).unwrap();
         assert_eq!(initial.clusters.len(), 1);
         assert_eq!(
             initial.clusters[0].cluster.id.as_deref(),
             Some("target-cluster")
         );
         assert_eq!(initial.kubeconfigs.len(), 1);
-        assert!(initial.kubeconfigs[0].credential.active);
+        assert!(
+            !initial.kubeconfigs[0].credential.active,
+            "seed credentials are knowledge-only, never active"
+        );
         assert_eq!(
             initial.kubeconfigs[0]
                 .credential
@@ -1413,7 +1390,7 @@ users:
         );
         assert_eq!(
             initial.kubeconfigs[0].provenance,
-            BTreeSet::from([KnowledgeProvenance::Scenario, KnowledgeProvenance::Operator,])
+            BTreeSet::from([KnowledgeProvenance::Scenario])
         );
     }
 
@@ -1422,7 +1399,6 @@ users:
         let tmp = tempfile::tempdir().unwrap();
         let path = tmp.path().join("config");
         std::fs::write(&path, KUBECONFIG).unwrap();
-        let active = resolve_kubeconfig(&path, None).unwrap();
         let seeds = vec![
             SeedKnowledgeConfig::Cluster(SeedClusterConfig {
                 id: "target".into(),
@@ -1441,7 +1417,7 @@ users:
             }),
         ];
 
-        assert!(build_initial_knowledge(&active, &seeds).is_err());
+        assert!(build_initial_knowledge(&seeds).is_err());
     }
 }
 
@@ -1615,7 +1591,8 @@ pub async fn start(cfg: ServerConfig) -> Result<()> {
     let kubeconfig_path = kubeconfig_path_or_err(cfg.kubeconfig)?;
     let active_kubeconfig = resolve_kubeconfig(kubeconfig_path.clone(), None)?;
     let k8s = Client::from_resolved_kubeconfig(&active_kubeconfig).await?;
-    let initial_knowledge = build_initial_knowledge(&active_kubeconfig, &cfg.seed_knowledge)?;
+    let mut initial_knowledge = build_initial_knowledge(&cfg.seed_knowledge)?;
+    initial_knowledge.operator_host_name = local_hostname();
     let (armory, user_armory_dir) = load_armory(cfg.armory_dir)?;
     let kubetier_catalog = kubetier::Catalog::load(cfg.kubetier_catalog.as_deref())?;
     info!(
@@ -2099,7 +2076,8 @@ pub async fn trigger(cfg: TriggerConfig) -> Result<()> {
     let kubeconfig_path = kubeconfig_path_or_err(cfg.kubeconfig)?;
     let active_kubeconfig = resolve_kubeconfig(kubeconfig_path.clone(), None)?;
     let k8s = Client::from_resolved_kubeconfig(&active_kubeconfig).await?;
-    let initial_knowledge = build_initial_knowledge(&active_kubeconfig, &cfg.seed_knowledge)?;
+    let mut initial_knowledge = build_initial_knowledge(&cfg.seed_knowledge)?;
+    initial_knowledge.operator_host_name = local_hostname();
     let (armory, user_armory_dir) = load_armory(cfg.armory_dir)?;
 
     let external_parser: Option<Arc<dyn ExternalParser>> =

--- a/crates/app/tests/service.rs
+++ b/crates/app/tests/service.rs
@@ -164,6 +164,7 @@ async fn app_state_get_and_reset_campaign_without_cli() {
                 ]),
             }],
             kubeconfigs: Vec::new(),
+            ..Default::default()
         },
         campaign_events,
         std::path::PathBuf::from("plans"),

--- a/crates/c2/src/executor.rs
+++ b/crates/c2/src/executor.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
@@ -183,6 +184,10 @@ impl C2Executor {
     async fn execute_command(&self, cmd: &ExecTtp) -> TtpExecuted {
         let trimmed = cmd.procedure.command.trim_start();
 
+        if let Some(explicit_path) = parse_read_local_kubeconfig_command(trimmed) {
+            return self.read_local_kubeconfig(cmd, explicit_path);
+        }
+
         if let Some(namespace) = parse_kubeconfig_permission_command(trimmed) {
             let Some(k8s) = self.k8s.as_ref() else {
                 let reason = "no K8s client configured".to_string();
@@ -205,7 +210,10 @@ impl C2Executor {
                     session_connected: None,
                 },
                 Err(error) => {
-                    let reason = error.to_string();
+                    // Alternate formatting retains anyhow's source chain. In particular,
+                    // connection, TLS, and API errors would otherwise be hidden behind
+                    // the high-level SelfSubjectRulesReview context.
+                    let reason = format!("{error:#}");
                     TtpExecuted {
                         id: cmd.id.clone(),
                         success: false,
@@ -321,6 +329,38 @@ impl C2Executor {
         let mut event = self.select_backend(cmd).await.execute(cmd).await;
         event.session_connected = None;
         event
+    }
+
+    /// Read the kubeconfig from the machine running Ran and return its contents
+    /// as stdout. This is a local filesystem read on the operator host — it does
+    /// not touch the cluster. The path is, in order of preference: the explicit
+    /// `PATH` argument, the path the active client was configured with, then the
+    /// default kubeconfig location.
+    fn read_local_kubeconfig(&self, cmd: &ExecTtp, explicit_path: Option<String>) -> TtpExecuted {
+        let path = explicit_path
+            .filter(|value| !value.trim().is_empty())
+            .map(PathBuf::from)
+            .or_else(|| {
+                self.k8s
+                    .as_ref()
+                    .and_then(|k8s| k8s.kubeconfig_path().map(Path::to_path_buf))
+            })
+            .unwrap_or_else(k8s::default_kubeconfig_path);
+
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => TtpExecuted {
+                id: cmd.id.clone(),
+                success: true,
+                results: vec![contents],
+                exit_code: 0,
+                fail_reason: String::new(),
+                session_connected: None,
+            },
+            Err(error) => failed_result(
+                cmd,
+                &format!("failed to read kubeconfig at {}: {error}", path.display()),
+            ),
+        }
     }
 
     fn spawn_session_listener(
@@ -485,7 +525,10 @@ async fn open_kubectl_exec_session(
     let stream = k8s
         .open_exec_session(&ns, &pod, container.as_deref())
         .await
-        .map_err(|e| format!("kubectl exec open failed for {target_entity_id}: {e}"))?;
+        // Preserve anyhow's complete source chain. Kubernetes API status,
+        // transport, TLS, container-selection, and upgrade errors otherwise
+        // collapse into the generic open_exec_session context.
+        .map_err(|e| format!("kubectl exec open failed for {target_entity_id}: {e:#}"))?;
 
     let (rx, tx) = tokio::io::split(stream);
     let session = crate::ShellSession::from_rw(rx, tx, &backend_id);
@@ -534,6 +577,23 @@ fn parse_kubectl_exec_command(cmd: &str) -> Option<Option<String>> {
         Some(inner.trim().to_string())
     };
     Some(container)
+}
+
+/// Parse `c2.read_local_kubeconfig()` or `c2.read_local_kubeconfig(path)` from a
+/// procedure command string. Returns `Some(None)` for the no-path form (use the
+/// configured/default kubeconfig), `Some(Some(path))` when an explicit path is
+/// given, and `None` when the command doesn't match.
+fn parse_read_local_kubeconfig_command(cmd: &str) -> Option<Option<String>> {
+    let inner = cmd
+        .trim()
+        .strip_prefix("c2.read_local_kubeconfig(")?
+        .strip_suffix(')')?;
+    let path = if inner.trim().is_empty() {
+        None
+    } else {
+        Some(inner.trim().to_string())
+    };
+    Some(path)
 }
 
 /// Derive a deterministic session backend ID for a kubectl exec session.
@@ -683,7 +743,10 @@ mod tests {
     use armory::{Procedure, Ttp};
     use tokio::sync::{mpsc, Semaphore};
 
-    use super::{parse_kubeconfig_permission_command, parse_kubectl_exec_command};
+    use super::{
+        parse_kubeconfig_permission_command, parse_kubectl_exec_command,
+        parse_read_local_kubeconfig_command,
+    };
     use super::{C2Backend, C2Event, C2Manager, ExecTtp, TtpExecuted, BUILTIN_C2_ID};
 
     struct MockBackend {
@@ -719,6 +782,26 @@ mod tests {
             Some(Some("debug".to_string()))
         );
         assert_eq!(parse_kubectl_exec_command("kubectl exec pod -- true"), None);
+    }
+
+    #[test]
+    fn parses_read_local_kubeconfig_control_command() {
+        assert_eq!(
+            parse_read_local_kubeconfig_command("c2.read_local_kubeconfig()"),
+            Some(None)
+        );
+        assert_eq!(
+            parse_read_local_kubeconfig_command("c2.read_local_kubeconfig(/home/op/.kube/config)"),
+            Some(Some("/home/op/.kube/config".to_string()))
+        );
+        assert_eq!(
+            parse_read_local_kubeconfig_command("  c2.read_local_kubeconfig()  "),
+            Some(None)
+        );
+        assert_eq!(
+            parse_read_local_kubeconfig_command("cat ~/.kube/config"),
+            None
+        );
     }
 
     #[async_trait::async_trait]

--- a/crates/campaign/src/campaign/state.rs
+++ b/crates/campaign/src/campaign/state.rs
@@ -62,6 +62,10 @@ pub struct InitialKubeconfigKnowledge {
 pub struct InitialKnowledge {
     pub clusters: Vec<InitialClusterKnowledge>,
     pub kubeconfigs: Vec<InitialKubeconfigKnowledge>,
+    /// Display name for the operator host (the machine running Ran). When set,
+    /// this is the local machine's hostname so it is obvious which host holds
+    /// the kubeconfig. Defaults to a generic label when unknown.
+    pub operator_host_name: Option<String>,
 }
 
 impl Campaign {
@@ -76,6 +80,7 @@ impl Campaign {
                     provenance: origins,
                 }],
                 kubeconfigs: Vec::new(),
+                ..Default::default()
             },
         )
     }
@@ -87,36 +92,38 @@ impl Campaign {
         let mut entities = EntityStore::default();
         let mut graph = KnowledgeGraph::new();
         let mut knowledge_provenance = KnowledgeProvenanceStore::default();
-        let operator_host_id = initial
-            .kubeconfigs
-            .iter()
-            .any(|entry| entry.credential.active)
-            .then(|| {
-                let operator_host = OperatorHost::new("Operator host");
-                let id = operator_host.entity_id();
-                entities.insert_typed(operator_host);
-                graph.ensure_node(id.clone());
-                knowledge_provenance.add_entity(id.clone(), KnowledgeProvenance::Operator);
-                id
-            });
+        // The operator host (the machine running Ran) always exists: it is the
+        // target of the Read Local Kubeconfig TTP, which is how Ran's own
+        // Kubernetes identity is now discovered rather than seeded at bootstrap.
+        let operator_host_id = {
+            let host_name = initial
+                .operator_host_name
+                .clone()
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or_else(|| "Operator host".to_string());
+            let operator_host = OperatorHost::new(host_name);
+            let id = operator_host.entity_id();
+            entities.insert_typed(operator_host);
+            graph.ensure_node(id.clone());
+            knowledge_provenance.add_entity(id.clone(), KnowledgeProvenance::Operator);
+            id
+        };
 
         let c2 = C2Server::new(ran_name.into());
         let c2_id = c2.entity_id();
         entities.insert_typed(c2);
         graph.ensure_node(c2_id.clone());
         knowledge_provenance.add_entity(c2_id.clone(), KnowledgeProvenance::Operator);
-        if let Some(operator_host_id) = &operator_host_id {
-            let host_contains_c2 = Contains::new(operator_host_id.0.clone(), c2_id.0);
-            graph.insert_edge(
-                host_contains_c2.source_id(),
-                host_contains_c2.target_id(),
-                cortex::edge_data_for(host_contains_c2.relation_name(), None, None),
-            );
-            knowledge_provenance.add_relation(
-                RelationProvenanceKey::from_relation(&host_contains_c2),
-                KnowledgeProvenance::Operator,
-            );
-        }
+        let host_contains_c2 = Contains::new(operator_host_id.0.clone(), c2_id.0);
+        graph.insert_edge(
+            host_contains_c2.source_id(),
+            host_contains_c2.target_id(),
+            cortex::edge_data_for(host_contains_c2.relation_name(), None, None),
+        );
+        knowledge_provenance.add_relation(
+            RelationProvenanceKey::from_relation(&host_contains_c2),
+            KnowledgeProvenance::Operator,
+        );
 
         for entry in initial.clusters {
             let cluster_id = entry.cluster.entity_id();
@@ -133,7 +140,7 @@ impl Campaign {
             let is_active = entry.credential.active;
             entities.insert_typed(entry.credential);
             graph.ensure_node(credential_id.clone());
-            if let (true, Some(operator_host_id)) = (is_active, &operator_host_id) {
+            if is_active {
                 let contains = Contains::new(operator_host_id.0.clone(), credential_id.0.clone());
                 graph.insert_edge(
                     contains.source_id(),
@@ -779,6 +786,7 @@ mod planner_helper_tests {
                 cluster_id: cluster_id.clone(),
                 provenance: origins.clone(),
             }],
+            ..Default::default()
         };
         let mut campaign = Campaign::bootstrap_with_knowledge("test", initial.clone());
 

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -72,16 +72,24 @@ fn bootstrap_without_local_credential_contains_c2_and_cluster_entities() {
             .with_server(Some("https://127.0.0.1:6443".to_string())),
     );
 
-    assert_eq!(campaign.entity_count(), 2);
-    assert!(!campaign
+    // The operator host always exists now — it is the target of the Read Local
+    // Kubeconfig TTP that establishes Ran's identity — so even without a local
+    // credential we have OperatorHost + C2 + cluster.
+    assert_eq!(campaign.entity_count(), 3);
+    let operator_host_id = EntityId::new("system/operator-host");
+    assert!(campaign
         .entities
-        .contains::<OperatorHost>(&EntityId::new("system/operator-host")));
+        .contains::<OperatorHost>(&operator_host_id));
     assert!(campaign
         .entities
         .contains::<C2Server>(&EntityId::new(BUILTIN_C2_ID)));
     assert!(campaign
         .entities
         .contains::<K8sCluster>(&EntityId::new("k8s/cluster/dev-cluster")));
+    assert!(campaign
+        .graph
+        .targets_of(&operator_host_id, "contains")
+        .contains(&&EntityId::new(BUILTIN_C2_ID)));
 }
 
 #[test]

--- a/crates/campaign/src/output_parsers/file.rs
+++ b/crates/campaign/src/output_parsers/file.rs
@@ -1,6 +1,6 @@
 use super::ParserOutput;
 use crate::FactsUpdate;
-use ran_domain::{Entity, K8sCredential, Uses};
+use ran_domain::{AuthenticatesTo, Contains, Entity, K8sCluster, K8sCredential, Namespace, Uses};
 
 // ---------------------------------------------------------------------------
 // Path extraction
@@ -123,6 +123,111 @@ pub(super) fn parse_file_kubeconfig(stdout: &str, source_id: &str) -> ParserOutp
     ParserOutput::SuccessWithFacts(facts, detail)
 }
 
+/// Parse the kubeconfig read from the machine running Ran and emit the
+/// **active** Kubernetes identity plus its cluster.
+///
+/// Unlike [`parse_file_kubeconfig`] (which records a knowledge-only credential
+/// discovered on some remote system), this reproduces the graph shape Ran used
+/// to seed at bootstrap for its own kubeconfig:
+/// - a `K8sCredential` with `active = true`
+/// - the `K8sCluster` it authenticates to
+/// - `AuthenticatesTo(credential → cluster)`
+/// - `Contains(source_id → credential)` where `source_id` is the operator host
+/// - when the context declares a default namespace, the `Namespace` entity and
+///   `Contains(cluster → namespace)`
+///
+/// `source_id` is the operator-host entity (`system/operator-host`). When empty
+/// the containment relation is skipped.
+///
+/// TODO(tech-debt): this duplicates most of [`parse_file_kubeconfig`]. Kubeconfig
+/// parsing is format-invariant — the API server and user identity are inferred
+/// the same way regardless of origin. The only real distinction (local/active
+/// vs in-cluster discovery) is a *provenance* concern and should drive `active`
+/// and cluster-graph emission from a single parser, rather than being encoded as
+/// a separate effect + function. See memory
+/// `project_kubeconfig_effect_provenance_debt`.
+///
+/// Returns:
+/// - `SuccessWithFacts` — active credential, cluster, and relations emitted
+/// - `KnownFailure` — empty content
+/// - `UnknownFormat` — non-empty content that fails to resolve to a cluster/user
+pub(super) fn parse_local_kubeconfig(stdout: &str, source_id: &str) -> ParserOutput {
+    if stdout.trim().is_empty() {
+        return ParserOutput::KnownFailure("empty stdout for file:local-kubeconfig".to_string());
+    }
+
+    let (mut cred, cluster_name) = match credential_from_kubeconfig(stdout) {
+        Some(c) => c,
+        None => {
+            return ParserOutput::UnknownFormat(
+                "could not extract cluster/user from local kubeconfig YAML".to_string(),
+            )
+        }
+    };
+    cred.active = true;
+    // A raw server URL is an unfriendly display name / id. Prefer the context
+    // name (what kubectl shows), then the user name, then fall back to the
+    // endpoint that `K8sCredential::new` defaulted to.
+    if let Some(label) = cred
+        .context_name
+        .clone()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            cred.user_name
+                .clone()
+                .filter(|value| !value.trim().is_empty())
+        })
+    {
+        cred.name = label;
+    }
+
+    let mut cluster = K8sCluster::new(&cluster_name);
+    cluster.context_name = cred.context_name.clone();
+    if !cred.endpoint.is_empty() {
+        cluster.server = Some(cred.endpoint.clone());
+    }
+    let cluster_id = cluster.entity_id().0.clone();
+    let cred_id = cred.entity_id().0.clone();
+    let default_namespace = cred.default_namespace.clone();
+
+    let detail = format!(
+        "established active K8sCredential for endpoint '{}' (context={}, cluster={}, default_namespace={}, token={}, cert={})",
+        if cred.endpoint.is_empty() {
+            "unknown"
+        } else {
+            &cred.endpoint
+        },
+        cred.context_name.as_deref().unwrap_or("unknown"),
+        cluster_name,
+        default_namespace.as_deref().unwrap_or("none"),
+        cred.token.is_some(),
+        cred.cert_data.is_some(),
+    );
+
+    let mut facts = FactsUpdate::default();
+    facts.new_entities.push(Box::new(cred));
+    facts.new_entities.push(Box::new(cluster));
+    facts.new_relations.push(Box::new(AuthenticatesTo::new(
+        cred_id.clone(),
+        cluster_id.clone(),
+    )));
+    if !source_id.is_empty() {
+        facts
+            .new_relations
+            .push(Box::new(Contains::new(source_id, cred_id)));
+    }
+    if let Some(namespace_name) = default_namespace {
+        let namespace = Namespace::new(namespace_name);
+        let namespace_id = namespace.entity_id().0.clone();
+        facts.new_entities.push(Box::new(namespace));
+        facts
+            .new_relations
+            .push(Box::new(Contains::new(cluster_id, namespace_id)));
+    }
+
+    ParserOutput::SuccessWithFacts(facts, detail)
+}
+
 /// Parse a `file:content(path)` effect.
 ///
 /// Always records `path` in the caller's system entity `files` list (via the
@@ -164,7 +269,7 @@ pub(super) fn parse_file_content(stdout: &str, path: &str, source_id: &str) -> P
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ran_domain::{K8sCredential, Uses};
+    use ran_domain::{AuthenticatesTo, Contains, K8sCluster, K8sCredential, Relation, Uses};
 
     // Minimal valid kubeconfig YAML with token auth.
     const KUBECONFIG_TOKEN: &str = r#"apiVersion: v1
@@ -368,5 +473,102 @@ users:
         // Regression: paths with colons shouldn't confuse the extractor.
         let effect = "file:content(/var/run/secrets/token)";
         assert_eq!(extract_path(effect), Some("/var/run/secrets/token"));
+    }
+
+    // -----------------------------------------------------------------------
+    // parse_local_kubeconfig
+    // -----------------------------------------------------------------------
+
+    const OPERATOR_HOST: &str = "system/operator-host";
+
+    #[test]
+    fn parse_local_kubeconfig_marks_credential_active_and_emits_cluster() {
+        let ParserOutput::SuccessWithFacts(facts, _) =
+            parse_local_kubeconfig(KUBECONFIG_TOKEN, OPERATOR_HOST)
+        else {
+            panic!("expected SuccessWithFacts");
+        };
+
+        let cred = facts
+            .new_entities
+            .iter()
+            .find_map(|e| e.as_any().downcast_ref::<K8sCredential>())
+            .expect("credential entity emitted");
+        assert!(
+            cred.active,
+            "local kubeconfig establishes the active identity"
+        );
+        assert_eq!(cred.endpoint, "https://10.96.0.1:6443");
+        let cred_id = cred.entity_id().0.clone();
+
+        let cluster = facts
+            .new_entities
+            .iter()
+            .find_map(|e| e.as_any().downcast_ref::<K8sCluster>())
+            .expect("cluster entity emitted");
+        assert_eq!(cluster.server.as_deref(), Some("https://10.96.0.1:6443"));
+        let cluster_id = cluster.entity_id().0.clone();
+
+        // AuthenticatesTo(credential -> cluster)
+        assert!(facts.new_relations.iter().any(|r| {
+            r.as_any()
+                .downcast_ref::<AuthenticatesTo>()
+                .is_some_and(|a| a.source_id().0 == cred_id && a.target_id().0 == cluster_id)
+        }));
+
+        // Contains(operator-host -> credential)
+        assert!(facts.new_relations.iter().any(|r| {
+            r.as_any()
+                .downcast_ref::<Contains>()
+                .is_some_and(|c| c.source_id().0 == OPERATOR_HOST && c.target_id().0 == cred_id)
+        }));
+    }
+
+    #[test]
+    fn parse_local_kubeconfig_names_credential_by_context_not_server() {
+        let ParserOutput::SuccessWithFacts(facts, _) =
+            parse_local_kubeconfig(KUBECONFIG_TOKEN, OPERATOR_HOST)
+        else {
+            panic!("expected SuccessWithFacts");
+        };
+        let cred = facts
+            .new_entities
+            .iter()
+            .find_map(|e| e.as_any().downcast_ref::<K8sCredential>())
+            .expect("credential entity emitted");
+        // KUBECONFIG_TOKEN's current context is `test-context`.
+        assert_eq!(cred.entity_name(), "test-context");
+        assert_ne!(cred.entity_name(), cred.endpoint);
+        assert_eq!(cred.entity_id().0, "k8s/credential/test-context");
+    }
+
+    #[test]
+    fn parse_local_kubeconfig_emits_default_namespace_containment() {
+        let ParserOutput::SuccessWithFacts(facts, _) =
+            parse_local_kubeconfig(KUBECONFIG_TOKEN, OPERATOR_HOST)
+        else {
+            panic!("expected SuccessWithFacts");
+        };
+        // KUBECONFIG_TOKEN declares namespace: default on its context.
+        assert!(facts
+            .new_entities
+            .iter()
+            .any(|e| e.as_any().downcast_ref::<Namespace>().is_some()));
+    }
+
+    #[test]
+    fn parse_local_kubeconfig_empty_stdout_is_known_failure() {
+        assert!(matches!(
+            parse_local_kubeconfig("", OPERATOR_HOST),
+            ParserOutput::KnownFailure(_)
+        ));
+    }
+
+    #[test]
+    fn parse_local_kubeconfig_malformed_is_unknown_format() {
+        assert!(matches!(
+            parse_local_kubeconfig("{not: yaml: at: all:", OPERATOR_HOST),
+            ParserOutput::UnknownFormat(_)
+        ));
     }
 }

--- a/crates/campaign/src/output_parsers/mod.rs
+++ b/crates/campaign/src/output_parsers/mod.rs
@@ -163,6 +163,7 @@ pub fn parse_output_effect(
                 let is_known = normalized.starts_with("sys.hasfile(")
                     || normalized.starts_with("file:content(")
                     || normalized == "file:kubeconfig"
+                    || normalized == "file:local-kubeconfig"
                     || normalized == "nmap"
                     || normalized == "k8s.selfsubjectrulesreview"
                     || normalized == "sys.node-name"
@@ -240,6 +241,20 @@ pub fn parse_output_effect(
     } else if normalized == "file:kubeconfig" {
         let source_id = resolve_target_id(campaign, cmd);
         file::parse_file_kubeconfig(stdout, source_id.as_deref().unwrap_or(""))
+    } else if normalized == "file:local-kubeconfig" {
+        // Ran's own kubeconfig, read from the operator host. The target is the
+        // OperatorHost entity, which is not a SystemEntity, so pass its id
+        // directly rather than via resolve_target_id (which resolves only
+        // system entities).
+        //
+        // TODO(tech-debt): this second kubeconfig effect duplicates
+        // `file:kubeconfig`. Kubeconfig structure is always the same; the only
+        // real difference is that this one came from *outside* the cluster
+        // (Ran's operator host) vs in-cluster discovery. That local-vs-in-cluster
+        // distinction should be established via provenance (target/source is the
+        // operator host), not a separate effect + parser. Collapse into one
+        // parser driven by provenance and drop `parse_local_kubeconfig`.
+        file::parse_local_kubeconfig(stdout, &cmd.target_id)
     } else if normalized == "sys.node-name" {
         parse_sys_node_name(campaign, cmd, stdout)
     } else {

--- a/crates/k8s/src/lib.rs
+++ b/crates/k8s/src/lib.rs
@@ -249,6 +249,7 @@ fn pod_to_running_pod(pod: &Pod) -> Option<RunningPod> {
 pub struct Client {
     client: KubeClient,
     kubeconfig_path: Option<PathBuf>,
+    api_server: String,
 }
 
 fn build_authenticated_http_request(request: &serde_json::Value) -> Result<Request<Vec<u8>>> {
@@ -323,7 +324,18 @@ impl Client {
         Ok(Self {
             client,
             kubeconfig_path: resolved.source_path.clone(),
+            api_server: resolved
+                .server
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string()),
         })
+    }
+
+    /// Path to the kubeconfig file that backs this client, when it is
+    /// file-backed. Used by local-host TTPs (e.g. Read Local Kubeconfig) to
+    /// read the same kubeconfig Ran was configured with.
+    pub fn kubeconfig_path(&self) -> Option<&std::path::Path> {
+        self.kubeconfig_path.as_deref()
     }
 
     pub async fn get_running_pods(&self, namespace: Option<&str>) -> Result<Vec<RunningPod>> {
@@ -360,8 +372,8 @@ impl Client {
             .await
             .with_context(|| {
                 format!(
-                    "failed to review kubeconfig permissions in namespace '{}'",
-                    namespace
+                    "could not complete SelfSubjectRulesReview request to Kubernetes API server '{}' for namespace '{}'",
+                    self.api_server, namespace
                 )
             })?;
         serde_json::to_string(&response)


### PR DESCRIPTION
Ran no longer auto-seeds its own kubeconfig as the active identity at bootstrap. Instead a new Credential Access TTP, Read Local Kubeconfig (c2.read_local_kubeconfig), targets the operator host and emits the active K8sCredential + cluster via the new file:local-kubeconfig effect. The campaign now boots knowing only Ran itself (OperatorHost + C2); cluster-facing TTPs become applicable once the local kubeconfig is read.

The operator host is now always present and named after the local machine's hostname so it is obvious which host holds the kubeconfig. The discovered credential is named by its context (falling back to user, then endpoint) instead of the raw server URL.

The live transport Client is still built at startup (knowledge-only change).

Tech debt logged: file:local-kubeconfig duplicates file:kubeconfig; the local-vs-in-cluster distinction should be driven by provenance from a single parser.
