### PR TITLE
Stop reporting a missing parse audit as a failed action

### DIFF
--- a/crates/campaign/src/runtime.rs
+++ b/crates/campaign/src/runtime.rs
@@ -175,12 +175,18 @@ pub fn spawn_c2_event_processor_with_external_parser(
                     };
 
                     if processing.parse_audits.is_empty() {
-                        warn!(
-                            cmd_id = %cmd.id,
-                            action_id = %action_id,
-                            target_id = %target_id,
-                            "Execution produced no parse audits; parser coverage may be missing"
-                        );
+                        // Only an effect-bearing TTP that emitted no audits is a
+                        // coverage gap. A TTP with no declared effects (e.g.
+                        // execute_shell) has nothing to parse, so silence there
+                        // is expected.
+                        if !cmd.ttp.effects.is_empty() {
+                            warn!(
+                                cmd_id = %cmd.id,
+                                action_id = %action_id,
+                                target_id = %target_id,
+                                "Execution produced no parse audits; parser coverage may be missing"
+                            );
+                        }
                     } else {
                         for audit in &processing.parse_audits {
                             match audit.parse_result {

--- a/frontend/src/lib/components/CampaignState.svelte.ts
+++ b/frontend/src/lib/components/CampaignState.svelte.ts
@@ -111,8 +111,12 @@ class CampaignState {
 		});
 		this.api.on('parse-audited', (data: any) => {
 			const audits = (data?.audits ?? []).map(normalizeParseAudit);
-			if (!Array.isArray(audits) || audits.length === 0) {
-				showToast('Parsing coverage', 'No parse audits were emitted for this action', 'error');
+			if (audits.length === 0) {
+				// A TTP that declares no effects has nothing to parse, so an empty
+				// audit list is the normal outcome, not a failed action. Keep it in
+				// the console for parser-coverage work instead of toasting an error
+				// at the operator, who would read it as the action having failed.
+				console.debug('[parse-audited] no parse audits for this action (no declared effects)');
 				return;
 			}
 


### PR DESCRIPTION
Creating a redirector returns `ok`, changes nothing visible, and then raises an error toast: **"Parsing coverage / No parse audits were emitted for this action."** Operators read that as the action having failed.

## Cause

Parse audits are emitted one per declared *effect* (`crates/campaign/src/campaign/execution.rs`, the `for effect in &cmd.ttp.effects` loop). A TTP that declares no effects has nothing to audit, so it emits an empty list, and the frontend treated that emptiness as a fault.

Absence of audits is not evidence of a parser gap. Every declared effect pushes exactly one audit in all three arms of that loop, and both failure paths push a failure-analyzer audit. An empty list therefore means only that there were no effects to parse.

## Change

- `frontend/src/lib/components/CampaignState.svelte.ts` — an empty audit list is a `console.debug`, not an error toast. Real gaps are untouched: `ParserBug` / `UnknownFormat` still toast, `NoParser` / `KnownFailure` stay log-only.
- `crates/campaign/src/runtime.rs` — the backend carried the same false positive, warning "parser coverage may be missing" on every effect-less TTP. It now warns only when the TTP actually declared effects.

## Scope

Eight TTPs currently reach this path and false-alarm on every successful run: `execute_shell`, `start_reverse_shell`, `drop_and_exec_implant`, `execute_node-proxy-exec`, `IngressNightmare`, `python_pickle_dropper`, `delete_k8s_events`, `mitm-cve-2020-8554`.

`create_redirector` was the ninth. It gains real effects and a `c2.port-forward(` parser arm in the Create/Stop Redirector work on `implement-redirector-enti`, so it drops off this list once that merges; the two changes touch `runtime.rs` in different places (this one is a guard around the existing `warn!`).

Whether those eight *should* declare effects is a separate question, and for several the answer is plainly yes.

## Verification

`cargo fmt --check`, `cargo clippy --workspace -- -D warnings`, and `cargo test -p campaign` (466 passed) are clean. The frontend change is unverified by tests: `frontend/node_modules` cannot be installed in this environment, so `svelte-check` and the vitest suite could not run.

## Not in this PR

`crates/c2/src/builtin.rs` returns `ok_result` ("ok", exit 0, success) for any non-pod target it cannot route, so an unroutable command reports success. Nothing reaches it today, but it will silently fake success for the next TTP that does.

https://claude.ai/code/session_01H7ca8yBuQ37EDHKiMo8QD1