### PR TITLE
Tag, reroute around, and recover broken C2 sessions

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -694,6 +694,12 @@ components:
         sessionId:
           type: string
           description: Backend ID of the active persistent session on this exec-channel edge, if any.
+        broken:
+          type: boolean
+          description: >-
+            True when the session backing this exec-channel edge has died. The
+            edge is kept (rendered as broken) and is non-traversable until a
+            session reconnects and recovers it.
         provenance:
           type: array
           items:
@@ -825,6 +831,13 @@ components:
             The bare inner command as it runs on the final target system,
             before any hop envelopes wrap it. Empty when there is no multi-hop
             traversal.
+        routeReason:
+          type: string
+          description: >-
+            Short, human-readable explanation of why this execution route was
+            chosen (e.g. a live session vs. a multi-hop path), including a note
+            when a broken session edge to the target was skipped. Empty for
+            direct/local commands with no joined traversal.
         args:
           type: object
           additionalProperties:

--- a/crates/api/src/api_handlers.rs
+++ b/crates/api/src/api_handlers.rs
@@ -661,6 +661,11 @@ pub(crate) struct AttackStep {
     /// Empty when there is no multi-hop traversal.
     #[serde(rename = "innerCommand")]
     pub inner_command: String,
+    /// Short, human-readable explanation of why this execution route was chosen
+    /// (e.g. live session vs. multi-hop, or a note that a broken session edge was
+    /// skipped). Empty for direct/local commands with no joined traversal.
+    #[serde(rename = "routeReason")]
+    pub route_reason: String,
     pub args: std::collections::HashMap<String, String>,
     #[serde(rename = "procedureId")]
     pub procedure_id: String,
@@ -686,6 +691,7 @@ impl From<&campaign::ExecutionRecord> for AttackStep {
             // Traversal is joined separately from the campaign side map by id.
             traversal: Vec::new(),
             inner_command: String::new(),
+            route_reason: String::new(),
             args: r.args.clone(),
             procedure_id: r.procedure_id.clone(),
             ttp: AttackStepTTP {
@@ -725,6 +731,7 @@ impl From<&campaign::ExecTtp> for AttackStep {
             // Traversal is joined separately from the campaign side map by id.
             traversal: Vec::new(),
             inner_command: String::new(),
+            route_reason: String::new(),
             args: exec.args.clone(),
             procedure_id: exec.procedure.id.clone(),
             ttp: AttackStepTTP {
@@ -763,6 +770,7 @@ mod flow_contract_tests {
                 command: "id".to_string(),
                 traversal: Vec::new(),
                 inner_command: String::new(),
+                route_reason: String::new(),
                 args: HashMap::new(),
                 procedure_id: "shell".to_string(),
                 ttp: AttackStepTTP {
@@ -811,6 +819,7 @@ pub(crate) async fn flow_handler<S: ApiService>(
         if let Some(ct) = campaign.command_traversal(&step.id) {
             step.traversal = ct.hops.iter().map(AttackStepHop::from).collect();
             step.inner_command = ct.inner_command.clone();
+            step.route_reason = ct.reason.clone();
         }
     }
 

--- a/crates/api/src/state_conversions.rs
+++ b/crates/api/src/state_conversions.rs
@@ -64,6 +64,9 @@ pub(crate) fn campaign_to_campaign_state(
                 if let Some(ref sid) = r.session_id {
                     m.insert("sessionId".to_string(), Value::String(sid.clone()));
                 }
+                if r.broken {
+                    m.insert("broken".to_string(), Value::Bool(true));
+                }
                 m.insert(
                     "provenance".to_string(),
                     provenance_value(campaign.relation_provenance(
@@ -225,6 +228,9 @@ pub(crate) fn campaign_to_graph(campaign: &Campaign, kubetier: &kubetier::Catalo
                     },
                     relation: None,
                     session_id: r.session_id.clone(),
+                    // Only present when broken, so healthy edges stay lean and
+                    // the frontend `edge[?broken]` selector reads absent as false.
+                    broken: if r.broken { Some(true) } else { None },
                     provenance: Some(provenance_strings(campaign.relation_provenance(
                         &r.name,
                         &r.source_id,

--- a/crates/c2/src/executor.rs
+++ b/crates/c2/src/executor.rs
@@ -391,6 +391,28 @@ impl C2Executor {
 
         let mut event = self.select_backend(cmd).await.execute(cmd).await;
         event.session_connected = None;
+
+        // A live session that died surfaces as a session-death fail_reason —
+        // either an unexpected close mid-command or sustained unresponsiveness
+        // (repeated timeouts). Both are distinct from an ordinary non-zero exit
+        // or a single slow-command timeout, which leave the session healthy.
+        // Signal it as a SessionLost so the campaign marks the backing
+        // exec-channel edge broken. The backend that ran the command —
+        // `exec_system_id` — is the session id carried on that edge, so it
+        // matches the edge back without extra bookkeeping.
+        if !event.success && crate::types::is_session_death_reason(&event.fail_reason) {
+            warn!(
+                backend_id = %cmd.exec_system_id,
+                target_id = %cmd.target_id,
+                reason = %event.fail_reason,
+                "session died; publishing SessionLost"
+            );
+            let _ = self.event_bus.publish(C2Event::SessionLost {
+                backend_id: cmd.exec_system_id.clone(),
+                target_entity_id: cmd.target_id.clone(),
+            });
+        }
+
         event
     }
 

--- a/crates/c2/src/shell_session.rs
+++ b/crates/c2/src/shell_session.rs
@@ -30,6 +30,13 @@ pub struct ShellSession {
     inner: Arc<Mutex<ShellInner>>,
     /// Entity ID this session currently exits into (for logging/debugging).
     pub entity_id: String,
+    /// Consecutive command timeouts with no response in between. A single
+    /// timeout is treated as a slow command; once this reaches
+    /// [`crate::types::SESSION_TIMEOUT_BREAK_THRESHOLD`] the session is reported
+    /// as dead so its exec-channel edge is broken. Reset to zero whenever a
+    /// command completes (even with a non-zero exit — that still proves the
+    /// session is responsive).
+    consecutive_timeouts: AtomicU64,
 }
 
 struct ShellInner {
@@ -79,6 +86,7 @@ impl ShellSession {
                 rx: BufReader::new(Box::new(reader)),
             })),
             entity_id: entity_id.into(),
+            consecutive_timeouts: AtomicU64::new(0),
         }
     }
 
@@ -224,7 +232,7 @@ impl C2Backend for ShellSession {
                 match guard.rx.read_line(&mut line).await {
                     Ok(0) => {
                         warn!(entity_id = %self.entity_id, "shell session EOF");
-                        return Err("shell session closed unexpectedly".to_string());
+                        return Err(crate::types::SESSION_CLOSED_UNEXPECTEDLY.to_string());
                     }
                     Err(e) => return Err(format!("shell read failed: {e}")),
                     Ok(_) => {}
@@ -241,15 +249,38 @@ impl C2Backend for ShellSession {
         let timeout_seconds = cmd.execution_timeout_seconds.max(1);
         match tokio::time::timeout(Duration::from_secs(timeout_seconds), read_fut).await {
             Ok(Ok((code, out))) => {
+                // The session responded (any exit code), so it is alive: clear
+                // the consecutive-timeout streak.
+                self.consecutive_timeouts.store(0, Ordering::Relaxed);
                 exit_code = code;
                 output = out;
             }
             Ok(Err(e)) => return exec_error(&cmd.id, e),
             Err(_) => {
+                // A single timeout is treated as a slow command — the session may
+                // still be healthy. Only sustained unresponsiveness escalates to a
+                // session death that breaks the exec-channel edge, so the streak is
+                // tracked across commands and reset by any response above.
+                let streak = self.consecutive_timeouts.fetch_add(1, Ordering::Relaxed) + 1;
+                if streak >= crate::types::SESSION_TIMEOUT_BREAK_THRESHOLD {
+                    warn!(
+                        entity_id = %self.entity_id,
+                        streak,
+                        "shell session unresponsive after consecutive timeouts"
+                    );
+                    return exec_error(
+                        &cmd.id,
+                        format!(
+                            "{} after {streak} consecutive timeouts \
+                             (last command timed out after {timeout_seconds}s)",
+                            crate::types::SESSION_UNRESPONSIVE_PREFIX
+                        ),
+                    );
+                }
                 return exec_error(
                     &cmd.id,
                     format!("shell command timed out after {timeout_seconds}s"),
-                )
+                );
             }
         }
 
@@ -406,6 +437,64 @@ mod tests {
         assert!(!result.success);
         assert_eq!(result.exit_code, 127);
         assert!(!result.results.is_empty());
+    }
+
+    /// A fake shell that answers `init()` but never replies to any command, so
+    /// every `execute` call times out.
+    fn silent_shell_session(entity_id: &str) -> ShellSession {
+        let (client, server) = tokio::io::duplex(4096);
+        let (server_rx, mut server_tx) = tokio::io::split(server);
+        let (client_rx, client_tx) = tokio::io::split(client);
+
+        tokio::spawn(async move {
+            use tokio::io::AsyncBufReadExt;
+            let mut reader = tokio::io::BufReader::new(server_rx);
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line).await {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {}
+                }
+                // Only unblock init(); real commands get no sentinel, so they hang.
+                if let Some(rest) = line.trim_end().strip_prefix("printf '") {
+                    let marker = rest.split('%').next().unwrap_or("").trim_end_matches(':');
+                    if marker.contains("INIT0") {
+                        let _ = server_tx.write_all(format!("{marker}\n").as_bytes()).await;
+                        let _ = server_tx.flush().await;
+                    }
+                }
+            }
+        });
+
+        ShellSession::from_rw(client_rx, client_tx, entity_id)
+    }
+
+    #[tokio::test]
+    async fn timeouts_escalate_to_session_death_only_after_the_threshold() {
+        let session = silent_shell_session("node/test");
+        session.init().await.expect("init");
+
+        let mut cmd = make_cmd("sleep 999", "session/test");
+        cmd.execution_timeout_seconds = 1;
+
+        // First timeout: treated as a slow command — the session is not yet dead.
+        let first = session.execute(&cmd).await;
+        assert!(!first.success);
+        assert!(
+            !crate::types::is_session_death_reason(&first.fail_reason),
+            "a single timeout must not break the session: {}",
+            first.fail_reason
+        );
+
+        // Second consecutive timeout crosses the threshold → session death.
+        let second = session.execute(&cmd).await;
+        assert!(!second.success);
+        assert!(
+            crate::types::is_session_death_reason(&second.fail_reason),
+            "consecutive timeouts should escalate to session death: {}",
+            second.fail_reason
+        );
     }
 
     fn make_cmd(command: &str, exec_system_id: &str) -> ExecTtp {

--- a/crates/c2/src/types.rs
+++ b/crates/c2/src/types.rs
@@ -6,6 +6,32 @@ use serde::{Deserialize, Serialize};
 
 /// The backend ID for the built-in Ran C2.
 pub const BUILTIN_C2_ID: &str = "c2/ran";
+
+/// `fail_reason` emitted by a [`crate::ShellSession`] when its underlying stream
+/// hits EOF mid-command — i.e. the live session died. Used as a stable sentinel
+/// so the executor can tell a dead session apart from an ordinary non-zero
+/// command exit and signal that the session's exec-channel edge is now broken.
+pub const SESSION_CLOSED_UNEXPECTEDLY: &str = "shell session closed unexpectedly";
+
+/// Prefix of the `fail_reason` a [`crate::ShellSession`] emits once it has hit
+/// [`SESSION_TIMEOUT_BREAK_THRESHOLD`] consecutive command timeouts with no
+/// intervening response. A single timeout is treated as a merely-slow command
+/// and leaves the session alone; only sustained unresponsiveness escalates to a
+/// session death that breaks the exec-channel edge. Matched by prefix because
+/// the full message also carries the timeout counts.
+pub const SESSION_UNRESPONSIVE_PREFIX: &str = "shell session unresponsive";
+
+/// Consecutive command timeouts (with no response in between) after which a
+/// [`crate::ShellSession`] is considered dead rather than merely slow.
+pub const SESSION_TIMEOUT_BREAK_THRESHOLD: u64 = 2;
+
+/// Whether a `fail_reason` denotes a dead session — either an unexpected close
+/// or sustained unresponsiveness — as opposed to an ordinary command failure
+/// (non-zero exit, a single slow-command timeout). The executor uses this to
+/// decide when to signal that the session's exec-channel edge is broken.
+pub fn is_session_death_reason(reason: &str) -> bool {
+    reason == SESSION_CLOSED_UNEXPECTEDLY || reason.starts_with(SESSION_UNRESPONSIVE_PREFIX)
+}
 pub const DEFAULT_EXECUTION_TIMEOUT_SECONDS: u64 = 60;
 
 fn default_execution_timeout_seconds() -> u64 {

--- a/crates/campaign/src/campaign/execution.rs
+++ b/crates/campaign/src/campaign/execution.rs
@@ -1045,6 +1045,13 @@ impl Campaign {
         // off `ExecTtp`/`ExecutionRecord` so it never touches the execution or
         // scoring data model. Surfaced by the flow API by joining on id.
         if let Some(traversal) = self.build_command_traversal(&route, &procedure.command) {
+            tracing::info!(
+                cmd_id = %cmd_id,
+                target_id = %route.target_id,
+                backend_id = %route.backend_id,
+                route_reason = %traversal.reason,
+                "resolved execution route"
+            );
             self.command_traversals.insert(cmd_id.clone(), traversal);
         }
 
@@ -1492,6 +1499,7 @@ impl Campaign {
                 return Some(CommandTraversal {
                     hops: hops.clone(),
                     inner_command: final_command.to_string(),
+                    reason: self.route_reason(route),
                 });
             }
         }
@@ -1524,7 +1532,54 @@ impl Campaign {
         Some(CommandTraversal {
             hops,
             inner_command,
+            reason: self.route_reason(route),
         })
+    }
+
+    /// Build a short, human-readable explanation of why `route` was chosen, from
+    /// the finalized route shape. Kept honest and derived from the route itself
+    /// (rather than the resolver's internal branch) so it never drifts from what
+    /// actually ran, and flags when a broken session edge to the target was
+    /// skipped — the visible counterpart to the resolver's decision logs.
+    fn route_reason(&self, route: &ExecRoute) -> String {
+        let exec_target = route
+            .exec_chain
+            .last()
+            .map(String::as_str)
+            .unwrap_or(route.target_id.as_str());
+
+        let mut reason = if route.backend_id.starts_with("session/") {
+            format!("Tunneled through live session {}", route.backend_id)
+        } else if route.exec_chain.len() > 1 {
+            format!(
+                "Multi-hop route {}",
+                format_exec_chain(&route.backend_id, &route.exec_chain, exec_target)
+            )
+        } else if route.backend_id.is_empty() {
+            "Local C2-side command (no remote hop)".to_string()
+        } else {
+            format!("Direct exec from {}", route.backend_id)
+        };
+
+        // If a session edge into the exec target exists but is broken, the router
+        // stepped around it — call that out so an operator understands why the
+        // path is not the (now-dead) session they might expect.
+        if self.has_broken_exec_edge_into(exec_target) && !route.backend_id.starts_with("session/")
+        {
+            reason.push_str(" (a broken session edge to the target was skipped)");
+        }
+
+        reason
+    }
+
+    /// Whether any incoming exec-channel edge into `target_id` is currently
+    /// marked broken. Used only to annotate the route reason.
+    fn has_broken_exec_edge_into(&self, target_id: &str) -> bool {
+        let eid = EntityId::new(target_id);
+        self.graph
+            .incoming(&eid)
+            .into_iter()
+            .any(|(_, d)| d.is_exec_channel && d.broken)
     }
 
     /// Wrap `procedure.command` through each hop in reverse order so BuiltinC2
@@ -1590,6 +1645,7 @@ impl Campaign {
                     output_transform: d.output_transform.clone(),
                     weight: d.weight,
                     session_id: d.session_id.clone(),
+                    broken: d.broken,
                 });
             // Capture the relation name and envelope template for this hop
             // before the match consumes `found` to rewrite the command.
@@ -2294,11 +2350,23 @@ impl Campaign {
     ) {
         use cortex::edge_data_for;
         let summary = ran_domain::RelationSummary::from_relation(rel);
-        let data = edge_data_for(
+        let mut data = edge_data_for(
             rel.relation_name(),
             summary.envelope,
             summary.output_transform,
         );
+        // Carry session state that lives on the relation but not in the
+        // name-keyed `relation_defaults` table. Without this a standalone
+        // `c2.session` edge (a reverse shell to an otherwise-unknown host) lands
+        // with no `session_id`, so it can never be matched when its session
+        // breaks — leaving a dead connection rendered as a live one. Upgrading
+        // (never downgrading) `is_exec_channel` also makes a live shell a real
+        // exec channel, so path-finding treats it as traversable while healthy
+        // and skips it once broken.
+        data.session_id = summary.session_id;
+        if summary.is_exec_channel {
+            data.is_exec_channel = true;
+        }
         self.graph.insert_edge(src, tgt, data);
 
         // When a C2 channel relation is added to a system entity, ensure

--- a/crates/campaign/src/campaign/state.rs
+++ b/crates/campaign/src/campaign/state.rs
@@ -391,6 +391,24 @@ impl Campaign {
                     exec_target_id: None,
                 });
             }
+
+            // No live session, but a down (lost/broken) one exists on this target:
+            // make the reroute explicit in the logs rather than silently falling
+            // through to graph-based routing.
+            let has_down_session = self.get_system_entity(target_id).is_some_and(|sys| {
+                sys.entity()
+                    .system()
+                    .sessions
+                    .iter()
+                    .any(|s| s.status != SessionStatus::Active)
+            });
+            if has_down_session {
+                tracing::info!(
+                    target_id = %target_id,
+                    "resolve_exec_channel: session on target is down; \
+                     rerouting via the knowledge graph"
+                );
+            }
         } else {
             tracing::debug!(
                 target_id = %target_id,
@@ -679,6 +697,13 @@ impl Campaign {
         self.graph.deactivate_session(backend_id);
     }
 
+    /// Mark every exec-channel edge carrying `backend_id` as broken so it is no
+    /// longer traversable, while keeping the edge (and its `session_id`) for
+    /// potential recovery. Returns the number of edges marked.
+    pub fn mark_session_broken(&mut self, backend_id: &str) -> usize {
+        self.graph.mark_session_broken(backend_id)
+    }
+
     /// Insert an entity into the store and register its node in the graph.
     pub(crate) fn insert_entity(&mut self, entity: &dyn Entity) {
         let id = entity.entity_id();
@@ -739,7 +764,10 @@ impl Campaign {
             .incoming(&system_eid)
             .into_iter()
             .find(|(src, d)| {
-                d.is_exec_channel && !self.is_system_entity_id(src) && src.0.starts_with("c2/")
+                d.is_exec_channel
+                    && !d.broken
+                    && !self.is_system_entity_id(src)
+                    && src.0.starts_with("c2/")
             })
         {
             return src.0.clone();
@@ -792,6 +820,38 @@ mod planner_helper_tests {
     fn entity_has_relation_false_when_no_relation() {
         let c = minimal_campaign();
         assert!(!c.entity_has_relation("ns/default/pod/nginx-abc", "rce.can-exec"));
+    }
+
+    /// A standalone `c2.session` edge (reverse shell to an otherwise-unknown
+    /// host) must carry its `session_id` onto the graph edge so a later session
+    /// break can find and mark it broken — otherwise the dead connection keeps
+    /// rendering as a live one.
+    #[test]
+    fn standalone_session_edge_carries_session_id_and_can_break() {
+        let mut c = minimal_campaign();
+        let channel = ran_domain::SessionChannel::new("c2/ran", "node/victim", "session/victim-1");
+        c.insert_relation(&channel);
+
+        let rel = c
+            .get_relations()
+            .into_iter()
+            .find(|r| r.name == "c2.session")
+            .expect("c2.session edge should exist");
+        assert_eq!(
+            rel.session_id.as_deref(),
+            Some("session/victim-1"),
+            "session_id must be carried onto the graph edge"
+        );
+        assert!(!rel.broken);
+
+        assert_eq!(c.mark_session_broken("session/victim-1"), 1);
+
+        let rel = c
+            .get_relations()
+            .into_iter()
+            .find(|r| r.name == "c2.session")
+            .expect("c2.session edge should still exist");
+        assert!(rel.broken, "the session's edge should be marked broken");
     }
 
     #[test]

--- a/crates/campaign/src/runtime.rs
+++ b/crates/campaign/src/runtime.rs
@@ -514,10 +514,13 @@ pub fn spawn_c2_event_processor_with_external_parser(
                         &backend_id,
                         SessionStatus::Lost,
                     );
-                    // Clear session_id from any exec-channel edge that carried
-                    // this session, regardless of edge type or transport.
-                    guard.deactivate_session(&backend_id);
-                    info!(%backend_id, %target_entity_id, "session lost");
+                    // Mark any exec-channel edge that carried this session as
+                    // broken rather than clearing it: the edge stays in the
+                    // graph (styled as broken) and keeps its session_id so a
+                    // reconnecting session can recover it, but path-finding
+                    // treats it as non-traversable in the meantime.
+                    let marked = guard.mark_session_broken(&backend_id);
+                    info!(%backend_id, %target_entity_id, marked, "session lost; exec-channel edge(s) marked broken");
                     let _ = campaign_events.publish(CampaignEvent::FactsChanged {
                         cmd_id: backend_id,
                         new_entities: vec![],

--- a/crates/campaign/src/traversal.rs
+++ b/crates/campaign/src/traversal.rs
@@ -40,4 +40,11 @@ pub struct CommandTraversal {
     /// The bare inner command as it runs on the final target system, before any
     /// hop envelopes wrap it.
     pub inner_command: String,
+    /// Short, human-readable explanation of *why* this route was chosen — e.g.
+    /// "Tunneled through live session …", "Direct exec from c2/ran", or a
+    /// multi-hop path — including a note when a broken session edge to the
+    /// target was skipped. Surfaced to the timeline UI and the logs so the
+    /// routing decision is legible rather than implicit. Empty when unknown.
+    #[serde(default)]
+    pub reason: String,
 }

--- a/crates/domain/relations.rs
+++ b/crates/domain/relations.rs
@@ -765,6 +765,10 @@ pub struct RelationSummary {
     /// exec session, if one is open. `None` = one-shot per-command exec mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    /// `true` when the session backing this exec-channel edge has died and the
+    /// edge is no longer traversable, but is kept for potential recovery.
+    #[serde(default)]
+    pub broken: bool,
 }
 
 impl RelationSummary {
@@ -806,6 +810,10 @@ impl RelationSummary {
             output_transform,
             weight: 0.0,
             session_id,
+            // A relation built directly from a trait object (not from a graph
+            // edge) has no liveness state yet; the graph is the source of truth
+            // for brokenness.
+            broken: false,
         }
     }
 

--- a/crates/graph/src/edge.rs
+++ b/crates/graph/src/edge.rs
@@ -23,6 +23,13 @@ pub struct EdgeData {
     /// is used in one-shot (per-command kubectl exec) mode.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
+    /// `true` when the C2 session backing this exec-channel edge has died (e.g.
+    /// the shell closed unexpectedly). The edge is kept — not removed — so it
+    /// can be recovered if a session reconnects, but it is treated as
+    /// non-traversable by path-finding while broken. `session_id` is retained so
+    /// a reconnecting session can be matched back to this edge.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub broken: bool,
 }
 
 impl EdgeData {
@@ -34,6 +41,7 @@ impl EdgeData {
             envelope: None,
             output_transform: None,
             session_id: None,
+            broken: false,
         }
     }
 
@@ -76,5 +84,6 @@ pub fn edge_data_for(
         envelope,
         output_transform,
         session_id: None,
+        broken: false,
     }
 }

--- a/crates/graph/src/graph.rs
+++ b/crates/graph/src/graph.rs
@@ -22,6 +22,8 @@ use crate::edge::EdgeData;
 ///   incoming one replaces the old one (K8s rescheduling is valid).
 /// - **SingleContainer** — an entity may have at most one incoming `contains`
 ///   edge; a more specific parent replaces its previous parent.
+/// - **SingleSession** — at most one `c2.session` edge per `src → tgt` pair; a
+///   reconnected session replaces the previous (possibly broken) one.
 #[derive(Debug, Clone)]
 pub struct KnowledgeGraph {
     pub(crate) graph: StableGraph<EntityId, EdgeData>,
@@ -51,6 +53,90 @@ mod tests {
             .collect();
         assert_eq!(contains.len(), 1);
         assert_eq!(contains[0].source_id, namespace.0);
+    }
+
+    /// A can-exec edge carrying a session that breaks becomes non-traversable
+    /// but is retained, and a reconnecting session recovers it.
+    #[test]
+    fn broken_session_edge_is_non_traversable_until_recovered() {
+        let mut graph = KnowledgeGraph::new();
+        let attacker = EntityId::new("ns/default/pod/attacker");
+        let victim = EntityId::new("ns/default/pod/victim");
+
+        graph.insert_edge(
+            &attacker,
+            &victim,
+            edge_data_for("k8s.can-exec", None, None),
+        );
+        // Session is live on the edge — the path exists.
+        assert!(graph.activate_session_on_incoming_exec(&victim, "session/victim-1".to_string()));
+        assert!(graph
+            .shortest_exec_path(std::slice::from_ref(&attacker), &victim)
+            .is_some());
+
+        // The shell dies: mark the session's edge broken.
+        assert_eq!(graph.mark_session_broken("session/victim-1"), 1);
+
+        // The edge is no longer traversable, and reachability skips it...
+        assert!(graph
+            .shortest_exec_path(std::slice::from_ref(&attacker), &victim)
+            .is_none());
+        assert!(graph.reachable_via_exec(&[attacker.clone()]).is_empty());
+
+        // ...but it is kept (not removed) and surfaced as broken for the UI.
+        let summary = graph
+            .to_relation_summaries()
+            .into_iter()
+            .find(|r| r.name == "k8s.can-exec")
+            .expect("edge should still exist");
+        assert!(summary.broken);
+        assert_eq!(summary.session_id.as_deref(), Some("session/victim-1"));
+
+        // A reconnecting session on the same edge clears the break.
+        assert!(graph.activate_session_on_incoming_exec(&victim, "session/victim-1".to_string()));
+        assert!(graph
+            .shortest_exec_path(std::slice::from_ref(&attacker), &victim)
+            .is_some());
+        let recovered = graph
+            .to_relation_summaries()
+            .into_iter()
+            .find(|r| r.name == "k8s.can-exec")
+            .expect("edge should still exist");
+        assert!(!recovered.broken);
+    }
+
+    /// A reconnected session's edge replaces the prior broken one for the same
+    /// pair, rather than accumulating as a stale artifact.
+    #[test]
+    fn new_c2_session_edge_replaces_the_prior_broken_one() {
+        let mut graph = KnowledgeGraph::new();
+        let c2 = EntityId::new("c2/ran");
+        let victim = EntityId::new("node/victim");
+
+        // Establish a session, then break it.
+        let mut first = edge_data_for("c2.session", None, None);
+        first.session_id = Some("session/victim-1".to_string());
+        graph.insert_edge(&c2, &victim, first);
+        assert_eq!(graph.mark_session_broken("session/victim-1"), 1);
+
+        // A reconnected session inserts a fresh c2.session edge for the same pair.
+        let mut second = edge_data_for("c2.session", None, None);
+        second.session_id = Some("session/victim-2".to_string());
+        graph.insert_edge(&c2, &victim, second);
+
+        // Exactly one c2.session edge remains, and it is the live (unbroken) one.
+        let sessions: Vec<_> = graph
+            .to_relation_summaries()
+            .into_iter()
+            .filter(|r| r.name == "c2.session")
+            .collect();
+        assert_eq!(
+            sessions.len(),
+            1,
+            "the broken session edge must be replaced"
+        );
+        assert!(!sessions[0].broken);
+        assert_eq!(sessions[0].session_id.as_deref(), Some("session/victim-2"));
     }
 }
 
@@ -154,6 +240,9 @@ impl KnowledgeGraph {
     ///   before the new one is added (K8s rescheduling is valid).
     /// - **SingleContainer**: a new `contains` edge replaces any existing
     ///   containment parent of `tgt`.
+    /// - **SingleSession**: a new `c2.session` edge replaces any existing
+    ///   `c2.session` edge for the same `src → tgt` pair (a reconnected shell
+    ///   supersedes the dead one instead of leaving it as an artifact).
     ///
     /// Parallel edges (same `src`/`tgt`, different `relation_name`) are allowed.
     pub fn insert_edge(
@@ -187,6 +276,23 @@ impl KnowledgeGraph {
                 .graph
                 .edges_directed(tgt_idx, Direction::Incoming)
                 .filter(|e| e.weight().relation_name == "contains")
+                .map(|e| e.id())
+                .collect();
+            for idx in stale {
+                self.graph.remove_edge(idx);
+            }
+        }
+
+        // SingleSession: a fresh `c2.session` edge supersedes any prior session
+        // edge for the same source→target pair. A reconnected shell replaces the
+        // dead one outright — a broken session edge carries no epistemic value
+        // once a live session to the same target exists, so it is not kept as a
+        // graph artifact.
+        if data.relation_name == "c2.session" {
+            let stale: Vec<EdgeIndex> = self
+                .graph
+                .edges_connecting(src_idx, tgt_idx)
+                .filter(|e| e.weight().relation_name == "c2.session")
                 .map(|e| e.id())
                 .collect();
             for idx in stale {
@@ -276,7 +382,7 @@ impl KnowledgeGraph {
             .edge_indices()
             .filter_map(|ei| {
                 let data = self.graph.edge_weight(ei)?;
-                if !data.is_exec_channel {
+                if !data.is_exec_channel || data.broken {
                     return None;
                 }
                 let (si, ti) = self.graph.edge_endpoints(ei)?;
@@ -306,7 +412,7 @@ impl KnowledgeGraph {
         let mut result = Vec::new();
         while let Some(nx) = queue.pop_front() {
             for edge in self.graph.edges_directed(nx, Direction::Outgoing) {
-                if !edge.weight().is_exec_channel {
+                if !edge.weight().is_exec_channel || edge.weight().broken {
                     continue;
                 }
                 let tgt = edge.target();
@@ -338,7 +444,9 @@ impl KnowledgeGraph {
 
         let exec_graph = EdgeFiltered::from_fn(
             &self.graph,
-            |e: petgraph::stable_graph::EdgeReference<EdgeData>| e.weight().is_exec_channel,
+            |e: petgraph::stable_graph::EdgeReference<EdgeData>| {
+                e.weight().is_exec_channel && !e.weight().broken
+            },
         );
 
         let mut best: Option<(f32, Vec<NodeIndex>)> = None;
@@ -401,9 +509,40 @@ impl KnowledgeGraph {
         for idx in idxs {
             if let Some(data) = self.graph.edge_weight_mut(idx) {
                 data.session_id = Some(session_id.clone());
+                // A (re)connecting session clears any prior broken mark so the
+                // edge becomes traversable again.
+                data.broken = false;
             }
         }
         found
+    }
+
+    /// Mark every exec-channel edge carrying `backend_id` as broken.
+    ///
+    /// Called when a live session dies (e.g. the shell closed unexpectedly).
+    /// The edge is intentionally kept, and its `session_id` is preserved, so a
+    /// reconnecting session can be matched back to it and clear the mark. While
+    /// broken, the edge is skipped by all exec-channel traversal queries.
+    /// Returns the number of edges marked.
+    pub fn mark_session_broken(&mut self, backend_id: &str) -> usize {
+        let idxs: Vec<petgraph::stable_graph::EdgeIndex> = self
+            .graph
+            .edge_indices()
+            .filter(|&ei| {
+                self.graph
+                    .edge_weight(ei)
+                    .and_then(|d| d.session_id.as_deref())
+                    == Some(backend_id)
+            })
+            .collect();
+        let mut marked = 0;
+        for idx in idxs {
+            if let Some(data) = self.graph.edge_weight_mut(idx) {
+                data.broken = true;
+                marked += 1;
+            }
+        }
+        marked
     }
 
     /// Clear `session_id` from every edge where `session_id == Some(backend_id)`.
@@ -445,6 +584,7 @@ impl KnowledgeGraph {
                     output_transform: data.output_transform.clone(),
                     weight: data.weight,
                     session_id: data.session_id.clone(),
+                    broken: data.broken,
                 })
             })
             .collect()

--- a/frontend/src/lib/api/gen_types.ts
+++ b/frontend/src/lib/api/gen_types.ts
@@ -533,6 +533,8 @@ export interface components {
             targetId: string;
             /** @description Backend ID of the active persistent session on this exec-channel edge, if any. */
             sessionId?: string;
+            /** @description True when the session backing this exec-channel edge has died. The edge is kept (rendered as broken) and is non-traversable until a session reconnects and recovers it. */
+            broken?: boolean;
             provenance?: ("scenario" | "operator" | "action" | "inference")[];
         };
         CampaignState: {
@@ -575,6 +577,8 @@ export interface components {
             traversal: components["schemas"]["TraversalHop"][];
             /** @description The bare inner command as it runs on the final target system, before any hop envelopes wrap it. Empty when there is no multi-hop traversal. */
             innerCommand: string;
+            /** @description Short, human-readable explanation of why this execution route was chosen (e.g. a live session vs. a multi-hop path), including a note when a broken session edge to the target was skipped. Empty for direct/local commands with no joined traversal. */
+            routeReason?: string;
             args: {
                 [key: string]: string;
             };

--- a/frontend/src/lib/components/attack_step_details.svelte
+++ b/frontend/src/lib/components/attack_step_details.svelte
@@ -125,6 +125,12 @@
 		</div>
 	</header>
 	<article class="flex min-h-10 flex-auto flex-col overflow-auto">
+			{#if step.routeReason}
+				<div class="mt-4 justify-start">
+					<div class="pr-2 mb-1">Route</div>
+					<p class="text-xs opacity-80">{step.routeReason}</p>
+				</div>
+			{/if}
 		<div class="mt-4 justify-start">
 			{#if hasTraversal}
 				<div class="pr-2 mb-2">Traversal</div>

--- a/frontend/src/routes/components/graph.svelte
+++ b/frontend/src/routes/components/graph.svelte
@@ -409,6 +409,14 @@
 						cy.getElementById(n.data.id).data(n.data);
 					});
 
+					// Update data for existing edges too. An edge's id is stable across a
+					// status change (e.g. a session breaking flips `broken` while source,
+					// target and name stay the same), so without this refresh the
+					// edge[?broken] restyle would not apply until a full remount.
+					edges.filter((e: any) => e.data.id && cyEdgeIdSet.has(e.data.id as string)).forEach((e: any) => {
+						cy.getElementById(e.data.id).data(e.data);
+					});
+
 					// Pre-position new nodes near their connected existing nodes so they don't spawn randomly
 					if (nodesToAdd.length > 0) {
 						const addingIds = new Set<string>(nodesToAdd.map((n: any) => n.data.id as string));

--- a/frontend/src/routes/components/graph_style.ts
+++ b/frontend/src/routes/components/graph_style.ts
@@ -447,6 +447,23 @@ export function getGraphStyle(isDark: boolean = false) {
 		// 	}
 		// },
 		{
+			// A broken exec-channel edge: the session that backed it died, so it is
+			// no longer traversable. Kept in the graph for possible recovery but
+			// visually degraded — dashed and in a distinct warning color — with its
+			// label always shown so the break is legible at a glance.
+			selector: 'edge[?broken]',
+			style: {
+				'line-style': 'dashed',
+				'line-dash-pattern': [6, 3],
+				'line-color': '#dc2626',
+				'target-arrow-color': '#dc2626',
+				color: '#dc2626',
+				opacity: 0.7,
+				content: 'data(name)',
+				'font-size': 8
+			}
+		},
+		{
 			selector: 'edge:selected',
 			style: {
 				color: 'darkred',


### PR DESCRIPTION
## Summary
A dead `c2.session` used to keep looking and behaving like a live connection. Now session death is detected, the edge is tagged broken, routing avoids it, and it recovers cleanly on reconnect.

## What changed
- **Detect death** (`c2`): EOF sentinel, plus escalation after `SESSION_TIMEOUT_BREAK_THRESHOLD` (2) consecutive command timeouts — a single slow command doesn't break the session; any response resets the streak.
- **Tag, don't remove** (`graph`/`campaign`): `mark_session_broken` flags the edge (keeps `session_id` for recovery); `shortest_exec_path`, `reachable_via_exec`, `exec_edges`, and `resolve_source_backend_id` all skip broken edges.
- **Recover / replace**: a reconnecting session clears the mark in place; the new `c2.session` edge replaces the prior one via a **SingleSession** insert invariant — no lingering artifact.
- **Edge data fix**: `insert_relation_with_ids` now carries `session_id` / `is_exec_channel` onto `c2.session` edges, so a standalone session edge can be matched and styled.
- **UI**: broken edges render dashed + crimson (`edge[?broken]`); existing edges refresh their data on `facts-changed` so the restyle applies without a remount.
- **Routing reasoning**: a `routeReason` per step (logs + timeline UI), noting when a broken session edge was skipped.

## Tests
- `cargo build --workspace` ✅
- New: `broken_session_edge_is_non_traversable_until_recovered`, `new_c2_session_edge_replaces_the_prior_broken_one`, `standalone_session_edge_carries_session_id_and_can_break`, `timeouts_escalate_to_session_death_only_after_the_threshold`.
- cortex / campaign / c2 / api suites green.
- Frontend `svelte-check` not run (no `node_modules` in this worktree; npm registry blocked in-session).