### PR TITLE
Keep a foothold executable after its entity id changes

### DIFF
--- a/crates/campaign/src/campaign/entity_store.rs
+++ b/crates/campaign/src/campaign/entity_store.rs
@@ -51,6 +51,7 @@ impl<T> EntityType for T where
 
 trait ErasedSlot: std::fmt::Debug + Send + Sync {
     fn len(&self) -> usize;
+    fn contains_id(&self, id: &EntityId) -> bool;
     fn insert_entity(&mut self, id: EntityId, entity: &dyn Entity);
     fn as_any(&self) -> &dyn Any;
     fn as_any_mut(&mut self) -> &mut dyn Any;
@@ -78,6 +79,10 @@ impl<T: EntityType> Slot<T> {
 impl<T: EntityType> ErasedSlot for Slot<T> {
     fn len(&self) -> usize {
         self.data.len()
+    }
+
+    fn contains_id(&self, id: &EntityId) -> bool {
+        self.data.contains_key(id)
     }
 
     fn insert_entity(&mut self, id: EntityId, entity: &dyn Entity) {
@@ -243,6 +248,13 @@ impl EntityStore {
 
     pub fn entity_count(&self) -> usize {
         self.slots.values().map(|s| s.len()).sum()
+    }
+
+    /// Returns `true` when any registered type holds an entity with `id`.
+    /// Type-agnostic counterpart to [`Self::contains`], used to tell a live id
+    /// from one that was merged away (see [`crate::Campaign::canonical_entity_id`]).
+    pub fn contains_id(&self, id: &EntityId) -> bool {
+        self.slots.values().any(|s| s.contains_id(id))
     }
 
     /// Returns a `CampaignEntityRef` for every entity across all registered types.

--- a/crates/campaign/src/campaign/execution.rs
+++ b/crates/campaign/src/campaign/execution.rs
@@ -2171,6 +2171,9 @@ impl Campaign {
             self.graph.merge_entities(preferred_id, stale_id);
             self.knowledge_provenance
                 .merge_entity(stale_id, preferred_id);
+            // Remember the rename: callers holding the old id (C2 session
+            // bookkeeping above all) must still reach the surviving entity.
+            self.record_entity_alias(stale_id, preferred_id);
             // Entity maps: merge runtime data (IPs, access level, binaries, etc.).
             // Dispatch to the correct merge function based on entity kind.
             if stale_id.0.starts_with("system/") {
@@ -2243,6 +2246,7 @@ impl Campaign {
                         };
                         self.graph.merge_entities(&preferred_node, &stale_node);
                         self.merge_node_entities(&preferred_node.0, &stale_node.0);
+                        self.record_entity_alias(&stale_node, &preferred_node);
                         // Insert edge to preferred node (graph PodSingleNode
                         // invariant removes the old runs-on automatically).
                         self.insert_relation_with_ids(&src, &preferred_node, rel.as_ref());

--- a/crates/campaign/src/campaign/state.rs
+++ b/crates/campaign/src/campaign/state.rs
@@ -43,6 +43,18 @@ pub struct Campaign {
     pub session_traversals: HashMap<String, Vec<crate::traversal::TraversalHop>>,
     #[serde(default)]
     pub knowledge_provenance: KnowledgeProvenanceStore,
+    /// Stale entity id → the id it was merged into. Recorded whenever two
+    /// entities turn out to be the same thing: an `UnknownSystem` promoted into
+    /// the Pod it always was, an IP-placeholder pod folded into its real
+    /// identity, a C2-supplied target id resolved to a locally created system.
+    ///
+    /// The merge changes the entity id, but long-lived callers keep the old
+    /// one — the C2 session bookkeeping captures a target id when a shell first
+    /// connects and quotes it back minutes later. Every id-keyed system lookup
+    /// therefore resolves through this table
+    /// (see [`Self::canonical_entity_id`]).
+    #[serde(default)]
+    pub entity_aliases: HashMap<EntityId, EntityId>,
 }
 
 #[derive(Debug, Clone)]
@@ -199,6 +211,7 @@ impl Campaign {
             command_traversals: HashMap::new(),
             session_traversals: HashMap::new(),
             knowledge_provenance,
+            entity_aliases: HashMap::new(),
         }
     }
 
@@ -304,8 +317,37 @@ impl Campaign {
             .collect()
     }
 
+    /// Follow [`Self::entity_aliases`] until the id names a live entity.
+    ///
+    /// An id that is still in the entity store is returned unchanged, so an
+    /// alias can never shadow an entity that exists — only ids that were merged
+    /// away (or were never created in the first place) are rewritten. Bounded
+    /// so a cyclic alias pair cannot spin.
+    pub fn canonical_entity_id(&self, id: &str) -> String {
+        let mut current = EntityId::new(id);
+        for _ in 0..16 {
+            if self.entities.contains_id(&current) {
+                break;
+            }
+            match self.entity_aliases.get(&current) {
+                Some(next) if *next != current => current = next.clone(),
+                _ => break,
+            }
+        }
+        current.0
+    }
+
+    /// Record that `stale` was merged into `preferred`, so later lookups keyed
+    /// by the old id still land on the surviving entity.
+    pub fn record_entity_alias(&mut self, stale: &EntityId, preferred: &EntityId) {
+        if stale == preferred {
+            return;
+        }
+        self.entity_aliases.insert(stale.clone(), preferred.clone());
+    }
+
     pub fn get_system_entity(&self, id: &str) -> Option<CampaignSystemEntityRef<'_>> {
-        let entity_id = EntityId::new(id);
+        let entity_id = EntityId::new(self.canonical_entity_id(id));
 
         if let Some(node) = self.entities.find::<K8sNode>(&entity_id) {
             return Some(CampaignSystemEntityRef::Node(node));
@@ -319,7 +361,7 @@ impl Campaign {
     }
 
     pub fn get_system_entity_mut(&mut self, id: &str) -> Option<CampaignSystemEntityMut<'_>> {
-        let entity_id = EntityId::new(id);
+        let entity_id = EntityId::new(self.canonical_entity_id(id));
 
         if self.entities.contains::<K8sNode>(&entity_id) {
             return self
@@ -365,6 +407,10 @@ impl Campaign {
         target_id: &str,
         prefer_session: bool,
     ) -> Result<ExecChannel, String> {
+        // The caller may hold an id that was merged away (a promoted foothold,
+        // a pod that gained its real name); route to whatever it became.
+        let canonical = self.canonical_entity_id(target_id);
+        let target_id = canonical.as_str();
         let target_eid = EntityId::new(target_id);
 
         // Prefer an Active session on the target system — it is a live shell
@@ -495,6 +541,13 @@ impl Campaign {
         source_id: &str,
         target_id: &str,
     ) -> Result<ExecChannel, String> {
+        // Both ids come from the UI and may predate a merge (the operator was
+        // looking at the foothold before it became a pod).
+        let canonical_source = self.canonical_entity_id(source_id);
+        let canonical_target = self.canonical_entity_id(target_id);
+        let source_id = canonical_source.as_str();
+        let target_id = canonical_target.as_str();
+
         let source_eid = EntityId::new(source_id);
         if !self.is_system_entity_id(&source_eid) {
             return Err(format!(
@@ -668,7 +721,7 @@ impl Campaign {
     /// Returns `true` when a matching edge was found; the caller should only
     /// create a new `SessionChannel` relation when this returns `false`.
     pub fn activate_session_on_exec_channel(&mut self, target_id: &str, backend_id: &str) -> bool {
-        let target_eid = EntityId::new(target_id);
+        let target_eid = EntityId::new(self.canonical_entity_id(target_id));
         self.graph
             .activate_session_on_incoming_exec(&target_eid, backend_id.to_string())
     }
@@ -777,6 +830,7 @@ mod planner_helper_tests {
             command_traversals: std::collections::HashMap::new(),
             session_traversals: std::collections::HashMap::new(),
             knowledge_provenance: KnowledgeProvenanceStore::default(),
+            entity_aliases: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -15,6 +15,106 @@ use super::{Campaign, ExecChannel, ExecuteActionError, ExecuteActionRequest};
 fn push_relation(campaign: &mut Campaign, rel: &dyn ran_domain::Relation) {
     campaign.insert_relation(rel);
 }
+
+// ---------------------------------------------------------------------------
+// Entity-id aliases (ids that changed under their holders after a merge)
+// ---------------------------------------------------------------------------
+
+/// An `UnknownSystem` folded into the pod discovered at the same IP: the same
+/// id change the promotion path makes, taken through `IpBasedSystemMergeAnalyzer`.
+#[test]
+fn a_merged_away_system_id_resolves_to_the_surviving_pod() {
+    use ran_domain::UnknownSystem;
+
+    let mut campaign = Campaign::bootstrap("ran", K8sCluster::new("test-cluster"));
+    let mut system = UnknownSystem::new("10.244.0.9");
+    system.system.sessions.push(SessionInfo {
+        id: "s1".to_string(),
+        kind: "tcp".to_string(),
+        port: Some(4444),
+        status: SessionStatus::Active,
+    });
+    let stale_id = system.entity_id();
+    campaign.insert_entity(&system);
+
+    let pod = Pod::new("netshoot", "default");
+    let pod_id = pod.entity_id();
+    let mut facts = crate::FactsUpdate::default();
+    facts.new_entities.push(Box::new(pod));
+    facts
+        .entity_aliases
+        .insert((stale_id.clone(), pod_id.clone()));
+    campaign.apply_facts(&facts);
+
+    assert_eq!(campaign.canonical_entity_id(&stale_id.0), pod_id.0);
+    assert_eq!(
+        campaign
+            .get_system_entity(&stale_id.0)
+            .map(|e| e.entity().entity_id()),
+        Some(pod_id.clone()),
+        "a lookup by the merged-away id must reach the pod"
+    );
+    let channel = campaign
+        .resolve_exec_channel(&stale_id.0)
+        .expect("the session that came with the system must still be reachable");
+    assert_eq!(channel.backend_id, "session/s1");
+}
+
+/// Aliases only ever cover ids that nothing answers to. An id that names a live
+/// entity is that entity, whatever the table says — otherwise a later, genuine
+/// `node/netshoot` would be shadowed by a reverse shell's old guess.
+#[test]
+fn an_alias_never_shadows_a_live_entity() {
+    let mut campaign = Campaign::bootstrap("ran", K8sCluster::new("test-cluster"));
+    let node = K8sNode::new("netshoot");
+    let node_id = node.entity_id();
+    let pod_id = EntityId::new("ns/?/pod/netshoot");
+
+    campaign.record_entity_alias(&node_id, &pod_id);
+    assert_eq!(
+        campaign.canonical_entity_id(&node_id.0),
+        pod_id.0,
+        "while nothing answers to the id, the alias applies"
+    );
+
+    campaign.insert_entity(&node);
+    assert_eq!(
+        campaign.canonical_entity_id(&node_id.0),
+        node_id.0,
+        "once the id names a real entity, the alias must not redirect it"
+    );
+}
+
+/// Chained merges: a foothold's id is rewritten twice (C2 guess → system →
+/// pod), and the C2 still only knows the id it started with.
+#[test]
+fn a_chain_of_aliases_resolves_to_the_last_surviving_id() {
+    let mut campaign = Campaign::bootstrap("ran", K8sCluster::new("test-cluster"));
+    let pod = Pod::new("netshoot", "?");
+    let pod_id = pod.entity_id();
+    campaign.insert_entity(&pod);
+
+    campaign.record_entity_alias(
+        &EntityId::new("node/netshoot"),
+        &EntityId::new("system/netshoot"),
+    );
+    campaign.record_entity_alias(&EntityId::new("system/netshoot"), &pod_id);
+
+    assert_eq!(campaign.canonical_entity_id("node/netshoot"), pod_id.0);
+}
+
+/// A cyclic table is malformed, but it must not hang the resolver.
+#[test]
+fn a_cyclic_alias_pair_terminates() {
+    let mut campaign = Campaign::bootstrap("ran", K8sCluster::new("test-cluster"));
+    let a = EntityId::new("system/a");
+    let b = EntityId::new("system/b");
+    campaign.record_entity_alias(&a, &b);
+    campaign.record_entity_alias(&b, &a);
+
+    let resolved = campaign.canonical_entity_id(&a.0);
+    assert!(resolved == a.0 || resolved == b.0);
+}
 use crate::failure_analyzers::FAILURE_ANALYZER_EFFECT_ID;
 use crate::ParseResult;
 

--- a/crates/campaign/src/runtime.rs
+++ b/crates/campaign/src/runtime.rs
@@ -413,52 +413,15 @@ pub fn spawn_c2_event_processor_with_external_parser(
                         }
                     };
 
-                    let session_kind = if port.is_some() {
-                        "tcp"
-                    } else {
-                        "kubectl-exec"
-                    };
-                    let session_short_id = backend_id
-                        .strip_prefix("session/")
-                        .unwrap_or(&backend_id)
-                        .to_string();
-
-                    // Resolve or create the target system entity.
-                    let channel_entity_id = if guard.get_system_entity(&target_entity_id).is_some()
-                    {
-                        if let Some(mut sys) = guard.get_system_entity_mut(&target_entity_id) {
-                            let system = sys.entity_mut().system_mut();
-                            if !os.is_empty() {
-                                system.os = Some(os.clone());
-                            }
-                            if !user.is_empty() {
-                                system.username = Some(user.clone());
-                            }
-                            system.access_level = AccessLevel::Exec;
-                            system.sessions.push(SessionInfo {
-                                id: session_short_id,
-                                kind: session_kind.to_string(),
-                                port,
-                                status: SessionStatus::Active,
-                            });
-                        }
-                        target_entity_id.clone()
-                    } else {
-                        let sys_name = hostname.to_lowercase();
-                        let mut sys = UnknownSystem::new(&sys_name);
-                        sys.system.os = if os.is_empty() { None } else { Some(os) };
-                        sys.system.username = if user.is_empty() { None } else { Some(user) };
-                        sys.system.access_level = AccessLevel::Exec;
-                        sys.system.sessions.push(SessionInfo {
-                            id: session_short_id,
-                            kind: session_kind.to_string(),
-                            port,
-                            status: SessionStatus::Active,
-                        });
-                        let entity_id = sys.entity_id().0.clone();
-                        guard.insert_entity(&sys);
-                        entity_id
-                    };
+                    let channel_entity_id = attach_connected_session(
+                        &mut guard,
+                        &backend_id,
+                        &target_entity_id,
+                        &hostname,
+                        &user,
+                        &os,
+                        port,
+                    );
 
                     // If the target already has an exec-channel edge, mark it as
                     // active so the session state lives on the existing relation.
@@ -562,6 +525,93 @@ fn record_session_path(campaign: &mut Campaign, establishing_cmd_id: &str, backe
     }
 }
 
+/// Attach a freshly connected C2 session to the system entity it exits into,
+/// returning that entity's id.
+///
+/// `target_entity_id` is whatever the C2 believed it was connecting to. For a
+/// reverse shell that is derived from the probed hostname and usually names no
+/// entity at all, so an `UnknownSystem` is created for it — and the C2's id is
+/// recorded as an alias of that system, so a later reconnect or status change
+/// still keyed by the C2's id lands on the right entity even after an analyzer
+/// has merged that system into the Pod it turned out to be.
+fn attach_connected_session(
+    campaign: &mut Campaign,
+    backend_id: &str,
+    target_entity_id: &str,
+    hostname: &str,
+    user: &str,
+    os: &str,
+    port: Option<u16>,
+) -> String {
+    let session_kind = if port.is_some() {
+        "tcp"
+    } else {
+        "kubectl-exec"
+    };
+    let session_short_id = backend_id
+        .strip_prefix("session/")
+        .unwrap_or(backend_id)
+        .to_string();
+
+    // Resolve the target system entity, following any merge it went through.
+    let resolved_id = campaign.canonical_entity_id(target_entity_id);
+    if let Some(mut sys) = campaign.get_system_entity_mut(&resolved_id) {
+        let system = sys.entity_mut().system_mut();
+        if !os.is_empty() {
+            system.os = Some(os.to_string());
+        }
+        if !user.is_empty() {
+            system.username = Some(user.to_string());
+        }
+        system.access_level = AccessLevel::Exec;
+        // A reconnect comes back on the listener's own backend id: revive that
+        // session instead of pushing a duplicate next to the dead one.
+        match system
+            .sessions
+            .iter_mut()
+            .find(|s| s.id == session_short_id)
+        {
+            Some(existing) => {
+                existing.kind = session_kind.to_string();
+                existing.port = port;
+                existing.status = SessionStatus::Active;
+            }
+            None => system.sessions.push(SessionInfo {
+                id: session_short_id,
+                kind: session_kind.to_string(),
+                port,
+                status: SessionStatus::Active,
+            }),
+        }
+        return resolved_id;
+    }
+
+    // Nothing answers to that id — a shell from a host we have never seen.
+    // Create a system for it, named after the hostname it reported.
+    let mut sys = UnknownSystem::new(hostname.to_lowercase());
+    sys.system.os = if os.is_empty() {
+        None
+    } else {
+        Some(os.to_string())
+    };
+    sys.system.username = if user.is_empty() {
+        None
+    } else {
+        Some(user.to_string())
+    };
+    sys.system.access_level = AccessLevel::Exec;
+    sys.system.sessions.push(SessionInfo {
+        id: session_short_id,
+        kind: session_kind.to_string(),
+        port,
+        status: SessionStatus::Active,
+    });
+    let entity_id = sys.entity_id();
+    campaign.insert_entity(&sys);
+    campaign.record_entity_alias(&EntityId::new(target_entity_id), &entity_id);
+    entity_id.0
+}
+
 fn apply_session_connected(
     campaign: &mut Campaign,
     data: &SessionConnectedData,
@@ -631,5 +681,173 @@ fn update_session_status(
             port: None,
             status: SessionStatus::Active,
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ran_domain::{K8sCluster, Pod, UnknownSystem};
+
+    use super::*;
+
+    /// The variables kubelet injects into every container it starts — enough of
+    /// them for `InClusterPodAnalyzer` to promote the system carrying them.
+    fn kubelet_env() -> Vec<(String, String)> {
+        [
+            ("KUBERNETES_SERVICE_HOST", "10.96.0.1"),
+            ("KUBERNETES_SERVICE_PORT", "443"),
+            ("KUBERNETES_PORT_443_TCP", "tcp://10.96.0.1:443"),
+            ("HOSTNAME", "netshoot"),
+        ]
+        .into_iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+    }
+
+    /// A campaign whose only foothold is a reverse shell on `netshoot`, after
+    /// reading the container's environment promoted it from an `UnknownSystem`
+    /// to `ns/?/pod/netshoot`. The entity id therefore changed under the C2,
+    /// which still knows that shell by the target id it connected with.
+    fn promoted_foothold() -> Campaign {
+        let mut campaign = Campaign::bootstrap("ran", K8sCluster::new("test-cluster"));
+
+        // The C2 names a reverse-shell target after the hostname it probed, so
+        // this id belongs to no entity in the graph.
+        let system_id = attach_connected_session(
+            &mut campaign,
+            "session/s1",
+            "node/netshoot",
+            "netshoot",
+            "root",
+            "Linux",
+            Some(4444),
+        );
+        assert_eq!(system_id, "system/netshoot");
+
+        // Reading /proc/1/environ over that shell hands us kubelet's variables.
+        campaign
+            .get_system_entity_mut(&system_id)
+            .expect("foothold system")
+            .entity_mut()
+            .system_mut()
+            .env_vars
+            .extend(kubelet_env());
+
+        let facts = crate::rules::run_rules_fixpoint(
+            &campaign,
+            &crate::analyzers::default_rules(),
+            crate::FactsUpdate::default(),
+        );
+        campaign.apply_facts(&facts);
+
+        assert!(
+            campaign
+                .entities
+                .contains::<Pod>(&EntityId::new("ns/?/pod/netshoot")),
+            "fixture expects the foothold to be promoted to a pod"
+        );
+        campaign
+    }
+
+    fn pod_sessions(campaign: &Campaign) -> Vec<SessionInfo> {
+        campaign
+            .entities
+            .find::<Pod>(&EntityId::new("ns/?/pod/netshoot"))
+            .expect("promoted pod")
+            .system
+            .sessions
+            .clone()
+    }
+
+    #[test]
+    fn a_session_status_change_keyed_by_the_pre_merge_id_reaches_the_pod() {
+        let mut campaign = promoted_foothold();
+
+        update_session_status(
+            &mut campaign,
+            "node/netshoot",
+            "session/s1",
+            SessionStatus::Lost,
+        );
+
+        let sessions = pod_sessions(&campaign);
+        assert_eq!(sessions.len(), 1, "sessions were: {:?}", sessions);
+        assert_eq!(
+            sessions[0].status,
+            SessionStatus::Lost,
+            "a status change addressed to the pre-merge id must reach the pod"
+        );
+        assert!(
+            campaign.entities.get::<UnknownSystem>().is_empty(),
+            "the promoted system must not be resurrected"
+        );
+    }
+
+    #[test]
+    fn a_reconnect_keyed_by_the_pre_merge_id_keeps_the_pod_executable() {
+        let mut campaign = promoted_foothold();
+        update_session_status(
+            &mut campaign,
+            "node/netshoot",
+            "session/s1",
+            SessionStatus::Lost,
+        );
+
+        // The shell comes back on the listener's own backend id, still
+        // announcing itself with the target id the C2 captured on first connect.
+        let channel_id = attach_connected_session(
+            &mut campaign,
+            "session/s1",
+            "node/netshoot",
+            "netshoot",
+            "root",
+            "Linux",
+            Some(4444),
+        );
+
+        assert_eq!(
+            channel_id, "ns/?/pod/netshoot",
+            "the reconnect must attach to the pod, not to a fresh system"
+        );
+        assert!(
+            campaign.entities.get::<UnknownSystem>().is_empty(),
+            "the reconnect must not resurrect the pre-merge system"
+        );
+
+        let sessions = pod_sessions(&campaign);
+        assert_eq!(
+            sessions.len(),
+            1,
+            "the reconnect must revive the session, not duplicate it; got: {:?}",
+            sessions
+        );
+        assert_eq!(sessions[0].status, SessionStatus::Active);
+
+        let channel = campaign
+            .resolve_exec_channel("ns/?/pod/netshoot")
+            .expect("the promoted foothold must stay executable");
+        assert_eq!(channel.backend_id, "session/s1");
+    }
+
+    #[test]
+    fn a_connect_to_a_target_that_resolves_records_no_alias() {
+        let mut campaign = Campaign::bootstrap("ran", K8sCluster::new("test-cluster"));
+        campaign.insert_entity(&Pod::new("api", "default"));
+
+        let channel_id = attach_connected_session(
+            &mut campaign,
+            "session/s2",
+            "ns/default/pod/api",
+            "api",
+            "root",
+            "Linux",
+            None,
+        );
+
+        assert_eq!(channel_id, "ns/default/pod/api");
+        assert!(
+            campaign.entity_aliases.is_empty(),
+            "a target that resolves on its own must not record an alias"
+        );
     }
 }


### PR DESCRIPTION
Follow-up to #63, from manual testing: after reading a container's environment
from a reverse-shell foothold, nothing could be executed on that foothold any
more.

```
no viable execution channel to 'ns/?/pod/netshoot' found in the knowledge graph
```

The promotion itself is sound — the pod inherits the session and the
exec-channel edges. What breaks is who holds the id. Two separate stalenesses,
not one:

**The promotion renames the entity.** `InClusterPodAnalyzer` merges
`system/netshoot` into `ns/?/pod/netshoot`, but the C2 keeps addressing that
shell by the id it captured when the session connected. Status transitions were
dropped, edge activation pointed at a node that no longer existed, and a
reconnect created a *fresh* `UnknownSystem` beside the pod with the live session
on it — so nothing routed to the target the graph showed.

**The runtime never recorded its own mapping.** A reverse shell's target id is
derived by the C2 from the hostname it probed (`node/netshoot`, `executor.rs`),
and names no entity at all. The runtime attached the session to a locally
created `system/netshoot` and threw the correspondence away, so those two ids
could never meet again — promotion or not. This is what actually resurrected the
system.

## The fix

`Campaign::entity_aliases` maps every merged-away id to the one that survived.
`canonical_entity_id` resolves through it in `get_system_entity`,
`get_system_entity_mut` (and so `apply_system_update`),
`activate_session_on_exec_channel`, `resolve_exec_channel` and
`resolve_exec_channel_from_source`, so one table fixes every caller at once —
including the C2 callbacks holding ids captured minutes earlier, and
`IpBasedSystemMergeAnalyzer`'s merges, which had the same latent problem.

Two invariants keep the table honest: an id that still names a live entity is
never rewritten, so an alias cannot shadow a real `node/netshoot` discovered
later; and chain-following is bounded, so a malformed pair cannot spin.

`attach_connected_session` is extracted from the C2 event loop (it was inline
and untestable) and now records the C2's target id as an alias of the system it
creates. It also revives an existing session on reconnect instead of stacking a
second entry beside the dead one — the listener reuses its backend id, so the
old behaviour left a `Lost` and an `Active` `s1` side by side.

## Tests

Both regression cases from the handoff, plus the alias-table invariants: 465
campaign tests, workspace green, clippy clean.

Each new test was confirmed to fail without the fix. With the alias table
disabled, the reconnect test reproduces the reported symptom exactly
(`left: "system/netshoot"`, `right: "ns/?/pod/netshoot"`); with the session
revive disabled, the pod ends up holding a duplicate `s1`, the dead one first.

https://claude.ai/code/session_0174nRG8MG2KE6nmY4aNemk5
