### PR TITLE
fix(campaign): preserve pod sessions during token discovery

### DIFF
--- a/crates/c2/src/builtin.rs
+++ b/crates/c2/src/builtin.rs
@@ -50,6 +50,21 @@ impl BuiltinC2 {
 
     pub async fn execute(&self, cmd: &ExecTtp) -> TtpExecuted {
         let routing_target = cmd.exec_entity();
+        if routing_target.starts_with("ns/?/pod/") {
+            let reason = format!(
+                "cannot exec pod target '{}': its Kubernetes namespace is unknown",
+                routing_target
+            );
+            warn!(cmd_id = %cmd.id, target_id = %cmd.target_id, routing_target, "{}", reason);
+            return TtpExecuted {
+                id: cmd.id.clone(),
+                success: false,
+                results: vec![reason.clone()],
+                exit_code: 1,
+                fail_reason: reason,
+                session_connected: None,
+            };
+        }
         if let Some((namespace, pod_name)) = parse_pod_target_id(routing_target) {
             debug!(
                 cmd_id = %cmd.id,
@@ -233,7 +248,12 @@ fn parse_pod_target_id(target_id: &str) -> Option<(&str, &str)> {
         return None;
     }
 
-    if kind_a != "ns" || kind_b != "pod" || namespace.is_empty() || pod_name.is_empty() {
+    if kind_a != "ns"
+        || kind_b != "pod"
+        || namespace.is_empty()
+        || namespace == "?"
+        || pod_name.is_empty()
+    {
         return None;
     }
 
@@ -399,6 +419,23 @@ mod tests {
 
         let calls = fake.calls.lock().expect("lock should not be poisoned");
         assert!(calls.is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_namespace_pod_target_is_not_sent_to_kubernetes() {
+        let fake = Arc::new(FakePodExecClient::default());
+        let builtin = BuiltinC2::from_pod_exec_client(fake.clone());
+
+        let cmd = exec_cmd("ns/?/pod/netshoot", "id", "");
+        let result = builtin.execute(&cmd).await;
+
+        assert!(!result.success);
+        assert!(result.fail_reason.contains("namespace is unknown"));
+        assert!(fake
+            .calls
+            .lock()
+            .expect("lock should not be poisoned")
+            .is_empty());
     }
 
     fn exec_cmd(target_id: &str, command: &str, exec_system_id: &str) -> ExecTtp {

--- a/crates/c2/src/executor.rs
+++ b/crates/c2/src/executor.rs
@@ -1144,6 +1144,21 @@ async fn await_tunnel_ready(
                     Ok(status) => format!("exited before the tunnel came up ({status})"),
                     Err(error) => format!("could not be waited on: {error}"),
                 };
+                // The process can exit before the independent pipe-draining
+                // tasks get their first scheduling turn. Give them a bounded
+                // chance to forward the final diagnostic before reporting the
+                // failure, otherwise a rejected `labctl` invocation looks like
+                // it produced no output.
+                if draining {
+                    while let Ok(Some(line)) = tokio::time::timeout(
+                            std::time::Duration::from_millis(250),
+                            lines.recv(),
+                        )
+                        .await
+                    {
+                        transcript.push(line);
+                    }
+                }
                 return Err(format!("{detail}: {}", quote_transcript(&transcript)));
             }
             line = lines.recv(), if draining => match line {

--- a/crates/c2/src/shell_session.rs
+++ b/crates/c2/src/shell_session.rs
@@ -22,7 +22,9 @@ static NONCE: AtomicU64 = AtomicU64::new(1);
 /// Framing protocol (written to stdin for each command):
 /// ```text
 /// {cmd} 2>&1
-/// printf '__RAN_{nonce}__:%d\n' $?
+/// __ran_status=$?
+/// printf '\n'
+/// printf '__RAN_{nonce}__:%d\n' "$__ran_status"
 /// ```
 /// Lines are read until the sentinel `__RAN_{nonce}__:{exit_code}` appears.
 /// Everything before it is stdout (stderr merged via `2>&1`).
@@ -42,6 +44,15 @@ pub struct ShellSession {
 struct ShellInner {
     tx: Box<dyn AsyncWrite + Unpin + Send>,
     rx: BufReader<Box<dyn AsyncRead + Unpin + Send>>,
+}
+
+/// Frame a shell command with a sentinel on a line of its own. The explicit
+/// newline matters for files such as Kubernetes ServiceAccount JWTs, which do
+/// not necessarily end with one.
+fn framed_command(command: &str, marker: &str) -> String {
+    format!(
+        "{command} 2>&1\n__ran_status=$?\nprintf '\\n'\nprintf '{marker}:%d\\n' \"$__ran_status\"\n"
+    )
 }
 
 impl ShellSession {
@@ -153,7 +164,7 @@ impl ShellSession {
     pub async fn run_raw(&self, cmd: &str) -> Result<String, String> {
         let nonce = NONCE.fetch_add(1, Ordering::Relaxed);
         let marker = format!("__RAN_{nonce}__");
-        let payload = format!("{cmd} 2>&1\nprintf '{marker}:%d\\n' $?\n");
+        let payload = framed_command(cmd, &marker);
 
         let mut guard = self.inner.lock().await;
         guard
@@ -211,7 +222,7 @@ impl C2Backend for ShellSession {
         // Two-line payload: run the command with merged stderr, then print
         // the sentinel on its own line so it's never mixed with command output.
         let command = &cmd.procedure.command;
-        let payload = format!("{command} 2>&1\nprintf '{marker}:%d\\n' $?\n");
+        let payload = framed_command(command, &marker);
 
         let mut guard = self.inner.lock().await;
 
@@ -353,6 +364,9 @@ mod tests {
                 // When we see a `printf '...'` line, extract the marker and reply.
                 if let Some(rest) = line.trim_end().strip_prefix("printf '") {
                     let marker = rest.split('%').next().unwrap_or("").trim_end_matches(':');
+                    if !marker.starts_with("__RAN_") {
+                        continue;
+                    }
                     let reply = if marker.contains("INIT0") {
                         format!("{marker}\n")
                     } else {
@@ -414,6 +428,9 @@ mod tests {
                 }
                 if let Some(rest) = line.trim_end().strip_prefix("printf '") {
                     let marker = rest.split('%').next().unwrap_or("").trim_end_matches(':');
+                    if !marker.starts_with("__RAN_") {
+                        continue;
+                    }
                     let reply = if marker.contains("INIT0") {
                         format!("{marker}\n")
                     } else {
@@ -459,6 +476,9 @@ mod tests {
                 // Only unblock init(); real commands get no sentinel, so they hang.
                 if let Some(rest) = line.trim_end().strip_prefix("printf '") {
                     let marker = rest.split('%').next().unwrap_or("").trim_end_matches(':');
+                    if !marker.starts_with("__RAN_") {
+                        continue;
+                    }
                     if marker.contains("INIT0") {
                         let _ = server_tx.write_all(format!("{marker}\n").as_bytes()).await;
                         let _ = server_tx.flush().await;
@@ -494,6 +514,14 @@ mod tests {
             crate::types::is_session_death_reason(&second.fail_reason),
             "consecutive timeouts should escalate to session death: {}",
             second.fail_reason
+        );
+    }
+
+    #[test]
+    fn command_framing_separates_a_marker_from_output_without_a_newline() {
+        assert_eq!(
+            super::framed_command("cat /token", "__RAN_42__"),
+            "cat /token 2>&1\n__ran_status=$?\nprintf '\\n'\nprintf '__RAN_42__:%d\\n' \"$__ran_status\"\n"
         );
     }
 

--- a/crates/campaign/src/campaign/execution.rs
+++ b/crates/campaign/src/campaign/execution.rs
@@ -1249,12 +1249,7 @@ impl Campaign {
         }
 
         if needs_remote_channel(procedure, tactic) {
-            // Credential Access TTPs read container-filesystem paths (e.g. SA tokens
-            // mounted at /var/run/secrets/...).  Active sessions may be running in host
-            // namespace after a container escape, so force a fresh kubectl exec that
-            // always targets the container's own mount namespace.
-            let prefer_session = normalize_tactic(tactic) != "credential access";
-            return self.route_remote(target_id, procedure, prefer_session, args);
+            return self.route_remote(target_id, procedure, args);
         }
 
         self.route_fallback(target_id)
@@ -1386,11 +1381,10 @@ impl Campaign {
         &mut self,
         target_id: &str,
         procedure: &mut Procedure,
-        prefer_session: bool,
         args: &HashMap<String, String>,
     ) -> Result<ExecRoute, ExecuteActionError> {
         let ch = self
-            .resolve_exec_channel_inner(target_id, prefer_session)
+            .resolve_exec_channel(target_id)
             .map_err(ExecuteActionError::NoExecChannel)?;
         let exec_target = ch
             .exec_target_id

--- a/crates/campaign/src/campaign/state.rs
+++ b/crates/campaign/src/campaign/state.rs
@@ -423,17 +423,13 @@ impl Campaign {
 
     /// Query the knowledge graph and return the best execution channel for `target_id`.
     pub fn resolve_exec_channel(&self, target_id: &str) -> Result<ExecChannel, String> {
-        self.resolve_exec_channel_inner(target_id, true)
+        self.resolve_exec_channel_inner(target_id)
     }
 
-    /// Inner resolver. When `prefer_session` is false the active-session fast-path
-    /// is skipped, forcing graph-based channel resolution (used for SA credential
-    /// reads that must run inside the container's mount namespace, not a host-side
-    /// session that may have escaped the container).
+    /// Inner resolver used for recursive resolution through non-system entities.
     pub(super) fn resolve_exec_channel_inner(
         &self,
         target_id: &str,
-        prefer_session: bool,
     ) -> Result<ExecChannel, String> {
         // The caller may hold an id that was merged away (a promoted foothold,
         // a pod that gained its real name); route to whatever it became.
@@ -441,52 +437,46 @@ impl Campaign {
         let target_id = canonical.as_str();
         let target_eid = EntityId::new(target_id);
 
-        // Prefer an Active session on the target system - it is a live shell
-        // already exiting into this entity, so no graph traversal is needed.
-        if prefer_session {
-            let active_session = self.get_system_entity(target_id).and_then(|sys| {
-                sys.entity()
-                    .system()
-                    .sessions
-                    .iter()
-                    .find(|s| s.status == SessionStatus::Active)
-                    .map(|s| s.backend_id())
-            });
+        // Prefer an Active session on the target system. Routing is independent
+        // of tactic: a session's containment is a property of the session, not
+        // of the action it happens to execute.
+        let active_session = self.get_system_entity(target_id).and_then(|sys| {
+            sys.entity()
+                .system()
+                .sessions
+                .iter()
+                .find(|s| s.status == SessionStatus::Active)
+                .map(|s| s.backend_id())
+        });
 
-            if let Some(ref backend_id) = active_session {
-                tracing::debug!(
-                    target_id = %target_id,
-                    backend_id = %backend_id,
-                    "resolve_exec_channel: using active session"
-                );
-                return Ok(ExecChannel {
-                    backend_id: backend_id.clone(),
-                    hops: vec![],
-                    exec_target_id: None,
-                });
-            }
-
-            // No live session, but a down (lost/broken) one exists on this target:
-            // make the reroute explicit in the logs rather than silently falling
-            // through to graph-based routing.
-            let has_down_session = self.get_system_entity(target_id).is_some_and(|sys| {
-                sys.entity()
-                    .system()
-                    .sessions
-                    .iter()
-                    .any(|s| s.status != SessionStatus::Active)
-            });
-            if has_down_session {
-                tracing::info!(
-                    target_id = %target_id,
-                    "resolve_exec_channel: session on target is down; \
-                     rerouting via the knowledge graph"
-                );
-            }
-        } else {
+        if let Some(ref backend_id) = active_session {
             tracing::debug!(
                 target_id = %target_id,
-                "resolve_exec_channel: session preference skipped (credential access path)"
+                backend_id = %backend_id,
+                "resolve_exec_channel: using active session"
+            );
+            return Ok(ExecChannel {
+                backend_id: backend_id.clone(),
+                hops: vec![],
+                exec_target_id: None,
+            });
+        }
+
+        // No live session, but a down (lost/broken) one exists on this target:
+        // make the reroute explicit in the logs rather than silently falling
+        // through to graph-based routing.
+        let has_down_session = self.get_system_entity(target_id).is_some_and(|sys| {
+            sys.entity()
+                .system()
+                .sessions
+                .iter()
+                .any(|s| s.status != SessionStatus::Active)
+        });
+        if has_down_session {
+            tracing::info!(
+                target_id = %target_id,
+                "resolve_exec_channel: session on target is down; \
+                 rerouting via the knowledge graph"
             );
         }
 
@@ -557,15 +547,10 @@ impl Campaign {
             .map(|(src, _)| src.clone());
 
         if let Some(pod_id) = sa_pod_id {
-            // Use graph-based routing (not any active session) for the pod so the command
-            // runs inside the container's mount namespace where the SA token is mounted.
-            // Active sessions may be in host namespace after a container escape.
-            return self
-                .resolve_exec_channel_inner(&pod_id.0, false)
-                .map(|mut ch| {
-                    ch.exec_target_id = Some(pod_id.0);
-                    ch
-                });
+            return self.resolve_exec_channel_inner(&pod_id.0).map(|mut ch| {
+                ch.exec_target_id = Some(pod_id.0);
+                ch
+            });
         }
 
         Err(format!(

--- a/crates/campaign/src/campaign/tests.rs
+++ b/crates/campaign/src/campaign/tests.rs
@@ -637,6 +637,29 @@ fn resolve_exec_channel_resolves_via_service_account_uses_relation() {
 }
 
 #[test]
+fn resolve_exec_channel_uses_active_pod_session_for_service_account_target() {
+    let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
+    let mut pod = Pod::new("player-pod", "dungeon");
+    let pod_id = pod.entity_id().0.clone();
+    pod.system.sessions.push(SessionInfo {
+        id: "shell-1".to_string(),
+        kind: "tcp".to_string(),
+        port: Some(4444),
+        status: SessionStatus::Active,
+    });
+    campaign.entities.insert_typed(pod);
+
+    let sa_id = "ns/dungeon/sa/player";
+    push_relation(&mut campaign, &Uses::new(&pod_id, sa_id));
+
+    let ch = campaign
+        .resolve_exec_channel(sa_id)
+        .expect("should resolve through the pod's active session");
+    assert_eq!(ch.backend_id, "session/shell-1");
+    assert_eq!(ch.exec_target_id.as_deref(), Some(pod_id.as_str()));
+}
+
+#[test]
 fn resolve_exec_channel_errors_when_no_path_in_graph() {
     let mut campaign = Campaign::bootstrap("Ran", K8sCluster::new("dev"));
     let pod = Pod::new("orphan", "default");

--- a/crates/campaign/src/output_parsers/iam.rs
+++ b/crates/campaign/src/output_parsers/iam.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use ran_domain::{
-    Contains, Entity, JwToken, K8sCredential, K8sNode, NameConfidence, Namespace, Pod,
+    Contains, Entity, EntityId, JwToken, K8sCredential, K8sNode, NameConfidence, Namespace, Pod,
     RbacPermission, RbacScopeKind, RbacScopeSource, RunsOn, ServiceAccount, ServiceAccountToken,
     Uses,
 };
@@ -152,7 +152,9 @@ fn parse_raw_service_account_token(
         if let Some((expected_sa_name, expected_ns)) =
             parse_sa_identity_from_target(expected_target)
         {
-            if expected_sa_name != sa_name || expected_ns != namespace {
+            if expected_sa_name != sa_name
+                || (expected_ns != UNKNOWN_NAMESPACE && expected_ns != namespace)
+            {
                 return ParserOutput::KnownFailure(format!(
                     "decoded SA token for {}/{} but target is {}/{}",
                     namespace, sa_name, expected_ns, expected_sa_name
@@ -165,6 +167,7 @@ fn parse_raw_service_account_token(
         {
             if let Some(decoded_pod_name) = pod_name.as_deref() {
                 if !decoded_pod_name.is_empty()
+                    && expected_pod_ns != UNKNOWN_NAMESPACE
                     && !is_ip_placeholder_pod_name(expected_pod_name)
                     && (decoded_pod_name != expected_pod_name || namespace != expected_pod_ns)
                 {
@@ -222,6 +225,20 @@ fn parse_raw_service_account_token(
     let sa_id = sa.entity_id();
     facts.new_entities.push(Box::new(sa));
 
+    // A placeholder namespace means the action was launched before identity
+    // discovery. The token's claims are authoritative for this reconciliation.
+    if let Some(expected_target) = args.get("TARGET_ID") {
+        if let Some((expected_sa_name, expected_ns)) =
+            parse_sa_identity_from_target(expected_target)
+        {
+            if expected_ns == UNKNOWN_NAMESPACE && expected_sa_name == sa_name {
+                facts
+                    .entity_aliases
+                    .insert((EntityId::new(expected_target), sa_id.clone()));
+            }
+        }
+    }
+
     // Contains: namespace → SA.
     facts
         .new_relations
@@ -236,6 +253,18 @@ fn parse_raw_service_account_token(
             pod.service_account_name = Some(sa_name.clone());
             pod.is_running = true;
             let pod_id = pod.entity_id();
+
+            if let Some(expected_target) = args.get("TARGET_ID") {
+                if let Some((_expected_pod_name, expected_pod_ns)) =
+                    parse_pod_identity_from_target(expected_target)
+                {
+                    if expected_pod_ns == UNKNOWN_NAMESPACE {
+                        facts
+                            .entity_aliases
+                            .insert((EntityId::new(expected_target), pod_id.clone()));
+                    }
+                }
+            }
 
             // If bound, attach the node name.
             if let Some(node_name) = &node_name {
@@ -604,6 +633,9 @@ fn parse_pod_identity_from_target(target_id: &str) -> Option<(&str, &str)> {
     }
 }
 
+/// Namespace placeholder for objects discovered before their namespace is known.
+const UNKNOWN_NAMESPACE: &str = "?";
+
 /// Heuristic for placeholder pod IDs derived from network discovery, e.g.
 /// `redis.10-0-0-35`.
 fn is_ip_placeholder_pod_name(name: &str) -> bool {
@@ -814,6 +846,30 @@ mod tests {
         assert!(facts.new_relations.iter().any(|r| r.is::<Contains>()));
         assert!(facts.new_relations.iter().any(|r| r.is::<Uses>()));
         assert!(facts.new_relations.iter().any(|r| r.is::<RunsOn>()));
+    }
+
+    #[test]
+    fn parse_raw_sa_token_resolves_unknown_namespace_pod_target() {
+        let payload = r#"{
+            "kubernetes.io": {
+                "namespace": "dungeon",
+                "pod": {"name": "netshoot-console-858465679b-lhxq4", "uid": "pod-uid-1"},
+                "serviceaccount": {"name": "player", "uid": "sa-uid-1"}
+            },
+            "sub": "system:serviceaccount:dungeon:player"
+        }"#;
+        let jwt = make_jwt(payload);
+        let args = HashMap::from([("TARGET_ID".to_string(), "ns/?/pod/netshoot".to_string())]);
+
+        let result = parse_raw_service_account_token(&jwt, "", &args);
+        let ParserOutput::SuccessWithFacts(facts, _) = result else {
+            panic!("expected SuccessWithFacts");
+        };
+
+        assert!(facts.entity_aliases.contains(&(
+            EntityId::new("ns/?/pod/netshoot"),
+            EntityId::new("ns/dungeon/pod/netshoot-console-858465679b-lhxq4"),
+        )));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- route credential reads through the same active-session selection as other remote actions
- use ServiceAccount token claims to resolve unknown pod namespaces
- reject Kubernetes API pod exec requests with an unresolved namespace

## Tests
- cargo test -p c2 'pod_target' --lib\n- cargo test -p campaign --lib