### PR TITLE
Read local kubeconfig: surface path in UI, tolerate broken auth, honor $KUBECONFIG

### DIFF
--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -33,7 +33,13 @@ use ran_domain::{Entity, K8sCluster, K8sCredential, Pod, RelationSummary};
 
 #[derive(Clone)]
 pub struct AppState {
-    k8s: Client,
+    /// Live Kubernetes client for the active kubeconfig context. `None` when
+    /// startup could not authenticate (e.g. the current context uses an
+    /// exec-auth plugin that failed to produce credentials). Cluster-facing
+    /// operations must guard for this; local-only actions like
+    /// `read-local-kubeconfig` remain available so the operator can inspect
+    /// what Ran was configured with.
+    k8s: Option<Client>,
     campaign: Arc<RwLock<Campaign>>,
     c2: C2Handle,
     armory: Armory,
@@ -67,7 +73,7 @@ pub struct AppState {
 impl AppState {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        k8s: Client,
+        k8s: Option<Client>,
         campaign: Arc<RwLock<Campaign>>,
         c2: C2Handle,
         armory: Armory,
@@ -270,8 +276,12 @@ impl ApiService for AppState {
         // Treat an empty string the same as absent — don't bypass the filter.
         let scope_ns = params.namespace.as_deref().filter(|ns| !ns.is_empty());
 
-        let pods = self
-            .k8s
+        let Some(k8s) = self.k8s.as_ref() else {
+            return Err(ApiError::internal(
+                "no active Kubernetes client — pod discovery unavailable until a working kubeconfig is loaded",
+            ));
+        };
+        let pods = k8s
             .get_running_pods(scope_ns)
             .await
             .map_err(|e| ApiError::internal(e.to_string()))?;
@@ -1568,8 +1578,12 @@ impl AppState {
             return Ok(());
         }
 
-        let candidates = self
-            .k8s
+        let Some(k8s) = self.k8s.as_ref() else {
+            return Err(ExecuteActionError::InvalidInput(
+                "cannot stage live initial-access target: no active Kubernetes client (read the local kubeconfig or restart with --kubeconfig)".to_string(),
+            ));
+        };
+        let candidates = k8s
             .get_running_pods(Some(&namespace))
             .await
             .map_err(|error| ExecuteActionError::NotFound(error.to_string()))?;
@@ -1630,7 +1644,26 @@ impl AppState {
 pub async fn start(cfg: ServerConfig) -> Result<()> {
     let kubeconfig_path = kubeconfig_path_or_err(cfg.kubeconfig)?;
     let active_kubeconfig = resolve_kubeconfig(kubeconfig_path.clone(), None)?;
-    let k8s = Client::from_resolved_kubeconfig(&active_kubeconfig).await?;
+    // Startup no longer aborts when the active kubeconfig context cannot
+    // authenticate (e.g. an exec-auth plugin like `aws eks get-token` fails).
+    // The design record for read-local-kubeconfig deliberately boots with just
+    // OperatorHost + C2; a broken current-context should therefore log a
+    // warning and let the server come up so the operator can still browse the
+    // UI, read the local kubeconfig via TTP, or switch to a working context.
+    let k8s = match Client::from_resolved_kubeconfig(&active_kubeconfig).await {
+        Ok(client) => Some(client),
+        Err(error) => {
+            warn!(
+                context = %active_kubeconfig.context_name,
+                kubeconfig = %kubeconfig_path.display(),
+                %error,
+                "failed to authenticate the active kubeconfig context; \
+                 cluster-facing actions will fail until a working context is \
+                 loaded (via read-local-kubeconfig or --kubeconfig)"
+            );
+            None
+        }
+    };
     let mut initial_knowledge = build_initial_knowledge(&cfg.seed_knowledge)?;
     initial_knowledge.operator_host_name = local_hostname();
     let (armory, user_armory_dir) = load_armory(cfg.armory_dir)?;
@@ -1887,7 +1920,12 @@ async fn seed_initial_access_targets(state: &AppState, plan: &planner::PlanDefin
     for (step_id, ns, pattern) in root_targets {
         // Build a fake entity-id list from cluster pods and use the planner's
         // resolver to match names — avoids a direct `regex` dep in this crate.
-        let pods = match state.k8s.get_running_pods(Some(&ns)).await {
+        let Some(k8s) = state.k8s.as_ref() else {
+            warn!(step_id = %step_id, namespace = %ns,
+                "no active Kubernetes client; skipping initial target seed");
+            continue;
+        };
+        let pods = match k8s.get_running_pods(Some(&ns)).await {
             Ok(p) => p,
             Err(e) => {
                 warn!(step_id = %step_id, namespace = %ns, error = %e,
@@ -2135,7 +2173,7 @@ pub async fn trigger(cfg: TriggerConfig) -> Result<()> {
     )));
 
     let k8s_client_registry = build_k8s_client_registry(&kubeconfig_path).await;
-    let (c2_handle, c2_events, c2_manager) = C2Manager::new(256, k8s, k8s_client_registry);
+    let (c2_handle, c2_events, c2_manager) = C2Manager::new(256, Some(k8s), k8s_client_registry);
     let campaign_events = CampaignEventBus::new(256);
 
     // Subscribe before spawning the processor so no events are dropped.

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -391,7 +391,26 @@ impl ApiService for AppState {
     }
 
     async fn get_armory(&self, params: api::GetArmoryParams) -> Result<Vec<armory::Ttp>, ApiError> {
-        Ok(self.armory.ttps_for_tactic(params.tactic.as_deref()))
+        let mut ttps = self.armory.ttps_for_tactic(params.tactic.as_deref());
+        // Surface the kubeconfig path Ran was configured with (via --kubeconfig
+        // or the standard resolution) as the PATH parameter's default on the
+        // read-local-kubeconfig TTP, so UI/MCP/REST callers see the concrete
+        // file that will be read. Runtime fallback in the executor still
+        // applies for callers that omit PATH entirely.
+        if let Some(kubeconfig) = self.k8s.as_ref().and_then(|k| k.kubeconfig_path()) {
+            let kubeconfig = kubeconfig.display().to_string();
+            for ttp in &mut ttps {
+                if ttp.id != "read-local-kubeconfig" {
+                    continue;
+                }
+                for param in &mut ttp.params {
+                    if param.name == "PATH" && param.default.is_empty() {
+                        param.default = kubeconfig.clone();
+                    }
+                }
+            }
+        }
+        Ok(ttps)
     }
 
     async fn execute_action(

--- a/crates/app/tests/service.rs
+++ b/crates/app/tests/service.rs
@@ -130,7 +130,7 @@ async fn app_state_get_and_reset_campaign_without_cli() {
     )));
 
     let (c2_handle, c2_events, c2_manager) =
-        c2::C2Manager::new(32, k8s.clone(), std::collections::HashMap::new());
+        c2::C2Manager::new(32, Some(k8s.clone()), std::collections::HashMap::new());
     let campaign_events = campaign::CampaignEventBus::new(32);
 
     tokio::spawn(c2_manager.run());
@@ -146,7 +146,7 @@ async fn app_state_get_and_reset_campaign_without_cli() {
     let armory = armory::Armory::load_from_dir(tmp.path()).expect("failed to load empty armory");
 
     let state = app::AppState::new(
-        k8s,
+        Some(k8s),
         campaign,
         c2_handle,
         armory,

--- a/crates/c2/src/executor.rs
+++ b/crates/c2/src/executor.rs
@@ -99,16 +99,42 @@ impl C2Backend for BuiltinC2 {
     }
 }
 
+/// Fallback backend registered when startup could not build a live Kubernetes
+/// client. Every command fails with a clear reason so the operator can tell
+/// the difference between "action ran and failed" and "action never had a
+/// chance to run because there's no cluster connection".
+struct NoClientBackend;
+
+#[async_trait]
+impl C2Backend for NoClientBackend {
+    async fn execute(&self, cmd: &ExecTtp) -> TtpExecuted {
+        failed_result(
+            cmd,
+            "no active Kubernetes client configured — read the local kubeconfig or restart with --kubeconfig",
+        )
+    }
+}
+
 impl C2Manager {
     pub fn new(
         buffer_size: usize,
-        k8s: Client,
+        k8s: Option<Client>,
         k8s_clients: HashMap<String, Client>,
     ) -> (C2Handle, C2EventBus, Self) {
         let (cmd_tx, cmd_rx) = mpsc::channel(buffer_size);
         let event_bus = C2EventBus::new(buffer_size);
 
-        let builtin: Arc<dyn C2Backend> = Arc::new(BuiltinC2::new(k8s.clone()));
+        // The builtin C2 backend routes commands through pod-exec, which needs
+        // a live Kubernetes client. Without one (e.g. startup could not
+        // authenticate to the cluster's current context) we register a stub
+        // that fails every command with a clear reason. Control commands like
+        // c2.read_local_kubeconfig are dispatched by the executor before it
+        // consults the backend, so those still work — which is the whole point
+        // of degrading here rather than aborting startup.
+        let builtin: Arc<dyn C2Backend> = match k8s.clone() {
+            Some(client) => Arc::new(BuiltinC2::new(client)),
+            None => Arc::new(NoClientBackend),
+        };
         let mut map: HashMap<String, Arc<dyn C2Backend>> = HashMap::new();
         map.insert(BUILTIN_C2_ID.to_string(), builtin.clone());
         map.insert("ran".to_string(), builtin);
@@ -125,7 +151,7 @@ impl C2Manager {
                 executor: C2Executor {
                     event_bus,
                     backends,
-                    k8s: Some(k8s),
+                    k8s,
                     k8s_clients: Arc::new(k8s_clients),
                 },
             },

--- a/crates/k8s/src/lib.rs
+++ b/crates/k8s/src/lib.rs
@@ -658,8 +658,51 @@ fn parse_exit_code(message: Option<&str>) -> Option<i32> {
     code_str.trim().parse().ok()
 }
 
+/// Resolve the kubeconfig file to use when no explicit path is provided.
+///
+/// Follows kubectl's resolution order:
+/// 1. `$KUBECONFIG` if set — may be a list separated by `:` on Unix or `;`
+///    on Windows; the first entry that exists on disk wins. When none of
+///    the listed files exists we fall back to the default (matches
+///    kubectl's behaviour of trying `~/.kube/config` last).
+/// 2. `$HOME/.kube/config`.
+/// 3. `.kube/config` relative to the current directory (last-resort
+///    fallback when `$HOME` is unset).
+///
+/// Callers who need `$KUBECONFIG`'s full multi-file merge semantics must
+/// go through `kube::Config` directly; this helper only picks one file
+/// for actions that read a single kubeconfig (e.g. read-local-kubeconfig).
 pub fn default_kubeconfig_path() -> PathBuf {
-    if let Ok(home) = env::var("HOME") {
+    resolve_default_kubeconfig_path(
+        env::var("KUBECONFIG").ok().as_deref(),
+        env::var("HOME").ok().as_deref(),
+        |p| p.exists(),
+    )
+}
+
+/// Testable core of [`default_kubeconfig_path`]. `path_exists` decides
+/// whether a `$KUBECONFIG` entry counts as present without touching the
+/// real filesystem — so tests can exercise the multi-entry precedence
+/// without racing on process-global env vars.
+fn resolve_default_kubeconfig_path(
+    kubeconfig_env: Option<&str>,
+    home_env: Option<&str>,
+    path_exists: impl Fn(&std::path::Path) -> bool,
+) -> PathBuf {
+    if let Some(value) = kubeconfig_env {
+        let separator = if cfg!(windows) { ';' } else { ':' };
+        for entry in value.split(separator) {
+            let trimmed = entry.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            let path = PathBuf::from(trimmed);
+            if path_exists(&path) {
+                return path;
+            }
+        }
+    }
+    if let Some(home) = home_env {
         return PathBuf::from(home).join(".kube/config");
     }
     PathBuf::from(".kube/config")
@@ -681,6 +724,49 @@ pub fn target_cluster_from_kubeconfig(path: Option<PathBuf>) -> Result<TargetClu
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn default_kubeconfig_prefers_first_existing_kubeconfig_entry() {
+        let present: HashSet<PathBuf> = ["/tmp/second"].iter().map(PathBuf::from).collect();
+        let picked = resolve_default_kubeconfig_path(
+            Some("/tmp/first:/tmp/second:/tmp/third"),
+            Some("/home/op"),
+            |p| present.contains(p),
+        );
+        assert_eq!(picked, PathBuf::from("/tmp/second"));
+    }
+
+    #[test]
+    fn default_kubeconfig_falls_back_to_home_when_no_kubeconfig_entry_exists() {
+        let picked = resolve_default_kubeconfig_path(
+            Some("/tmp/missing-a:/tmp/missing-b"),
+            Some("/home/op"),
+            |_| false,
+        );
+        assert_eq!(picked, PathBuf::from("/home/op/.kube/config"));
+    }
+
+    #[test]
+    fn default_kubeconfig_ignores_empty_kubeconfig_entries() {
+        let present: HashSet<PathBuf> = ["/tmp/real"].iter().map(PathBuf::from).collect();
+        let picked = resolve_default_kubeconfig_path(Some("::/tmp/real:"), Some("/home/op"), |p| {
+            present.contains(p)
+        });
+        assert_eq!(picked, PathBuf::from("/tmp/real"));
+    }
+
+    #[test]
+    fn default_kubeconfig_uses_home_when_kubeconfig_env_unset() {
+        let picked = resolve_default_kubeconfig_path(None, Some("/home/op"), |_| false);
+        assert_eq!(picked, PathBuf::from("/home/op/.kube/config"));
+    }
+
+    #[test]
+    fn default_kubeconfig_final_fallback_is_relative_dot_kube_config() {
+        let picked = resolve_default_kubeconfig_path(None, None, |_| false);
+        assert_eq!(picked, PathBuf::from(".kube/config"));
+    }
 
     const KUBECONFIG: &str = r#"apiVersion: v1
 kind: Config


### PR DESCRIPTION
Follow-ups to #50 (read-local-kubeconfig TTP) motivated by real usage.

## 2f8d6d23 — fix(app): tolerate broken kubeconfig auth at startup

`ran emulate` crashed before binding its port when the active kubeconfig context could not authenticate (repro: an EKS context whose `aws eks get-token` exec-auth exited non-zero). This contradicts the intent recorded in #50:

> The campaign now boots knowing only Ran itself (OperatorHost + C2); cluster-facing TTPs become applicable once the local kubeconfig is read.

If the campaign boots knowing "only Ran itself", startup must not depend on live cluster credentials — otherwise the very TTP designed to load a working kubeconfig can never run.

- `AppState.k8s` is now `Option<Client>`; startup logs a warning and degrades to `None` on auth failure.
- `C2Manager::new` takes `Option<Client>` and registers a `NoClientBackend` stub when the client is missing, so builtin routing keeps its invariant and cluster-facing commands fail with a clear reason (`no active Kubernetes client configured — read the local kubeconfig or restart with --kubeconfig`) instead of panicking.
- `read-local-kubeconfig` is dispatched by the executor *before* backend lookup, so it works with or without a live client — the operator can boot broken, then load a working kubeconfig via TTP.
- Cluster-side call sites (`get_running_pods`, `stage_live_initial_access_target`, `seed_initial_access_targets`) guard on `Option` and return clear errors.
- `trigger()` (atomic CLI) still requires a live client — it genuinely needs the cluster; only `start()` (emulate server) tolerates.

## a4af9e9a — feat(api): surface kubeconfig path as read-local-kubeconfig default

The action modal renders `param.default` verbatim. Since the YAML default is `""`, the UI showed an empty PATH field even though the executor falls back to the configured path. `AppState::get_armory` now fills the `PATH` parameter default with the concrete path Ran was configured with (from `--kubeconfig` or default resolution) before returning the TTP. UI, MCP `list_ttps` / `get_ttp_detail`, and any REST client see the same resolved default.

The executor's runtime fallback stays as a safety net for callers that omit `PATH` entirely.

## 94f67a31 — feat(k8s): honor $KUBECONFIG env var

`default_kubeconfig_path` ignored `$KUBECONFIG`, diverging from kubectl. New order (kubectl-compatible for single-file lookup):

1. `--kubeconfig` CLI flag
2. `$KUBECONFIG` — first entry that exists (`:` on Unix, `;` on Windows)
3. `$HOME/.kube/config`
4. `.kube/config`

Full multi-file merge semantics aren't reproduced (callers needing that construct `kube::Config` directly); this helper only picks one file for actions that read a single kubeconfig (e.g. `read-local-kubeconfig`).

Refactored to a testable core that takes env vars + filesystem predicate as arguments so tests don't race on process-global env vars.

## Verification
- `cargo build --workspace` ✓
- `cargo test --workspace` ✓
- `make lint` ✓
- New tests: 5 for `resolve_default_kubeconfig_path` covering precedence, empty entries, and fallbacks.
