### PR TITLE
Infer Kubernetes services from injected environment variables

### DIFF
--- a/crates/campaign/src/analyzers.rs
+++ b/crates/campaign/src/analyzers.rs
@@ -1,6 +1,8 @@
+use std::collections::HashMap;
+
 use ran_domain::{
-    AuthenticatesTo, BindsTo, Confidence, Contains, DaemonSet, Deployment, Entity, EntityId,
-    GCPServiceAccount, Grants, Job, K8sCluster, K8sCredential, K8sGateway, K8sHTTPRoute,
+    AuthenticatesTo, BindsTo, CanReach, Confidence, Contains, DaemonSet, Deployment, Entity,
+    EntityId, GCPServiceAccount, Grants, Job, K8sCluster, K8sCredential, K8sGateway, K8sHTTPRoute,
     K8sIngress, K8sNode, K8sRole, K8sRoleBinding, K8sService, KubeletExecSink, KubeletExecSource,
     NameConfidence, Namespace, Owns, Pod, PodExec, RbacPermission, RbacScopeKind, RbacScopeSource,
     RunsOn, ServiceAccount, StatefulSet, UnknownSystem, Uses,
@@ -1808,6 +1810,203 @@ impl InferenceRule for KubeconfigCredentialAnalyzer {
 }
 
 // ---------------------------------------------------------------------------
+// KubeEnvVarAnalyzer
+// ---------------------------------------------------------------------------
+
+/// One system carrying environment variables that may describe K8s Services.
+struct EnvTarget {
+    id: EntityId,
+    env_vars: HashMap<String, String>,
+    /// The target's own namespace, when it has one. Only pods do.
+    namespace: Option<String>,
+    /// `true` for an `UnknownSystem`, whose cluster membership no other
+    /// analyzer establishes. Pods and nodes are placed by their own rules.
+    needs_cluster_link: bool,
+}
+
+/// Reconstruct Kubernetes facts from the environment variables kubelet injects
+/// into containers.
+///
+/// This restores the analyzer lost in the Go → Rust rewrite
+/// (`legacy/src/campaign/analyzers.go::analyzeEnvironmentVariables`), with two
+/// corrections to the original:
+///
+/// 1. **It does not infer pod-ness.** The legacy version cast its source entity
+///    to a `Pod`, but `sys.envVar` has precondition `kind: System` and runs
+///    against nodes and unknown systems too. Deciding what kind of system a
+///    target is belongs to a separate rule built on container fingerprints
+///    (see issue #56); here the target's existing type decides what may be
+///    derived from it.
+/// 2. **`KUBERNETES_SERVICE_HOST` is a Service VIP, not a pod address.** The
+///    legacy version invented a `kube-system/api-server` Pod holding that IP.
+///    It is in fact the ClusterIP of the `kubernetes` Service in `default`,
+///    realized by kube-proxy/eBPF DNAT — no pod owns it, and attributing it to
+///    one would let `IpBasedSystemMergeAnalyzer` merge an unrelated system into
+///    the phantom pod.
+///
+/// Facts emitted:
+///
+/// * the `kubernetes` Service in `default` with its ClusterIP, plus
+///   `can-reach(system → service)`: an API-server endpoint this target can talk
+///   to, which holds whatever kind of system it turns out to be;
+/// * `K8sCluster.server`, when exactly one cluster is known and its address is
+///   still unset;
+/// * `contains(cluster → system)` for an `UnknownSystem` carrying the injected
+///   master-service variables. Kubelet injects them, so the system is running
+///   inside the cluster. The one exception is a host where they were exported
+///   by hand — bastions and CI runners do this so client-go's
+///   `InClusterConfig()` works from outside — which makes this a strong signal
+///   rather than a certainty; the `can-reach` edge above is the part that
+///   always holds.
+/// * one Service per `<NAME>_SERVICE_HOST` group, but only for a target with a
+///   known namespace. Service links are namespace-local, and a node or unknown
+///   system has no namespace to attribute them to.
+pub struct KubeEnvVarAnalyzer;
+
+impl InferenceRule for KubeEnvVarAnalyzer {
+    fn name(&self) -> &'static str {
+        "envvar.kubernetes"
+    }
+
+    fn infer(&self, campaign: &Campaign, update: &FactsUpdate) -> FactsUpdate {
+        let mut inferred = FactsUpdate::default();
+        let view = PendingView::new(campaign, update);
+
+        // Env vars reach an entity through `apply_system_update`, which mutates
+        // committed state in place rather than emitting a new entity, so the
+        // trigger has to be a scan of every system rather than `new_entities`.
+        let mut targets: Vec<EnvTarget> = Vec::new();
+        for pod in view.collect::<Pod>() {
+            targets.push(EnvTarget {
+                id: pod.entity_id(),
+                // `"?"` is the placeholder for a pod discovered without its
+                // namespace (see `KubeletMountAnalyzer`). Attributing services
+                // to it would strand them in a namespace that never resolves,
+                // so it counts as unknown here.
+                namespace: pod
+                    .namespace()
+                    .filter(|ns| !ns.is_empty() && *ns != "?")
+                    .map(str::to_string),
+                env_vars: pod.system.env_vars.clone(),
+                needs_cluster_link: false,
+            });
+        }
+        for node in view.collect::<K8sNode>() {
+            targets.push(EnvTarget {
+                id: node.entity_id(),
+                namespace: None,
+                env_vars: node.system.env_vars.clone(),
+                needs_cluster_link: false,
+            });
+        }
+        for system in view.collect::<UnknownSystem>() {
+            targets.push(EnvTarget {
+                id: system.entity_id(),
+                namespace: None,
+                env_vars: system.system.env_vars.clone(),
+                needs_cluster_link: true,
+            });
+        }
+
+        let clusters = view.collect::<K8sCluster>();
+        let cluster_ids: Vec<EntityId> = clusters.iter().map(Entity::entity_id).collect();
+        let relations = view.relations();
+
+        for target in targets {
+            if target.env_vars.is_empty() {
+                continue;
+            }
+
+            for env_service in crate::kube_env::services_from_env(&target.env_vars) {
+                // The master service always lives in `default`; linked services
+                // always live in the observing pod's namespace.
+                let service_namespace = if env_service.is_master_service() {
+                    Some(crate::kube_env::MASTER_SERVICE_NAMESPACE.to_string())
+                } else {
+                    target.namespace.clone()
+                };
+                let Some(service_namespace) = service_namespace else {
+                    continue;
+                };
+
+                let mut service = K8sService::new(env_service.name.clone(), service_namespace);
+                service.cluster_ip = Some(env_service.cluster_ip.clone());
+                service.ports = env_service.ports.clone();
+                // `service_type` stays empty: env vars are injected for
+                // ClusterIP, NodePort and LoadBalancer services alike, so the
+                // type is not observable here. `K8sService::merge_from` fills it
+                // in once the API is read.
+                let service_id = service.entity_id();
+
+                // Re-emitting an unchanged entity every fixpoint iteration would
+                // keep the loop spinning to its iteration cap, so only emit when
+                // something is actually added.
+                let adds_facts = match view.find::<K8sService>(&service_id) {
+                    None => true,
+                    Some(known) => {
+                        known.cluster_ip.is_none()
+                            || (known.ports.is_empty() && !service.ports.is_empty())
+                    }
+                };
+                if adds_facts {
+                    inferred.new_entities.push(Box::new(service));
+                }
+
+                let reachable = relations.iter().any(|relation| {
+                    relation.name == "can-reach"
+                        && relation.source_id == target.id.0
+                        && relation.target_id == service_id.0
+                });
+                if !reachable {
+                    inferred.new_relations.push(Box::new(CanReach::new(
+                        target.id.0.clone(),
+                        service_id.0.clone(),
+                    )));
+                }
+
+                if !env_service.is_master_service() {
+                    continue;
+                }
+
+                // Cluster-level facts follow only from the master service, and
+                // only when there is exactly one candidate cluster to attach to.
+                let [cluster] = clusters.as_slice() else {
+                    continue;
+                };
+
+                if cluster.server.is_none() {
+                    // A server address already learned from a kubeconfig is an
+                    // external URL for the same cluster; leave it alone rather
+                    // than overwrite it with the in-cluster VIP.
+                    let port = env_service.ports.first().map(|p| p.port).unwrap_or(443);
+                    let mut resolved = cluster.clone();
+                    resolved.server = Some(format!("https://{}:{}", env_service.cluster_ip, port));
+                    inferred.new_entities.push(Box::new(resolved));
+                }
+
+                if target.needs_cluster_link {
+                    let already_placed = relations.iter().any(|relation| {
+                        relation.name == "contains"
+                            && relation.target_id == target.id.0
+                            && cluster_ids
+                                .iter()
+                                .any(|candidate| candidate.0 == relation.source_id)
+                    });
+                    if !already_placed {
+                        inferred.new_relations.push(Box::new(Contains::new(
+                            cluster.entity_id().0.clone(),
+                            target.id.0.clone(),
+                        )));
+                    }
+                }
+            }
+        }
+
+        inferred
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Default rule pipeline
 // ---------------------------------------------------------------------------
 
@@ -1842,6 +2041,7 @@ pub fn default_rules() -> Vec<Box<dyn InferenceRule>> {
         Box::new(HTTPRouteNamespaceAnalyzer),
         Box::new(IpBasedSystemMergeAnalyzer),
         Box::new(KubeconfigCredentialAnalyzer),
+        Box::new(KubeEnvVarAnalyzer),
     ]
 }
 
@@ -3721,5 +3921,284 @@ mod tests {
             }),
             "expected RunsOn(argocd-84cc979b → node/cplane-01)"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // KubeEnvVarAnalyzer
+    // -----------------------------------------------------------------------
+
+    /// The variables kubelet injects into every container it starts.
+    fn master_service_env() -> Vec<(String, String)> {
+        [
+            ("KUBERNETES_SERVICE_HOST", "10.96.0.1"),
+            ("KUBERNETES_SERVICE_PORT", "443"),
+            ("KUBERNETES_SERVICE_PORT_HTTPS", "443"),
+            ("KUBERNETES_PORT_443_TCP", "tcp://10.96.0.1:443"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+    }
+
+    fn pod_with_env(name: &str, namespace: &str, env: Vec<(String, String)>) -> Pod {
+        let mut pod = Pod::new(name, namespace);
+        pod.system.env_vars.extend(env);
+        pod
+    }
+
+    #[test]
+    fn master_service_env_yields_the_kubernetes_service_and_reachability() {
+        let mut campaign = test_campaign();
+        campaign
+            .entities
+            .insert_typed(pod_with_env("demo", "default", master_service_env()));
+        let pod_id = "ns/default/pod/demo";
+
+        let rules = default_rules();
+        let update = run_rules_fixpoint(&campaign, &rules, FactsUpdate::default());
+
+        let service = update
+            .new_entities
+            .iter()
+            .find(|e| e.entity_id().0 == "ns/default/svc/kubernetes")
+            .and_then(|e| e.as_any().downcast_ref::<K8sService>())
+            .expect("expected the kubernetes service in namespace default");
+        assert_eq!(service.cluster_ip.as_deref(), Some("10.96.0.1"));
+        assert_eq!(service.ports.len(), 1);
+        assert_eq!(service.ports[0].port, 443);
+        assert_eq!(service.ports[0].name.as_deref(), Some("https"));
+        // The type is not observable from env vars and must not be guessed.
+        assert!(service.service_type.is_empty());
+
+        assert!(
+            update.new_relations.iter().any(|r| {
+                r.is::<CanReach>()
+                    && r.source_id().0 == pod_id
+                    && r.target_id().0 == "ns/default/svc/kubernetes"
+            }),
+            "expected can-reach(pod → kubernetes service)"
+        );
+    }
+
+    #[test]
+    fn master_service_env_fills_in_an_unknown_cluster_address() {
+        let mut campaign = test_campaign();
+        campaign
+            .entities
+            .insert_typed(pod_with_env("demo", "default", master_service_env()));
+
+        let rules = default_rules();
+        let update = run_rules_fixpoint(&campaign, &rules, FactsUpdate::default());
+
+        let cluster = update
+            .new_entities
+            .iter()
+            .filter_map(|e| e.as_any().downcast_ref::<K8sCluster>())
+            .next()
+            .expect("expected the cluster to be re-emitted with its address");
+        assert_eq!(cluster.server.as_deref(), Some("https://10.96.0.1:443"));
+    }
+
+    #[test]
+    fn a_cluster_address_from_a_kubeconfig_is_not_overwritten() {
+        let mut campaign = test_campaign();
+        let existing = campaign
+            .entities
+            .values::<K8sCluster>()
+            .next()
+            .unwrap()
+            .clone()
+            .with_server(Some("https://prod.example.com:6443".to_string()));
+        campaign.entities.insert_typed(existing);
+        campaign
+            .entities
+            .insert_typed(pod_with_env("demo", "default", master_service_env()));
+
+        let rules = default_rules();
+        let update = run_rules_fixpoint(&campaign, &rules, FactsUpdate::default());
+
+        assert!(
+            !update
+                .new_entities
+                .iter()
+                .any(|e| e.as_any().is::<K8sCluster>()),
+            "cluster with a known external address must be left alone"
+        );
+    }
+
+    #[test]
+    fn linked_services_are_placed_in_the_observing_pods_namespace() {
+        let mut campaign = test_campaign();
+        let mut env = master_service_env();
+        env.push(("REDIS_SERVICE_HOST".to_string(), "10.0.0.10".to_string()));
+        env.push(("REDIS_SERVICE_PORT".to_string(), "6379".to_string()));
+        campaign
+            .entities
+            .insert_typed(pod_with_env("app", "shop", env));
+
+        let rules = default_rules();
+        let update = run_rules_fixpoint(&campaign, &rules, FactsUpdate::default());
+
+        let redis = update
+            .new_entities
+            .iter()
+            .find(|e| e.entity_id().0 == "ns/shop/svc/redis")
+            .and_then(|e| e.as_any().downcast_ref::<K8sService>())
+            .expect("expected redis in the pod's own namespace");
+        assert_eq!(redis.cluster_ip.as_deref(), Some("10.0.0.10"));
+
+        // The master service belongs to `default`, never to the pod's namespace.
+        assert!(update
+            .new_entities
+            .iter()
+            .any(|e| e.entity_id().0 == "ns/default/svc/kubernetes"));
+        assert!(!update
+            .new_entities
+            .iter()
+            .any(|e| e.entity_id().0 == "ns/shop/svc/kubernetes"));
+    }
+
+    #[test]
+    fn a_node_target_yields_only_the_master_service() {
+        // A node has no namespace, so namespace-local service links cannot be
+        // attributed and are dropped rather than guessed at.
+        let mut campaign = test_campaign();
+        let mut node = K8sNode::new("node-1");
+        node.system.env_vars.extend(master_service_env());
+        node.system
+            .env_vars
+            .insert("REDIS_SERVICE_HOST".to_string(), "10.0.0.10".to_string());
+        campaign.entities.insert_typed(node);
+
+        let rules = default_rules();
+        let update = run_rules_fixpoint(&campaign, &rules, FactsUpdate::default());
+
+        let services: Vec<&str> = update
+            .new_entities
+            .iter()
+            .filter(|e| e.entity_kind() == "Service")
+            .map(|e| e.entity_name())
+            .collect();
+        assert_eq!(services, vec!["kubernetes"]);
+
+        assert!(
+            update.new_relations.iter().any(|r| {
+                r.is::<CanReach>()
+                    && r.source_id().0 == "node/node-1"
+                    && r.target_id().0 == "ns/default/svc/kubernetes"
+            }),
+            "expected can-reach(node → kubernetes service)"
+        );
+    }
+
+    #[test]
+    fn an_unknown_system_with_injected_vars_is_placed_in_the_cluster() {
+        let mut campaign = test_campaign();
+        let cluster_id = campaign
+            .entities
+            .values::<K8sCluster>()
+            .next()
+            .unwrap()
+            .entity_id();
+        let mut system = UnknownSystem::new("10.0.0.42");
+        system.system.env_vars.extend(master_service_env());
+        let system_id = system.entity_id();
+        campaign.entities.insert_typed(system);
+
+        let rules = default_rules();
+        let update = run_rules_fixpoint(&campaign, &rules, FactsUpdate::default());
+
+        assert!(
+            update.new_relations.iter().any(|r| {
+                r.is::<Contains>()
+                    && r.source_id().0 == cluster_id.0
+                    && r.target_id().0 == system_id.0
+            }),
+            "expected contains(cluster → unknown system)"
+        );
+    }
+
+    #[test]
+    fn a_pod_with_a_placeholder_namespace_gets_no_linked_services() {
+        // A pod discovered from node mounts carries namespace `"?"`. Service
+        // links must not be stranded there; the master service is unaffected
+        // because it lives in `default` by definition.
+        let mut campaign = test_campaign();
+        let mut env = master_service_env();
+        env.push(("REDIS_SERVICE_HOST".to_string(), "10.0.0.10".to_string()));
+        env.push(("REDIS_SERVICE_PORT".to_string(), "6379".to_string()));
+        campaign
+            .entities
+            .insert_typed(pod_with_env("argocd-84cc979b", "?", env));
+
+        let rules = default_rules();
+        let update = run_rules_fixpoint(&campaign, &rules, FactsUpdate::default());
+
+        let services: Vec<String> = update
+            .new_entities
+            .iter()
+            .filter(|e| e.entity_kind() == "Service")
+            .map(|e| e.entity_id().0)
+            .collect();
+        assert_eq!(services, vec!["ns/default/svc/kubernetes".to_string()]);
+    }
+
+    #[test]
+    fn env_vars_without_service_entries_produce_nothing() {
+        let mut campaign = test_campaign();
+        let env = vec![
+            ("HOME".to_string(), "/root".to_string()),
+            ("PATH".to_string(), "/usr/bin".to_string()),
+        ];
+        campaign
+            .entities
+            .insert_typed(pod_with_env("demo", "default", env));
+
+        let rules = default_rules();
+        let update = run_rules_fixpoint(&campaign, &rules, FactsUpdate::default());
+
+        assert!(
+            !update
+                .new_entities
+                .iter()
+                .any(|e| e.entity_kind() == "Service"),
+            "no service variables means no services"
+        );
+        assert!(!update.new_relations.iter().any(|r| r.is::<CanReach>()));
+    }
+
+    #[test]
+    fn a_known_service_is_not_re_emitted() {
+        let mut campaign = test_campaign();
+        campaign
+            .entities
+            .insert_typed(pod_with_env("demo", "default", master_service_env()));
+        let mut known = K8sService::new("kubernetes", "default");
+        known.cluster_ip = Some("10.96.0.1".to_string());
+        known.service_type = "ClusterIP".to_string();
+        known.ports = vec![ran_domain::K8sServicePort {
+            port: 443,
+            target_port: "6443".to_string(),
+            protocol: "TCP".to_string(),
+            name: Some("https".to_string()),
+            node_port: None,
+        }];
+        campaign.entities.insert_typed(known);
+
+        let rules = default_rules();
+        let update = run_rules_fixpoint(&campaign, &rules, FactsUpdate::default());
+
+        assert!(
+            !update
+                .new_entities
+                .iter()
+                .any(|e| e.entity_kind() == "Service"),
+            "an already-known service must not be re-emitted"
+        );
+        // The reachability edge is still new and must still be recorded.
+        assert!(update
+            .new_relations
+            .iter()
+            .any(|r| { r.is::<CanReach>() && r.target_id().0 == "ns/default/svc/kubernetes" }));
     }
 }

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -136,6 +136,63 @@ fn on_ttp_executed_parses_sys_envvar_into_target_system_info() {
 }
 
 #[test]
+fn on_ttp_executed_derives_cluster_facts_from_injected_env_vars() {
+    // End-to-end: `sys.envvar` writes the variables straight onto the committed
+    // entity via `apply_system_update`, so `KubeEnvVarAnalyzer` has to pick them
+    // up from a scan of campaign state rather than from `new_entities`.
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev-cluster"));
+    let pod = Pod::new("demo", "shop");
+    let target_id = pod.entity_id().0.clone();
+    campaign.entities.insert_typed(pod);
+
+    let cmd = sample_exec_ttp(&target_id, vec!["sys.envvar"]);
+    let event = sample_event(
+        "HOME=/root\n\
+         KUBERNETES_SERVICE_HOST=10.96.0.1\n\
+         KUBERNETES_SERVICE_PORT=443\n\
+         KUBERNETES_SERVICE_PORT_HTTPS=443\n\
+         REDIS_SERVICE_HOST=10.0.0.10\n\
+         REDIS_SERVICE_PORT=6379\n",
+    );
+
+    campaign.on_ttp_executed(&cmd, &event).unwrap();
+
+    // The master service always lands in `default`, the linked one in the pod's
+    // own namespace.
+    let services: Vec<String> = campaign
+        .entities
+        .values::<ran_domain::K8sService>()
+        .map(|s| s.entity_id().0)
+        .collect();
+    assert!(
+        services.contains(&"ns/default/svc/kubernetes".to_string()),
+        "expected the kubernetes service, got: {:?}",
+        services
+    );
+    assert!(
+        services.contains(&"ns/shop/svc/redis".to_string()),
+        "expected redis in the pod's namespace, got: {:?}",
+        services
+    );
+
+    let relations = campaign.get_relations();
+    assert!(
+        relations.iter().any(|r| r.name == "can-reach"
+            && r.source_id == target_id
+            && r.target_id == "ns/default/svc/kubernetes"),
+        "expected can-reach(pod → kubernetes service)"
+    );
+
+    // The cluster address is now known from inside the cluster.
+    let cluster = campaign
+        .entities
+        .values::<K8sCluster>()
+        .next()
+        .expect("cluster");
+    assert_eq!(cluster.server.as_deref(), Some("https://10.96.0.1:443"));
+}
+
+#[test]
 fn on_ttp_executed_marks_exec_pod_running_before_kubelet_source_inference() {
     let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev-cluster"));
 

--- a/crates/campaign/src/kube_env.rs
+++ b/crates/campaign/src/kube_env.rs
@@ -1,0 +1,353 @@
+//! Reconstruct Kubernetes Service facts from container environment variables.
+//!
+//! Kubelet injects a set of environment variables into every container it
+//! starts (`getServiceEnvVarMap` in `pkg/kubelet/kubelet_pods.go`, rendered by
+//! `pkg/kubelet/envvars`). Two tiers exist:
+//!
+//! * The `kubernetes` Service from the `default` namespace is **always**
+//!   injected — `KUBERNETES_SERVICE_HOST`, `KUBERNETES_SERVICE_PORT` and the
+//!   Docker-legacy `KUBERNETES_PORT_443_TCP*` family — regardless of the pod's
+//!   `enableServiceLinks` setting.
+//! * Every other Service is injected only when it lives in the pod's own
+//!   namespace, carries a real ClusterIP (headless services are skipped),
+//!   existed before the container started, and `enableServiceLinks` is true
+//!   (the PodSpec default).
+//!
+//! Consequences for inference:
+//!
+//! * `KUBERNETES_SERVICE_HOST` is a reliable "kubelet injected this" signal,
+//!   and is not distro-specific — only its value varies between clusters.
+//! * The *absence* of `<NAME>_SERVICE_HOST` entries proves nothing: charts
+//!   commonly set `enableServiceLinks: false`, headless services never appear,
+//!   and cross-namespace services are never linked.
+//! * Every value is a snapshot from container-start time, so a Service that has
+//!   since been deleted or re-assigned a ClusterIP still shows its old address.
+//! * The values are writable by the workload, so nothing derived here is
+//!   authoritative — entities keep the default `NameConfidence::Derived`.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+
+use ran_domain::K8sServicePort;
+
+/// Namespace of the Service whose address kubelet always injects.
+pub const MASTER_SERVICE_NAMESPACE: &str = "default";
+
+/// Name of that Service.
+pub const MASTER_SERVICE_NAME: &str = "kubernetes";
+
+const SERVICE_HOST_SUFFIX: &str = "_SERVICE_HOST";
+const SERVICE_PORT_SUFFIX: &str = "_SERVICE_PORT";
+
+/// A Kubernetes Service reconstructed from environment variables.
+#[derive(Debug, Clone)]
+pub struct EnvService {
+    /// Service name, mapped back from the env-var prefix.
+    pub name: String,
+    /// ClusterIP, read from `<PREFIX>_SERVICE_HOST`.
+    pub cluster_ip: String,
+    /// Ports, read from `<PREFIX>_SERVICE_PORT[_<PORTNAME>]`, ordered by number.
+    pub ports: Vec<K8sServicePort>,
+}
+
+impl EnvService {
+    /// True for the `kubernetes` Service, which kubelet injects into every
+    /// container regardless of `enableServiceLinks`. It lives in the `default`
+    /// namespace, not in the namespace of the pod that observed it.
+    pub fn is_master_service(&self) -> bool {
+        self.name == MASTER_SERVICE_NAME
+    }
+}
+
+/// Extract every Service described by the given environment variables.
+///
+/// The heuristic follows kubelet's own generator in reverse:
+///
+/// 1. Every `<PREFIX>_SERVICE_HOST` key names one Service. A Service with no
+///    host entry cannot be located, so it is skipped.
+/// 2. The host value must parse as an IP address. ClusterIPs always do, and the
+///    check rejects a Service whose *port* happens to be named `service-host`
+///    (which would otherwise produce the key `FOO_SERVICE_PORT_SERVICE_HOST`
+///    and be mistaken for a Service called `foo-service-port`).
+/// 3. Ports come from the exact key `<PREFIX>_SERVICE_PORT` and from keys
+///    prefixed `<PREFIX>_SERVICE_PORT_`. Matching the full prefix rather than
+///    just `<PREFIX>` keeps sibling Services apart: `redis` must not absorb the
+///    variables belonging to `redis-replica`.
+///
+/// Results are sorted by name so callers see a deterministic order.
+pub fn services_from_env(env: &HashMap<String, String>) -> Vec<EnvService> {
+    let mut prefixes: Vec<&str> = env
+        .keys()
+        .filter_map(|key| key.strip_suffix(SERVICE_HOST_SUFFIX))
+        .filter(|prefix| !prefix.is_empty())
+        .collect();
+    prefixes.sort_unstable();
+
+    let mut services = Vec::new();
+    for prefix in prefixes {
+        let Some(host) = env.get(&format!("{prefix}{SERVICE_HOST_SUFFIX}")) else {
+            continue;
+        };
+        let host = host.trim();
+        if host.parse::<IpAddr>().is_err() {
+            continue;
+        }
+
+        services.push(EnvService {
+            name: service_name_from_env(prefix),
+            cluster_ip: host.to_string(),
+            ports: ports_for_prefix(env, prefix),
+        });
+    }
+
+    services.sort_by(|a, b| a.name.cmp(&b.name));
+    services
+}
+
+/// Map an env-var fragment back to the Kubernetes object name it came from.
+///
+/// Kubelet upper-cases the name and rewrites `-` as `_`. The mapping is
+/// lossless in reverse because Service names are DNS-1035 labels and port names
+/// are IANA service names — neither may contain an underscore or an upper-case
+/// character.
+fn service_name_from_env(fragment: &str) -> String {
+    fragment.to_ascii_lowercase().replace('_', "-")
+}
+
+fn ports_for_prefix(env: &HashMap<String, String>, prefix: &str) -> Vec<K8sServicePort> {
+    let named_prefix = format!("{prefix}{SERVICE_PORT_SUFFIX}_");
+    let mut ports: Vec<K8sServicePort> = Vec::new();
+
+    for (key, value) in env {
+        let Some(port_name) = key.strip_prefix(&named_prefix) else {
+            continue;
+        };
+        if port_name.is_empty() {
+            continue;
+        }
+        let Ok(port) = value.trim().parse::<i32>() else {
+            continue;
+        };
+        ports.push(K8sServicePort {
+            port,
+            target_port: String::new(),
+            protocol: protocol_for_port(env, prefix, port),
+            name: Some(service_name_from_env(port_name)),
+            node_port: None,
+        });
+    }
+
+    // The unnamed `<PREFIX>_SERVICE_PORT` repeats the Service's first port, so
+    // it only adds information when no named entry already covers that number.
+    if let Some(value) = env.get(&format!("{prefix}{SERVICE_PORT_SUFFIX}")) {
+        if let Ok(port) = value.trim().parse::<i32>() {
+            if !ports.iter().any(|existing| existing.port == port) {
+                ports.push(K8sServicePort {
+                    port,
+                    target_port: String::new(),
+                    protocol: protocol_for_port(env, prefix, port),
+                    name: None,
+                    node_port: None,
+                });
+            }
+        }
+    }
+
+    ports.sort_by(|a, b| a.port.cmp(&b.port).then_with(|| a.name.cmp(&b.name)));
+    ports
+}
+
+/// Recover a port's protocol from the Docker-legacy variables kubelet also
+/// emits (`<PREFIX>_PORT_<port>_<PROTO>`).
+///
+/// Those variables are keyed by port *number*, while named ports are keyed by
+/// name, so the two cannot be joined when one number is exposed under several
+/// protocols — CoreDNS publishes `dns` (UDP) and `dns-tcp` (TCP) both on 53.
+/// A protocol is therefore only reported when it is the sole one advertised for
+/// that number; otherwise the Kubernetes default of TCP stands.
+fn protocol_for_port(env: &HashMap<String, String>, prefix: &str, port: i32) -> String {
+    let advertised: Vec<&str> = ["TCP", "UDP", "SCTP"]
+        .into_iter()
+        .filter(|proto| env.contains_key(&format!("{prefix}_PORT_{port}_{proto}")))
+        .collect();
+
+    match advertised.as_slice() {
+        [only] => only.to_string(),
+        _ => "TCP".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn env(pairs: &[(&str, &str)]) -> HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    /// The variable block every kubelet-managed container receives, taken from
+    /// the Kubernetes container-environment documentation.
+    fn master_service_env() -> HashMap<String, String> {
+        env(&[
+            ("KUBERNETES_PORT", "tcp://10.96.0.1:443"),
+            ("KUBERNETES_PORT_443_TCP", "tcp://10.96.0.1:443"),
+            ("KUBERNETES_PORT_443_TCP_ADDR", "10.96.0.1"),
+            ("KUBERNETES_PORT_443_TCP_PORT", "443"),
+            ("KUBERNETES_PORT_443_TCP_PROTO", "tcp"),
+            ("KUBERNETES_SERVICE_HOST", "10.96.0.1"),
+            ("KUBERNETES_SERVICE_PORT", "443"),
+            ("KUBERNETES_SERVICE_PORT_HTTPS", "443"),
+        ])
+    }
+
+    #[test]
+    fn extracts_the_master_service() {
+        let services = services_from_env(&master_service_env());
+
+        assert_eq!(services.len(), 1);
+        let svc = &services[0];
+        assert_eq!(svc.name, "kubernetes");
+        assert!(svc.is_master_service());
+        assert_eq!(svc.cluster_ip, "10.96.0.1");
+        // `KUBERNETES_SERVICE_PORT` and `KUBERNETES_SERVICE_PORT_HTTPS` are the
+        // same port — the named entry wins and the number is not duplicated.
+        assert_eq!(svc.ports.len(), 1);
+        assert_eq!(svc.ports[0].port, 443);
+        assert_eq!(svc.ports[0].name.as_deref(), Some("https"));
+        assert_eq!(svc.ports[0].protocol, "TCP");
+    }
+
+    #[test]
+    fn maps_underscores_back_to_dashes_in_service_names() {
+        let services = services_from_env(&env(&[
+            ("MY_SVC_SERVICE_HOST", "10.0.0.7"),
+            ("MY_SVC_SERVICE_PORT", "8080"),
+        ]));
+
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "my-svc");
+        assert_eq!(services[0].ports[0].port, 8080);
+        assert_eq!(services[0].ports[0].name, None);
+    }
+
+    #[test]
+    fn sibling_services_do_not_absorb_each_others_ports() {
+        // The legacy Go implementation matched variables by `HasPrefix(key, name)`,
+        // so `REDIS` also swept up every `REDIS_REPLICA_*` entry.
+        let services = services_from_env(&env(&[
+            ("REDIS_SERVICE_HOST", "10.0.0.10"),
+            ("REDIS_SERVICE_PORT", "6379"),
+            ("REDIS_REPLICA_SERVICE_HOST", "10.0.0.11"),
+            ("REDIS_REPLICA_SERVICE_PORT", "6380"),
+            ("REDIS_REPLICA_SERVICE_PORT_METRICS", "9121"),
+        ]));
+
+        assert_eq!(services.len(), 2);
+
+        let redis = services.iter().find(|s| s.name == "redis").unwrap();
+        assert_eq!(redis.cluster_ip, "10.0.0.10");
+        assert_eq!(redis.ports.len(), 1);
+        assert_eq!(redis.ports[0].port, 6379);
+
+        let replica = services.iter().find(|s| s.name == "redis-replica").unwrap();
+        assert_eq!(replica.cluster_ip, "10.0.0.11");
+        assert_eq!(
+            replica.ports.iter().map(|p| p.port).collect::<Vec<_>>(),
+            vec![6380, 9121]
+        );
+    }
+
+    #[test]
+    fn skips_services_without_a_host_entry() {
+        // Ports alone cannot locate a service.
+        let services = services_from_env(&env(&[("ORPHAN_SERVICE_PORT", "8080")]));
+        assert!(services.is_empty());
+    }
+
+    #[test]
+    fn skips_host_values_that_are_not_ip_addresses() {
+        // A port named `service-host` yields `FOO_SERVICE_PORT_SERVICE_HOST`,
+        // which ends in the host suffix but holds a port number.
+        let services = services_from_env(&env(&[
+            ("FOO_SERVICE_HOST", "10.0.0.5"),
+            ("FOO_SERVICE_PORT", "80"),
+            ("FOO_SERVICE_PORT_SERVICE_HOST", "8080"),
+        ]));
+
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "foo");
+    }
+
+    #[test]
+    fn handles_a_service_whose_name_ends_in_the_suffix() {
+        let services = services_from_env(&env(&[
+            ("FOO_SERVICE_HOST_SERVICE_HOST", "10.0.0.9"),
+            ("FOO_SERVICE_HOST_SERVICE_PORT", "80"),
+        ]));
+
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "foo-service-host");
+        assert_eq!(services[0].cluster_ip, "10.0.0.9");
+    }
+
+    #[test]
+    fn reads_protocol_from_docker_legacy_variables() {
+        let services = services_from_env(&env(&[
+            ("SYSLOG_SERVICE_HOST", "10.0.0.20"),
+            ("SYSLOG_SERVICE_PORT", "514"),
+            ("SYSLOG_PORT_514_UDP", "udp://10.0.0.20:514"),
+        ]));
+
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].ports[0].protocol, "UDP");
+    }
+
+    #[test]
+    fn falls_back_to_tcp_when_one_port_number_serves_several_protocols() {
+        // CoreDNS publishes `dns` on UDP 53 and `dns-tcp` on TCP 53. The legacy
+        // variables are keyed by number only, so neither named port can claim a
+        // protocol and both keep the Kubernetes default.
+        let services = services_from_env(&env(&[
+            ("KUBE_DNS_SERVICE_HOST", "10.96.0.10"),
+            ("KUBE_DNS_SERVICE_PORT_DNS", "53"),
+            ("KUBE_DNS_SERVICE_PORT_DNS_TCP", "53"),
+            ("KUBE_DNS_PORT_53_UDP", "udp://10.96.0.10:53"),
+            ("KUBE_DNS_PORT_53_TCP", "tcp://10.96.0.10:53"),
+        ]));
+
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0].name, "kube-dns");
+        assert_eq!(
+            services[0]
+                .ports
+                .iter()
+                .map(|p| (p.name.as_deref().unwrap_or(""), p.protocol.as_str()))
+                .collect::<Vec<_>>(),
+            vec![("dns", "TCP"), ("dns-tcp", "TCP")]
+        );
+    }
+
+    #[test]
+    fn ignores_unrelated_environment_variables() {
+        let services = services_from_env(&env(&[
+            ("HOME", "/root"),
+            ("PATH", "/usr/bin"),
+            ("DATABASE_URL", "postgres://user:pw@db:5432/app"),
+        ]));
+        assert!(services.is_empty());
+    }
+
+    #[test]
+    fn ignores_unparseable_port_values() {
+        let services = services_from_env(&env(&[
+            ("APP_SERVICE_HOST", "10.0.0.3"),
+            ("APP_SERVICE_PORT", "not-a-port"),
+        ]));
+
+        assert_eq!(services.len(), 1);
+        assert!(services[0].ports.is_empty());
+    }
+}

--- a/crates/campaign/src/lib.rs
+++ b/crates/campaign/src/lib.rs
@@ -5,6 +5,7 @@ pub mod execution_record;
 pub mod external_parser;
 pub mod failure_analyzers;
 pub mod grounding;
+pub mod kube_env;
 pub mod output_parsers;
 pub mod pending_view;
 pub mod provenance;


### PR DESCRIPTION
Restores the environment-variable analyzer lost in the Go → Rust rewrite
(`legacy/src/campaign/analyzers.go::analyzeEnvironmentVariables`, deleted in 177ceb5b).

Until now `sys.envVar` parsed variables into `SystemInfo.env_vars` and nothing read them back except
`GCPServiceAccountAnalyzer`. An `env` run inside a pod left `KUBERNETES_SERVICE_HOST=10.96.0.1` sitting
inert in a HashMap — no API-server endpoint, no service graph, no reachability edges.

## What it derives

Kubelet injects service variables into every container it starts. The `kubernetes` Service from the
`default` namespace is injected **unconditionally** — not gated by `enableServiceLinks` — so its
presence is a reliable "kubelet-managed container" signal, and the same in every distro (only the
value varies: kubeadm `10.96.0.1`, EKS `172.20.0.1`). Other services are injected only from the pod's
own namespace, only with a real ClusterIP, only when they predate the container, and only when
`enableServiceLinks` is true, so their absence proves nothing.

New `KubeEnvVarAnalyzer` (`envvar.kubernetes`) emits:

* the `kubernetes` Service in `default` with its ClusterIP and ports, plus `can-reach(system → service)`;
* `K8sCluster.server`, when exactly one cluster is known and its address is still unset — an address
  already learned from a kubeconfig is an external URL for the same cluster and is left alone;
* `contains(cluster → system)` for an `UnknownSystem` carrying the injected variables;
* one Service per `<NAME>_SERVICE_HOST` group, but only for a target with a known namespace.

## Two corrections to the legacy behaviour

**It no longer infers pod-ness.** The legacy version hard-cast its source to a `Pod`
(`source.(domain.Pod)`), but `read_environment_variables.yaml` has precondition `kind: System`, and
three entities carry `SystemInfo` — `Pod`, `K8sNode`, `UnknownSystem`. The variables can also appear on
non-pods: nodes with them set in kubelet's systemd env file (standard for kube-proxy-less CNI setups),
bastions where they were exported so `InClusterConfig()` works from outside, and escaped shells that
inherited a container's environment. Identifying what kind of system a target is belongs to a separate
rule built on container fingerprints — #56. Here the target's existing type decides what may be derived,
and namespace-local service links are dropped rather than guessed at when the target has no namespace
(including the `"?"` placeholder used for pods discovered from node mounts).

**`KUBERNETES_SERVICE_HOST` is a Service VIP, not a pod address.** The legacy version invented a
`kube-system/api-server` Pod holding that IP. It is the ClusterIP of the `kubernetes` Service in
`default` (not `kube-system`), realized by kube-proxy/eBPF DNAT — no pod owns it, and attributing it to
one would let `IpBasedSystemMergeAnalyzer` merge unrelated systems into the phantom.

## Bug fixed in the ported heuristic

The Go version grouped variables with `strings.HasPrefix(key, svcName)`, so `redis` swept up every
`REDIS_REPLICA_*` entry. Matching the full `<PREFIX>_SERVICE_PORT` prefix keeps siblings apart.

Host values must also parse as an IP address. Without that guard, a service with a port named
`service-host` yields `FOO_SERVICE_PORT_SERVICE_HOST` — ends in the host suffix, holds a port number —
and would register a phantom service `foo-service-port`.

## Notes for review

* `service_type` is deliberately left empty. Env vars are injected for ClusterIP, NodePort and
  LoadBalancer alike, so the type is not observable; `K8sService::merge_from` fills it once the API is read.
* Env-derived entities keep the default `NameConfidence::Derived`. The values are a snapshot from
  container-start time (a re-IP'd service still shows its old address) and are writable by the workload.
* Protocol comes from the Docker-legacy `<PREFIX>_PORT_<n>_<PROTO>` variables, but only when one protocol
  is advertised for that number. CoreDNS publishes `dns` (UDP) and `dns-tcp` (TCP) both on 53 and those
  variables are keyed by number, so ambiguous cases keep the TCP default.
* The analyzer scans committed state rather than `update.new_entities`, because `sys.envVar` reaches the
  entity through `apply_system_update`, which mutates in place and returns an empty `FactsUpdate`. That
  also forces explicit "does this add anything new?" guards, or the fixpoint spins to its iteration cap.
  #58 tracks fixing the underlying channel; this analyzer can drop its scan once that lands.

## Testing

19 new tests — 10 for the extraction heuristic, 8 for the analyzer, and 1 end-to-end through
`on_ttp_executed` that covers the in-place-update path the rule harness would miss. Full workspace green
(25 targets), clippy clean.

https://claude.ai/code/session_01Rx1J9WcgzodMnAKzLx52Zk
