### PR TITLE
fix(build): unbreak the windows release build

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -118,11 +118,15 @@ jobs:
           retention-days: 1
 
   # ============================================
-  # Stage 2: Build binaries (matrix, only on release)
+  # Stage 2: Build binaries (matrix, on release or on demand)
+  #
+  # Also runs on workflow_dispatch so a release build can be proven on every
+  # target without cutting a tag. Stage 3 still requires a tag, so a manual
+  # run builds and uploads artifacts without publishing a release.
   # ============================================
   build:
     needs: [test-rust, test-and-build-frontend]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
     strategy:
       matrix:
         include:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "planner",
  "ran-domain",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -207,29 +208,6 @@ name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.44.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "pkg-config",
-]
 
 [[package]]
 name = "axum"
@@ -386,8 +364,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -396,12 +372,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -502,15 +472,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -798,12 +759,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -899,12 +854,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1011,10 +960,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1036,11 +983,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1538,16 +1483,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
-dependencies = [
- "getrandom 0.4.3",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1606,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -1713,12 +1649,6 @@ name = "log"
 version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "matchers"
@@ -1943,12 +1873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
 name = "planner"
 version = "0.1.0"
 dependencies = [
@@ -2003,63 +1927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quinn"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.4.3",
- "lru-slab",
- "rand 0.10.2",
- "rand_pcg",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2168,15 +2035,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
-name = "rand_pcg"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
-dependencies = [
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2247,7 +2105,6 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -2359,12 +2216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,7 +2243,6 @@ version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2420,7 +2270,6 @@ version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -2457,7 +2306,6 @@ version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2954,21 +2802,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3411,16 +3244,6 @@ name = "web-sys"
 version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -14,7 +14,12 @@ kubetier = { path = "../kubetier" }
 utility-ai = { path = "../utility-ai" }
 ran-domain = { path = "../domain" }
 mime_guess = "2"
-reqwest = "0.13"
+reqwest = { version = "0.13", default-features = false, features = [
+    "rustls-no-provider",
+    "charset",
+    "http2",
+    "system-proxy",
+] }
 rmcp = { version = "1", features = ["server", "macros", "schemars", "transport-streamable-http-server"] }
 rust-embed = "8"
 serde = { workspace = true }

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -19,7 +19,14 @@ k8s = { path = "../k8s" }
 kubetier = { path = "../kubetier" }
 planner = { path = "../planner" }
 ran-domain = { path = "../domain" }
-reqwest = { version = "0.13", features = ["json"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+reqwest = { version = "0.13", default-features = false, features = [
+    "rustls-no-provider",
+    "charset",
+    "http2",
+    "system-proxy",
+    "json",
+] }
 serde = { workspace = true }
 serde_json = "1"
 serde_yaml = "0.9"

--- a/crates/app/src/lib.rs
+++ b/crates/app/src/lib.rs
@@ -914,6 +914,7 @@ impl ScriptParserRunner {
             info!(webhook = %url, "parser-gap generator webhook enabled");
         }
 
+        ensure_crypto_provider();
         let webhook_client = reqwest::Client::builder()
             .timeout(Duration::from_millis(1500))
             .build()
@@ -1270,13 +1271,26 @@ fn local_tool_binaries(armory: &Armory) -> HashMap<String, BinaryPresence> {
     binaries
 }
 
+/// Installs the `ring` crypto provider unless one is already installed.
+///
+/// `reqwest` is built with `rustls-no-provider`, which keeps the `aws-lc-rs`
+/// C library out of the build. The cost is that it panics rather than erroring
+/// when no provider is registered, so anything constructing an HTTPS client
+/// has to register one first. Binaries do this in `main`; this keeps library
+/// consumers from tripping over it. `install_default` returns `Err` when a
+/// provider is already set, which is the normal case and not a problem.
+fn ensure_crypto_provider() {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
 /// First executable named `tool` on `PATH`, or `None`.
 ///
 /// Deliberately not a `which` subprocess: this runs for every armory tool at
 /// startup, and reading `PATH` is both faster and free of shell quoting.
 fn which(tool: &str) -> Option<PathBuf> {
     // A name with a separator is a path, not something to search for.
-    if tool.contains('/') {
+    // `/` counts on every platform; Windows also accepts `\`.
+    if tool.contains('/') || tool.contains(std::path::MAIN_SEPARATOR) {
         return None;
     }
     let path = std::env::var_os("PATH")?;
@@ -1286,10 +1300,19 @@ fn which(tool: &str) -> Option<PathBuf> {
 }
 
 fn is_executable_file(path: &Path) -> bool {
-    use std::os::unix::fs::PermissionsExt;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
 
-    std::fs::metadata(path)
-        .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        std::fs::metadata(path)
+            .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+    }
+    // Windows has no executable bit: being a file is as much as a PATH scan
+    // can tell us.
+    #[cfg(not(unix))]
+    {
+        path.is_file()
+    }
 }
 
 /// Non-loopback IPs of the machine running Ran.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,4 +18,4 @@ clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
-rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -102,7 +102,7 @@ struct EmulateArgs {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    rustls::crypto::aws_lc_rs::default_provider()
+    rustls::crypto::ring::default_provider()
         .install_default()
         .expect("failed to install rustls crypto provider");
     init_tracing();

--- a/crates/kubetier/Cargo.toml
+++ b/crates/kubetier/Cargo.toml
@@ -6,7 +6,13 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 chrono = { workspace = true }
-reqwest = "0.13"
+reqwest = { version = "0.13", default-features = false, features = [
+    "rustls-no-provider",
+    "charset",
+    "http2",
+    "system-proxy",
+] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { workspace = true }
 serde_json = "1"
 sha2 = "0.11"

--- a/crates/kubetier/src/bin/update_catalog.rs
+++ b/crates/kubetier/src/bin/update_catalog.rs
@@ -20,6 +20,11 @@ struct Args {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // `reqwest` is built with `rustls-no-provider`, so the process has to pick
+    // the crypto provider itself before any HTTPS client is constructed.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
     let args = parse_args()?;
     let client = reqwest::Client::builder()
         .user_agent("Ran KubeTier snapshot importer (+https://github.com/Magier/Ran)")


### PR DESCRIPTION
The v0.2.4 release build failed on `x86_64-pc-windows-msvc`: `crates/app` had an ungated `use std::os::unix::fs::PermissionsExt`, added in #71 with the operator-host tool probe. The Windows matrix only runs on tags, so PR checks never saw it.

## Changes

- `is_executable_file` is now cfg-split, matching the existing pattern in `crates/campaign`. Windows has no executable bit, so it falls back to `is_file()`.
- `which()` also rejects `MAIN_SEPARATOR`, not just `/`.
- Dropped `aws-lc-rs` in favour of `ring`, removing the `aws-lc-sys` C build. The source was `reqwest`'s default `rustls` feature, which hard-wires `__rustls-aws-lc-rs`; `kube` was already on `ring`, so both providers were being compiled. `reqwest` now uses `rustls-no-provider` with the other three defaults restored explicitly.
- `rustls-no-provider` panics rather than erroring when no provider is registered, so both binaries install one. `update_catalog` needed it (second binary, no install), and `AppState::new` calls `ensure_crypto_provider()` since the existing `unwrap_or_else` fallback cannot catch a panic inside `build()`.

## Verification

- `aws-lc-sys`/`aws-lc-rs`: gone from the graph on host and Windows targets, 0 hits in `Cargo.lock`
- `cargo test --workspace`: 724 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- Repo-wide sweep confirms no other `std::os::unix` usage

Cross-compiling windows-msvc from macOS is still blocked by `ring`'s C shim needing MSVC libc headers, so the native CI build is the only end-to-end proof. Note the Windows job is tag-gated and will not run on this PR.

https://claude.ai/code/session_015cCbFTLVFwHNGmqUECRvHr