### PR TITLE
Read local kubeconfig via TTP + switchable multi-context identities

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -1193,6 +1193,46 @@ fn local_hostname() -> Option<String> {
         .or_else(|| std::env::var("HOST").ok().and_then(&clean))
 }
 
+/// Build a Kubernetes client for every context in the local kubeconfig, keyed
+/// by the `K8sCredential` entity id the output parser derives for that context
+/// (`campaign::credential_from_resolved`). This lets "Authenticate As" a
+/// non-current context actually authenticate as that identity. Contexts whose
+/// client cannot be constructed (e.g. exec/auth-provider plugins) are skipped —
+/// they remain visible as knowledge but are not switchable.
+async fn build_k8s_client_registry(
+    kubeconfig_path: &std::path::Path,
+) -> std::collections::HashMap<String, Client> {
+    let mut registry = std::collections::HashMap::new();
+    let contexts = match k8s::resolve_all_kubeconfig_contexts_from_path(kubeconfig_path) {
+        Ok(contexts) => contexts,
+        Err(error) => {
+            warn!(%error, "failed to enumerate kubeconfig contexts; only the current context will be usable");
+            return registry;
+        }
+    };
+    for resolved in &contexts {
+        match Client::from_resolved_kubeconfig(resolved).await {
+            Ok(client) => {
+                let id = campaign::credential_from_resolved(resolved).entity_id().0;
+                registry.insert(id, client);
+            }
+            Err(error) => {
+                warn!(
+                    context = %resolved.context_name,
+                    %error,
+                    "failed to build client for kubeconfig context; identity will not be switchable"
+                );
+            }
+        }
+    }
+    info!(
+        contexts = contexts.len(),
+        clients = registry.len(),
+        "built per-context Kubernetes client registry"
+    );
+    registry
+}
+
 fn build_initial_knowledge(seeds: &[SeedKnowledgeConfig]) -> Result<InitialKnowledge> {
     let mut initial = InitialKnowledge::default();
     let mut cluster_aliases: std::collections::HashMap<String, usize> =
@@ -1621,7 +1661,8 @@ pub async fn start(cfg: ServerConfig) -> Result<()> {
         initial_knowledge.clone(),
     )));
 
-    let (c2_handle, c2_events, c2_manager) = C2Manager::new(256, k8s.clone());
+    let k8s_client_registry = build_k8s_client_registry(&kubeconfig_path).await;
+    let (c2_handle, c2_events, c2_manager) = C2Manager::new(256, k8s.clone(), k8s_client_registry);
     let campaign_events = CampaignEventBus::new(256);
 
     tokio::spawn(c2_manager.run());
@@ -2093,7 +2134,8 @@ pub async fn trigger(cfg: TriggerConfig) -> Result<()> {
         initial_knowledge,
     )));
 
-    let (c2_handle, c2_events, c2_manager) = C2Manager::new(256, k8s);
+    let k8s_client_registry = build_k8s_client_registry(&kubeconfig_path).await;
+    let (c2_handle, c2_events, c2_manager) = C2Manager::new(256, k8s, k8s_client_registry);
     let campaign_events = CampaignEventBus::new(256);
 
     // Subscribe before spawning the processor so no events are dropped.

--- a/crates/app/tests/service.rs
+++ b/crates/app/tests/service.rs
@@ -129,7 +129,8 @@ async fn app_state_get_and_reset_campaign_without_cli() {
         campaign_cluster.clone(),
     )));
 
-    let (c2_handle, c2_events, c2_manager) = c2::C2Manager::new(32, k8s.clone());
+    let (c2_handle, c2_events, c2_manager) =
+        c2::C2Manager::new(32, k8s.clone(), std::collections::HashMap::new());
     let campaign_events = campaign::CampaignEventBus::new(32);
 
     tokio::spawn(c2_manager.run());

--- a/crates/c2/src/executor.rs
+++ b/crates/c2/src/executor.rs
@@ -67,7 +67,24 @@ pub struct C2Manager {
 struct C2Executor {
     event_bus: C2EventBus,
     backends: Backends,
+    /// Default Kubernetes client (the kubeconfig's current context).
     k8s: Option<Client>,
+    /// Per-identity Kubernetes clients keyed by K8sCredential entity id
+    /// (`k8s/credential/<slug>`). Populated from every context in the local
+    /// kubeconfig so that "Authenticate As" a non-current context actually
+    /// authenticates as that identity instead of silently using the default.
+    k8s_clients: Arc<HashMap<String, Client>>,
+}
+
+impl C2Executor {
+    /// Select the Kubernetes client for an action's authentication identity,
+    /// falling back to the default (current-context) client when the identity
+    /// has no dedicated client (e.g. a discovered credential).
+    fn client_for(&self, auth_identity_id: Option<&str>) -> Option<&Client> {
+        auth_identity_id
+            .and_then(|id| self.k8s_clients.get(id))
+            .or(self.k8s.as_ref())
+    }
 }
 
 #[async_trait]
@@ -83,7 +100,11 @@ impl C2Backend for BuiltinC2 {
 }
 
 impl C2Manager {
-    pub fn new(buffer_size: usize, k8s: Client) -> (C2Handle, C2EventBus, Self) {
+    pub fn new(
+        buffer_size: usize,
+        k8s: Client,
+        k8s_clients: HashMap<String, Client>,
+    ) -> (C2Handle, C2EventBus, Self) {
         let (cmd_tx, cmd_rx) = mpsc::channel(buffer_size);
         let event_bus = C2EventBus::new(buffer_size);
 
@@ -105,6 +126,7 @@ impl C2Manager {
                     event_bus,
                     backends,
                     k8s: Some(k8s),
+                    k8s_clients: Arc::new(k8s_clients),
                 },
             },
         )
@@ -131,6 +153,7 @@ impl C2Manager {
                     event_bus,
                     backends,
                     k8s: None,
+                    k8s_clients: Arc::new(HashMap::new()),
                 },
             },
         )
@@ -189,7 +212,7 @@ impl C2Executor {
         }
 
         if let Some(namespace) = parse_kubeconfig_permission_command(trimmed) {
-            let Some(k8s) = self.k8s.as_ref() else {
+            let Some(k8s) = self.client_for(cmd.auth_identity_id.as_deref()) else {
                 let reason = "no K8s client configured".to_string();
                 return TtpExecuted {
                     id: cmd.id.clone(),
@@ -263,7 +286,7 @@ impl C2Executor {
             .as_deref()
             .is_some_and(|identity| identity.starts_with("k8s/credential/"))
         {
-            let Some(k8s) = self.k8s.as_ref() else {
+            let Some(k8s) = self.client_for(cmd.auth_identity_id.as_deref()) else {
                 return failed_result(cmd, "no active Kubernetes client configured");
             };
             let result = if let Some(request) = cmd.procedure.k8s_request.as_ref() {

--- a/crates/campaign/src/campaign/execution.rs
+++ b/crates/campaign/src/campaign/execution.rs
@@ -83,14 +83,23 @@ fn normalise_exec_hint(exec_system_id: Option<&str>, target_id: &str) -> Option<
 
 #[derive(Debug, Clone)]
 enum ResolvedK8sAuth {
-    ServiceAccount { id: String, token: String },
-    Kubeconfig { id: String },
+    ServiceAccount {
+        id: String,
+        token: String,
+    },
+    Kubeconfig {
+        id: String,
+        /// The kubeconfig context this credential selects. Emitted as
+        /// `--context` so kubectl targets the chosen identity rather than the
+        /// file's current-context.
+        context: Option<String>,
+    },
 }
 
 impl ResolvedK8sAuth {
     fn id(&self) -> &str {
         match self {
-            Self::ServiceAccount { id, .. } | Self::Kubeconfig { id } => id,
+            Self::ServiceAccount { id, .. } | Self::Kubeconfig { id, .. } => id,
         }
     }
 
@@ -99,7 +108,13 @@ impl ResolvedK8sAuth {
             Self::ServiceAccount { token, .. } => {
                 format!("--token {}", shell_words::quote(token))
             }
-            Self::Kubeconfig { .. } => "--kubeconfig \"$KUBECONFIG\"".to_string(),
+            Self::Kubeconfig { context, .. } => {
+                let mut arg = "--kubeconfig \"$KUBECONFIG\"".to_string();
+                if let Some(context) = context.as_deref().filter(|c| !c.trim().is_empty()) {
+                    arg.push_str(&format!(" --context {}", shell_words::quote(context)));
+                }
+                arg
+            }
         }
     }
 
@@ -904,15 +919,21 @@ impl Campaign {
                     id: identity_id,
                     token: token.to_string(),
                 })
-            } else if self
+            } else if let Some(context) = self
                 .entities
                 .find::<K8sCredential>(&entity_id)
-                .is_some_and(|credential| credential.active)
+                .filter(|credential| {
+                    credential.active || self.is_operator_host_credential(&entity_id)
+                })
+                .map(|credential| credential.context_name.clone())
             {
-                Some(ResolvedK8sAuth::Kubeconfig { id: identity_id })
+                Some(ResolvedK8sAuth::Kubeconfig {
+                    id: identity_id,
+                    context,
+                })
             } else {
                 return Err(ExecuteActionError::InvalidInput(format!(
-                    "authentication identity '{}' is neither a captured ServiceAccount nor the active K8sCredential",
+                    "authentication identity '{}' is neither a captured ServiceAccount nor a usable local K8sCredential",
                     identity_id
                 )));
             }
@@ -2676,4 +2697,30 @@ fn ground_binary_in_cmd(
     }
 
     cmd.to_string()
+}
+
+#[cfg(test)]
+mod k8s_auth_tests {
+    use super::ResolvedK8sAuth;
+
+    #[test]
+    fn kubeconfig_auth_grounds_context_flag() {
+        let auth = ResolvedK8sAuth::Kubeconfig {
+            id: "k8s/credential/staging".to_string(),
+            context: Some("staging".to_string()),
+        };
+        assert_eq!(
+            auth.kubectl_arg(),
+            "--kubeconfig \"$KUBECONFIG\" --context staging"
+        );
+    }
+
+    #[test]
+    fn kubeconfig_auth_without_context_omits_flag() {
+        let auth = ResolvedK8sAuth::Kubeconfig {
+            id: "k8s/credential/prod".to_string(),
+            context: None,
+        };
+        assert_eq!(auth.kubectl_arg(), "--kubeconfig \"$KUBECONFIG\"");
+    }
 }

--- a/crates/campaign/src/campaign/state.rs
+++ b/crates/campaign/src/campaign/state.rs
@@ -234,6 +234,20 @@ impl Campaign {
         self.knowledge_provenance.entity(id)
     }
 
+    /// Whether `credential_id` is a local kubeconfig identity — i.e. contained
+    /// by the operator host. Every context read from Ran's own kubeconfig is
+    /// contained by the operator host and has a backing per-context client, so
+    /// these identities can be selected via Authenticate As even when they are
+    /// not the current (active) context. Credentials discovered elsewhere (e.g.
+    /// on a node) are linked by `Uses`, not `Contains`, and are excluded.
+    pub fn is_operator_host_credential(&self, credential_id: &EntityId) -> bool {
+        let host = EntityId::new("system/operator-host");
+        self.graph
+            .targets_of(&host, "contains")
+            .iter()
+            .any(|id| id.0 == credential_id.0)
+    }
+
     pub fn relation_provenance(
         &self,
         name: &str,

--- a/crates/campaign/src/lib.rs
+++ b/crates/campaign/src/lib.rs
@@ -24,7 +24,7 @@ pub use campaign::{
 pub use effects::{EffectCategory, EffectKind, FactsUpdate};
 pub use execution_record::{ExecutionEntity, ExecutionRecord};
 pub use external_parser::{ExternalParseRequest, ExternalParseResponse, ExternalParser};
-pub use output_parsers::{ParseAudit, ParseResult};
+pub use output_parsers::{credential_from_resolved, ParseAudit, ParseResult};
 pub use pending_view::PendingView;
 pub use provenance::{KnowledgeProvenance, KnowledgeProvenanceStore, RelationProvenanceKey};
 pub use rules::{run_rules_fixpoint, InferenceRule};

--- a/crates/campaign/src/output_parsers/file.rs
+++ b/crates/campaign/src/output_parsers/file.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use super::ParserOutput;
 use crate::FactsUpdate;
 use ran_domain::{AuthenticatesTo, Contains, Entity, K8sCluster, K8sCredential, Namespace, Uses};
@@ -44,29 +46,48 @@ pub(super) fn is_kubeconfig_content(content: &str) -> bool {
 // Kubeconfig YAML parsing
 // ---------------------------------------------------------------------------
 
-/// Parse kubeconfig YAML and build a `K8sCredential` entity.
+/// Build a `K8sCredential` entity from an already-resolved kubeconfig context.
 ///
-/// Extracts the first cluster's `server` and `certificate-authority-data`, and
-/// the first user's `token` or `client-certificate-data` + `client-key-data`.
+/// This is the single, canonical mapping from a resolved context to a
+/// credential entity, shared by the output parser and by the app-side
+/// per-context client registry so that both derive the **same** entity id for
+/// the same context. The credential is named by its context (a raw server URL
+/// is an unfriendly display name / id), falling back to the user name, then the
+/// endpoint. `active` is left `false` for the caller to set.
+pub fn credential_from_resolved(resolved: &k8s::ResolvedKubeconfig) -> K8sCredential {
+    let mut cred = K8sCredential::new(resolved.server.clone().unwrap_or_default());
+    cred.context_name = Some(resolved.context_name.clone());
+    cred.default_namespace = resolved.default_namespace.clone();
+    cred.user_name = resolved.user_name.clone();
+    cred.auth_method = resolved.auth_method.clone();
+    cred.has_token = resolved.has_token;
+    cred.has_client_certificate = resolved.has_client_certificate;
+    cred.has_client_key = resolved.has_client_key;
+    cred.ca_data = resolved.ca_data.clone();
+    cred.token = resolved.token.clone();
+    cred.cert_data = resolved.cert_data.clone();
+    cred.key_data = resolved.key_data.clone();
+
+    if let Some(label) = non_empty(&resolved.context_name)
+        .or_else(|| resolved.user_name.as_deref().and_then(non_empty))
+    {
+        cred.name = label.to_string();
+    }
+    cred
+}
+
+fn non_empty(value: &str) -> Option<&str> {
+    let trimmed = value.trim();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+/// Parse kubeconfig YAML and build a `K8sCredential` for its current context.
 ///
 /// Returns `None` when the YAML does not contain a usable cluster entry.
 fn credential_from_kubeconfig(content: &str) -> Option<(K8sCredential, String)> {
     let resolved = k8s::resolve_kubeconfig_yaml(content, None).ok()?;
     let cluster_name = resolved.cluster_name.clone();
-    let mut cred = K8sCredential::new(resolved.server.clone().unwrap_or_default());
-    cred.context_name = Some(resolved.context_name);
-    cred.default_namespace = resolved.default_namespace;
-    cred.user_name = resolved.user_name;
-    cred.auth_method = resolved.auth_method;
-    cred.has_token = resolved.has_token;
-    cred.has_client_certificate = resolved.has_client_certificate;
-    cred.has_client_key = resolved.has_client_key;
-    cred.ca_data = resolved.ca_data;
-    cred.token = resolved.token;
-    cred.cert_data = resolved.cert_data;
-    cred.key_data = resolved.key_data;
-
-    Some((cred, cluster_name))
+    Some((credential_from_resolved(&resolved), cluster_name))
 }
 
 // ---------------------------------------------------------------------------
@@ -123,14 +144,16 @@ pub(super) fn parse_file_kubeconfig(stdout: &str, source_id: &str) -> ParserOutp
     ParserOutput::SuccessWithFacts(facts, detail)
 }
 
-/// Parse the kubeconfig read from the machine running Ran and emit the
-/// **active** Kubernetes identity plus its cluster.
+/// Parse the kubeconfig read from the machine running Ran and emit **every**
+/// context it defines as a switchable Kubernetes identity.
 ///
-/// Unlike [`parse_file_kubeconfig`] (which records a knowledge-only credential
-/// discovered on some remote system), this reproduces the graph shape Ran used
-/// to seed at bootstrap for its own kubeconfig:
-/// - a `K8sCredential` with `active = true`
-/// - the `K8sCluster` it authenticates to
+/// Unlike [`parse_file_kubeconfig`] (which records a single knowledge-only
+/// credential discovered on some remote system), this reproduces the graph
+/// shape Ran used to seed at bootstrap, for each context:
+/// - a `K8sCredential`, `active = true` only for the kubeconfig's current
+///   context; the others are known-but-inactive identities the operator can
+///   switch to via Authenticate As
+/// - the `K8sCluster` it authenticates to (deduplicated by entity id)
 /// - `AuthenticatesTo(credential → cluster)`
 /// - `Contains(source_id → credential)` where `source_id` is the operator host
 /// - when the context declares a default namespace, the `Namespace` entity and
@@ -148,82 +171,77 @@ pub(super) fn parse_file_kubeconfig(stdout: &str, source_id: &str) -> ParserOutp
 /// `project_kubeconfig_effect_provenance_debt`.
 ///
 /// Returns:
-/// - `SuccessWithFacts` — active credential, cluster, and relations emitted
+/// - `SuccessWithFacts` — one credential per context, clusters, and relations
 /// - `KnownFailure` — empty content
-/// - `UnknownFormat` — non-empty content that fails to resolve to a cluster/user
+/// - `UnknownFormat` — non-empty content with no resolvable context
 pub(super) fn parse_local_kubeconfig(stdout: &str, source_id: &str) -> ParserOutput {
     if stdout.trim().is_empty() {
         return ParserOutput::KnownFailure("empty stdout for file:local-kubeconfig".to_string());
     }
 
-    let (mut cred, cluster_name) = match credential_from_kubeconfig(stdout) {
-        Some(c) => c,
-        None => {
+    let contexts = match k8s::resolve_all_kubeconfig_contexts_yaml(stdout) {
+        Ok(contexts) if !contexts.is_empty() => contexts,
+        _ => {
             return ParserOutput::UnknownFormat(
-                "could not extract cluster/user from local kubeconfig YAML".to_string(),
+                "could not resolve any context from local kubeconfig YAML".to_string(),
             )
         }
     };
-    cred.active = true;
-    // A raw server URL is an unfriendly display name / id. Prefer the context
-    // name (what kubectl shows), then the user name, then fall back to the
-    // endpoint that `K8sCredential::new` defaulted to.
-    if let Some(label) = cred
-        .context_name
-        .clone()
-        .filter(|value| !value.trim().is_empty())
-        .or_else(|| {
-            cred.user_name
-                .clone()
-                .filter(|value| !value.trim().is_empty())
-        })
-    {
-        cred.name = label;
-    }
-
-    let mut cluster = K8sCluster::new(&cluster_name);
-    cluster.context_name = cred.context_name.clone();
-    if !cred.endpoint.is_empty() {
-        cluster.server = Some(cred.endpoint.clone());
-    }
-    let cluster_id = cluster.entity_id().0.clone();
-    let cred_id = cred.entity_id().0.clone();
-    let default_namespace = cred.default_namespace.clone();
-
-    let detail = format!(
-        "established active K8sCredential for endpoint '{}' (context={}, cluster={}, default_namespace={}, token={}, cert={})",
-        if cred.endpoint.is_empty() {
-            "unknown"
-        } else {
-            &cred.endpoint
-        },
-        cred.context_name.as_deref().unwrap_or("unknown"),
-        cluster_name,
-        default_namespace.as_deref().unwrap_or("none"),
-        cred.token.is_some(),
-        cred.cert_data.is_some(),
-    );
 
     let mut facts = FactsUpdate::default();
-    facts.new_entities.push(Box::new(cred));
-    facts.new_entities.push(Box::new(cluster));
-    facts.new_relations.push(Box::new(AuthenticatesTo::new(
-        cred_id.clone(),
-        cluster_id.clone(),
-    )));
-    if !source_id.is_empty() {
-        facts
-            .new_relations
-            .push(Box::new(Contains::new(source_id, cred_id)));
+    let mut emitted_clusters: HashSet<String> = HashSet::new();
+    let mut emitted_namespaces: HashSet<String> = HashSet::new();
+    let mut credential_labels: Vec<String> = Vec::new();
+
+    for resolved in &contexts {
+        let mut cred = credential_from_resolved(resolved);
+        cred.active = resolved.is_current_context;
+        let cred_id = cred.entity_id().0.clone();
+        credential_labels.push(format!(
+            "{}{}",
+            cred.entity_name(),
+            if cred.active { " (active)" } else { "" }
+        ));
+
+        let mut cluster = K8sCluster::new(&resolved.cluster_name);
+        cluster.context_name = Some(resolved.context_name.clone());
+        if let Some(server) = resolved.server.clone().filter(|s| !s.is_empty()) {
+            cluster.server = Some(server);
+        }
+        let cluster_id = cluster.entity_id().0.clone();
+
+        facts.new_entities.push(Box::new(cred));
+        if emitted_clusters.insert(cluster_id.clone()) {
+            facts.new_entities.push(Box::new(cluster));
+        }
+        facts.new_relations.push(Box::new(AuthenticatesTo::new(
+            cred_id.clone(),
+            cluster_id.clone(),
+        )));
+        if !source_id.is_empty() {
+            facts
+                .new_relations
+                .push(Box::new(Contains::new(source_id, cred_id)));
+        }
+        if let Some(namespace_name) = resolved.default_namespace.clone() {
+            let namespace = Namespace::new(namespace_name);
+            let namespace_id = namespace.entity_id().0.clone();
+            if emitted_namespaces.insert(namespace_id.clone()) {
+                facts.new_entities.push(Box::new(namespace));
+            }
+            facts
+                .new_relations
+                .push(Box::new(Contains::new(cluster_id, namespace_id)));
+        }
     }
-    if let Some(namespace_name) = default_namespace {
-        let namespace = Namespace::new(namespace_name);
-        let namespace_id = namespace.entity_id().0.clone();
-        facts.new_entities.push(Box::new(namespace));
-        facts
-            .new_relations
-            .push(Box::new(Contains::new(cluster_id, namespace_id)));
-    }
+
+    let detail = format!(
+        "established {} local kubeconfig identit{} across {} cluster(s): {}",
+        contexts.len(),
+        if contexts.len() == 1 { "y" } else { "ies" },
+        emitted_clusters.len(),
+        credential_labels.join(", "),
+    );
 
     ParserOutput::SuccessWithFacts(facts, detail)
 }
@@ -480,6 +498,80 @@ users:
     // -----------------------------------------------------------------------
 
     const OPERATOR_HOST: &str = "system/operator-host";
+
+    // Kubeconfig with two contexts against two clusters; prod is current.
+    const KUBECONFIG_MULTI: &str = r#"apiVersion: v1
+kind: Config
+clusters:
+- name: prod-cluster
+  cluster:
+    server: https://prod:6443
+- name: staging-cluster
+  cluster:
+    server: https://staging:6443
+contexts:
+- name: prod
+  context:
+    cluster: prod-cluster
+    user: prod-admin
+    namespace: default
+- name: staging
+  context:
+    cluster: staging-cluster
+    user: staging-admin
+current-context: prod
+users:
+- name: prod-admin
+  user:
+    token: prod-token
+- name: staging-admin
+  user:
+    token: staging-token
+"#;
+
+    #[test]
+    fn parse_local_kubeconfig_emits_every_context_only_current_active() {
+        let ParserOutput::SuccessWithFacts(facts, _) =
+            parse_local_kubeconfig(KUBECONFIG_MULTI, OPERATOR_HOST)
+        else {
+            panic!("expected SuccessWithFacts");
+        };
+
+        let creds: Vec<&K8sCredential> = facts
+            .new_entities
+            .iter()
+            .filter_map(|e| e.as_any().downcast_ref::<K8sCredential>())
+            .collect();
+        assert_eq!(creds.len(), 2, "one credential per context");
+
+        let prod = creds
+            .iter()
+            .find(|c| c.entity_name() == "prod")
+            .expect("prod credential");
+        let staging = creds
+            .iter()
+            .find(|c| c.entity_name() == "staging")
+            .expect("staging credential");
+        assert!(prod.active, "current context is active");
+        assert!(!staging.active, "non-current context is inactive");
+
+        // Two distinct clusters emitted.
+        let clusters: Vec<&K8sCluster> = facts
+            .new_entities
+            .iter()
+            .filter_map(|e| e.as_any().downcast_ref::<K8sCluster>())
+            .collect();
+        assert_eq!(clusters.len(), 2);
+
+        // Both credentials are contained by the operator host.
+        let contains_from_host = facts
+            .new_relations
+            .iter()
+            .filter_map(|r| r.as_any().downcast_ref::<Contains>())
+            .filter(|c| c.source_id().0 == OPERATOR_HOST)
+            .count();
+        assert_eq!(contains_from_host, 2);
+    }
 
     #[test]
     fn parse_local_kubeconfig_marks_credential_active_and_emits_cluster() {

--- a/crates/campaign/src/output_parsers/mod.rs
+++ b/crates/campaign/src/output_parsers/mod.rs
@@ -5,6 +5,8 @@ mod k8s;
 mod network;
 mod sys;
 
+pub use file::credential_from_resolved;
+
 use std::collections::HashMap;
 use std::sync::OnceLock;
 

--- a/crates/campaign/src/ttp_applicability.rs
+++ b/crates/campaign/src/ttp_applicability.rs
@@ -98,7 +98,9 @@ pub fn eligible_auth_identities(
         campaign
             .entities
             .values::<K8sCredential>()
-            .filter(|credential| credential.active)
+            .filter(|credential| {
+                credential.active || campaign.is_operator_host_credential(&credential.entity_id())
+            })
             .filter(|credential| {
                 identity_target != Some("K8sCredential") || credential.entity_id().0 == target_id
             })
@@ -382,7 +384,9 @@ pub fn ttp_rbac_satisfied(ttp: &armory::Ttp, campaign: &Campaign) -> bool {
         || campaign
             .entities
             .values::<K8sCredential>()
-            .filter(|credential| credential.active)
+            .filter(|credential| {
+                credential.active || campaign.is_operator_host_credential(&credential.entity_id())
+            })
             .any(|credential| entitlements_satisfy(ttp, &credential.entitlements))
 }
 

--- a/crates/k8s/src/lib.rs
+++ b/crates/k8s/src/lib.rs
@@ -47,6 +47,9 @@ pub struct ResolvedKubeconfig {
     kubeconfig: Kubeconfig,
     source_path: Option<PathBuf>,
     pub context_name: String,
+    /// `true` when this context is the kubeconfig's `current-context`. Used to
+    /// decide which of several resolved identities is the active one.
+    pub is_current_context: bool,
     /// Explicit default namespace configured on the selected context.
     /// Kubernetes' implicit `default` fallback is intentionally not inferred.
     pub default_namespace: Option<String>,
@@ -104,6 +107,7 @@ pub fn resolve_kubeconfig_data(
         .map(str::to_string)
         .or_else(|| kubeconfig.current_context.clone())
         .ok_or_else(|| anyhow!("kubeconfig does not define current-context"))?;
+    let is_current_context = kubeconfig.current_context.as_deref() == Some(context_name.as_str());
 
     let named_context = kubeconfig
         .contexts
@@ -176,6 +180,7 @@ pub fn resolve_kubeconfig_data(
         kubeconfig,
         source_path: None,
         context_name,
+        is_current_context,
         default_namespace,
         cluster_name,
         user_name,
@@ -200,6 +205,41 @@ pub fn resolve_kubeconfig_yaml(
     let kubeconfig: Kubeconfig =
         serde_yaml::from_str(content).context("failed to parse kubeconfig YAML")?;
     resolve_kubeconfig_data(kubeconfig, context_override)
+}
+
+/// Resolve **every** context defined in the kubeconfig, not just the current
+/// one. Contexts that cannot be resolved (missing cluster/user) are skipped
+/// rather than failing the whole set. The `is_current_context` flag on each
+/// entry marks which one the kubeconfig selects by default.
+pub fn resolve_all_kubeconfig_contexts(kubeconfig: Kubeconfig) -> Vec<ResolvedKubeconfig> {
+    kubeconfig
+        .contexts
+        .iter()
+        .map(|ctx| ctx.name.clone())
+        .filter_map(|name| resolve_kubeconfig_data(kubeconfig.clone(), Some(&name)).ok())
+        .collect()
+}
+
+/// Read a kubeconfig file and resolve every context it defines. Each entry's
+/// `source_path` is set to `path`.
+pub fn resolve_all_kubeconfig_contexts_from_path(
+    path: impl Into<PathBuf>,
+) -> Result<Vec<ResolvedKubeconfig>> {
+    let path = path.into();
+    let kubeconfig = Kubeconfig::read_from(path.clone())
+        .with_context(|| format!("failed to read kubeconfig at {}", path.display()))?;
+    let mut resolved = resolve_all_kubeconfig_contexts(kubeconfig);
+    for entry in &mut resolved {
+        entry.source_path = Some(path.clone());
+    }
+    Ok(resolved)
+}
+
+/// Parse kubeconfig YAML and resolve every context it defines.
+pub fn resolve_all_kubeconfig_contexts_yaml(content: &str) -> Result<Vec<ResolvedKubeconfig>> {
+    let kubeconfig: Kubeconfig =
+        serde_yaml::from_str(content).context("failed to parse kubeconfig YAML")?;
+    Ok(resolve_all_kubeconfig_contexts(kubeconfig))
 }
 
 fn pod_to_running_pod(pod: &Pod) -> Option<RunningPod> {
@@ -249,6 +289,7 @@ fn pod_to_running_pod(pod: &Pod) -> Option<RunningPod> {
 pub struct Client {
     client: KubeClient,
     kubeconfig_path: Option<PathBuf>,
+    context_name: Option<String>,
     api_server: String,
 }
 
@@ -324,11 +365,17 @@ impl Client {
         Ok(Self {
             client,
             kubeconfig_path: resolved.source_path.clone(),
+            context_name: Some(resolved.context_name.clone()),
             api_server: resolved
                 .server
                 .clone()
                 .unwrap_or_else(|| "unknown".to_string()),
         })
+    }
+
+    /// The kubeconfig context this client authenticates as, when known.
+    pub fn context_name(&self) -> Option<&str> {
+        self.context_name.as_deref()
     }
 
     /// Path to the kubeconfig file that backs this client, when it is
@@ -694,6 +741,30 @@ users:
         assert!(resolve_kubeconfig_yaml(KUBECONFIG, Some("missing")).is_err());
         let missing_user = KUBECONFIG.replace("user: user-a", "user: missing");
         assert!(resolve_kubeconfig_yaml(&missing_user, None).is_err());
+    }
+
+    #[test]
+    fn resolve_all_contexts_returns_every_context_and_flags_current() {
+        let mut resolved = resolve_all_kubeconfig_contexts_yaml(KUBECONFIG).unwrap();
+        resolved.sort_by(|a, b| a.context_name.cmp(&b.context_name));
+        assert_eq!(resolved.len(), 2);
+
+        assert_eq!(resolved[0].context_name, "context-a");
+        assert!(resolved[0].is_current_context);
+        assert_eq!(resolved[0].cluster_name, "cluster-a");
+
+        assert_eq!(resolved[1].context_name, "context-b");
+        assert!(!resolved[1].is_current_context);
+        assert_eq!(resolved[1].cluster_name, "cluster-b");
+    }
+
+    #[test]
+    fn resolve_all_contexts_skips_unresolvable_entries() {
+        // Break context-b's user reference; context-a must still resolve.
+        let broken = KUBECONFIG.replace("user: user-b", "user: missing");
+        let resolved = resolve_all_kubeconfig_contexts_yaml(&broken).unwrap();
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].context_name, "context-a");
     }
 
     #[test]


### PR DESCRIPTION
## What & why

Ran used to read the local kubeconfig **automatically** at bootstrap and seed its own cluster identity as knowledge. This PR turns that into an explicit **TTP** and makes every kubeconfig context a **switchable identity**.

### Read Local Kubeconfig TTP (first commit)
- New Credential Access TTP `read-local-kubeconfig` (`c2.read_local_kubeconfig`) targets the operator host and reads Ran's own kubeconfig, emitting the active `K8sCredential` + cluster via a new `file:local-kubeconfig` effect.
- The campaign now boots knowing only Ran itself (`OperatorHost` + `C2`); cluster-facing TTPs become applicable **after** the local kubeconfig is read.
- The operator host is always present and named after the local machine's **hostname**, so it's obvious which host holds the kubeconfig.
- The credential is named by its **context** (not the raw server URL).
- The live transport `Client` is still built at startup (knowledge-only change).

### Multi-context identities + real switching (second commit)
- `Read Local Kubeconfig` now emits **one credential per context**; only the current context is `active`, the rest are switchable via **Authenticate As**.
- The app builds a Kubernetes **client per context** at startup, keyed by credential id (`campaign::credential_from_resolved` is the single canonical mapping shared by the parser and the registry).
- The C2 executor selects the per-context client (`client_for`) for permission reviews and `k8s/credential/*` dispatch, falling back to the default client.
- Auth eligibility accepts any **local (operator-host-contained)** credential, not only the active one; node-discovered credentials (linked by `Uses`) stay excluded.
- `${K8S_AUTH}` grounding emits `--context <name>` so kubectl targets the chosen identity.
- Contexts whose client can't be built (exec/auth-provider plugins) are skipped and logged — visible as knowledge, not switchable.

## Testing
- `cargo test --workspace` — green; new tests for multi-context resolution (k8s), per-context credential emission with only current active (campaign), `--context` grounding, and the executor/parser paths.
- `cargo clippy --workspace` and `cargo fmt --check` clean.

## Known follow-up (tech debt)
`file:local-kubeconfig` duplicates `file:kubeconfig`. Kubeconfig parsing is format-invariant; the local-vs-in-cluster distinction should be driven by **provenance** from a single parser rather than two effects. Tracked in code with `TODO(tech-debt)` markers.

https://claude.ai/code/session_019kQhcDNiadj1pvVqicbCaV
