### PR TITLE
chore(frontend): green lint baseline and CI gate

### DIFF
--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -107,6 +107,9 @@ jobs:
       - name: Lint frontend
         run: make lint-frontend
 
+      - name: Typecheck frontend
+        run: make check-frontend
+
       - name: Run frontend tests
         run: make test-frontend
 

--- a/.github/workflows/build-rust.yaml
+++ b/.github/workflows/build-rust.yaml
@@ -104,6 +104,9 @@ jobs:
       - name: Install dependencies
         run: pnpm --prefix frontend install --frozen-lockfile
 
+      - name: Lint frontend
+        run: make lint-frontend
+
       - name: Run frontend tests
         run: make test-frontend
 

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,12 @@ fmt-check:
 clippy:
 	cargo clippy --workspace --locked -- -D warnings
 
+.PHONY: lint-frontend
+lint-frontend:
+	pnpm --prefix frontend lint
+
 .PHONY: lint
-lint: fmt-check clippy
+lint: fmt-check clippy lint-frontend
 
 # === Testing ===
 .PHONY: test-rust

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,14 @@ clippy:
 lint-frontend:
 	pnpm --prefix frontend lint
 
+# svelte-check: type errors that eslint does not see. Green as of the #52
+# baseline, and gated so it stays that way.
+.PHONY: check-frontend
+check-frontend:
+	pnpm --prefix frontend check
+
 .PHONY: lint
-lint: fmt-check clippy lint-frontend
+lint: fmt-check clippy lint-frontend check-frontend
 
 # === Testing ===
 .PHONY: test-rust

--- a/frontend/.vscode/extensions.json
+++ b/frontend/.vscode/extensions.json
@@ -1,5 +1,3 @@
 {
-  "recommendations": [
-    "svelte.svelte-vscode"
-  ]
+	"recommendations": ["svelte.svelte-vscode"]
 }

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -21,6 +21,19 @@ export default ts.config(
 				...globals.browser,
 				...globals.node
 			}
+		},
+		rules: {
+			// A leading underscore marks a binding that exists for its side effect,
+			// not its value. The common case is a $effect dependency tracker:
+			// reading the value is the point, so the read must not be deleted.
+			'@typescript-eslint/no-unused-vars': [
+				'error',
+				{
+					argsIgnorePattern: '^_',
+					varsIgnorePattern: '^_',
+					caughtErrorsIgnorePattern: '^_'
+				}
+			]
 		}
 	},
 	{

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -37,6 +37,21 @@ export default ts.config(
 		}
 	},
 	{
+		// Tech debt from before frontend linting was enforced, tracked in
+		// https://github.com/Magier/Ran/issues/52. Warnings so CI gates every
+		// other rule at error while these are worked down; each one goes back
+		// to 'error' as its area is cleaned up.
+		//
+		//   @typescript-eslint/no-explicit-any    cytoscape and its plugins
+		//   svelte/require-each-key               {#each} blocks without a key
+		//   svelte/prefer-svelte-reactivity       plain Map/Set in reactive state
+		rules: {
+			'@typescript-eslint/no-explicit-any': 'warn',
+			'svelte/require-each-key': 'warn',
+			'svelte/prefer-svelte-reactivity': 'warn'
+		}
+	},
+	{
 		files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
 		ignores: ['eslint.config.js', 'svelte.config.js'],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,7 +42,7 @@
 		"openapi-typescript": "^7.13.0",
 		"prettier": "^3.8.3",
 		"prettier-plugin-svelte": "^3.5.1",
-		"prettier-plugin-tailwindcss": "^0.6.14",
+		"prettier-plugin-tailwindcss": "^0.8.1",
 		"svelte": "^5.55.5",
 		"svelte-check": "^4.4.6",
 		"tailwindcss": "^4.2.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -121,8 +121,8 @@ importers:
         specifier: ^3.5.1
         version: 3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.0))
       prettier-plugin-tailwindcss:
-        specifier: ^0.6.14
-        version: 0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.0)))(prettier@3.8.3)
+        specifier: ^0.8.1
+        version: 0.8.1(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.0)))(prettier@3.8.3)
       svelte:
         specifier: ^5.55.5
         version: 5.55.5(@typescript-eslint/types@8.59.0)
@@ -1943,9 +1943,9 @@ packages:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
 
-  prettier-plugin-tailwindcss@0.6.14:
-    resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
-    engines: {node: '>=14.21.3'}
+  prettier-plugin-tailwindcss@0.8.1:
+    resolution: {integrity: sha512-iaFMYqDsE4ffdDkn5qup0j5f2aCEBFZrdrZnvu9QKTlWx/iGPeQ4HHu7b7fCPMxeo9nwQBiOAh2nSypdFYWJkw==}
+    engines: {node: '>=20.19'}
     peerDependencies:
       '@ianvs/prettier-plugin-sort-imports': '*'
       '@prettier/plugin-hermes': '*'
@@ -1957,14 +1957,12 @@ packages:
       prettier: ^3.0
       prettier-plugin-astro: '*'
       prettier-plugin-css-order: '*'
-      prettier-plugin-import-sort: '*'
       prettier-plugin-jsdoc: '*'
       prettier-plugin-marko: '*'
       prettier-plugin-multiline-arrays: '*'
       prettier-plugin-organize-attributes: '*'
       prettier-plugin-organize-imports: '*'
       prettier-plugin-sort-imports: '*'
-      prettier-plugin-style-order: '*'
       prettier-plugin-svelte: '*'
     peerDependenciesMeta:
       '@ianvs/prettier-plugin-sort-imports':
@@ -1985,8 +1983,6 @@ packages:
         optional: true
       prettier-plugin-css-order:
         optional: true
-      prettier-plugin-import-sort:
-        optional: true
       prettier-plugin-jsdoc:
         optional: true
       prettier-plugin-marko:
@@ -1998,8 +1994,6 @@ packages:
       prettier-plugin-organize-imports:
         optional: true
       prettier-plugin-sort-imports:
-        optional: true
-      prettier-plugin-style-order:
         optional: true
       prettier-plugin-svelte:
         optional: true
@@ -4292,7 +4286,7 @@ snapshots:
       prettier: 3.8.3
       svelte: 5.55.5(@typescript-eslint/types@8.59.0)
 
-  prettier-plugin-tailwindcss@0.6.14(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.0)))(prettier@3.8.3):
+  prettier-plugin-tailwindcss@0.8.1(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.0)))(prettier@3.8.3):
     dependencies:
       prettier: 3.8.3
     optionalDependencies:

--- a/frontend/scripts/generate-api-methods.mjs
+++ b/frontend/scripts/generate-api-methods.mjs
@@ -5,7 +5,7 @@
  * Run after: make generate-api
  */
 
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 
@@ -13,14 +13,12 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const openapiPath = join(__dirname, '../src/api/openapi.yaml');
-const ranApiPath = join(__dirname, '../src/lib/ran_api.ts');
 
 // Read OpenAPI spec
 const yaml = readFileSync(openapiPath, 'utf-8');
 
 // Extract paths and generate methods
-const paths = {};
-const pathRegex = /^  \/api\/([^:]+):\s*$/gm;
+const pathRegex = /^ {2}\/api\/([^:]+):\s*$/gm;
 let match;
 
 while ((match = pathRegex.exec(yaml)) !== null) {

--- a/frontend/scripts/generate-api-methods.mjs
+++ b/frontend/scripts/generate-api-methods.mjs
@@ -24,7 +24,7 @@ const pathRegex = /^  \/api\/([^:]+):\s*$/gm;
 let match;
 
 while ((match = pathRegex.exec(yaml)) !== null) {
-    console.log('Found path:', match[1]);
+	console.log('Found path:', match[1]);
 }
 
 console.log('✓ To add new endpoints, update openapi.yaml and run: make generate-api');

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
-@plugin "@tailwindcss/forms";
+@plugin '@tailwindcss/forms';
 
 @custom-variant dark (&:where(.dark, .dark *));
 
@@ -10,7 +10,6 @@
 
 @import '@skeletonlabs/skeleton-svelte';
 
-
 /* custom definition of the color pairing, as the Skeleton theme doesn't seem to define them correctly (or possibly an incorrect setup int his project?) */
 * {
 	--text-scaling: 0.9;
@@ -20,157 +19,367 @@
 
 	/* Primary pairings */
 	--color-primary-50-950: light-dark(var(--color-primary-50), var(--color-primary-950));
-	--color-primary-contrast-50-950: light-dark(var(--color-primary-contrast-50), var(--color-primary-contrast-950));
+	--color-primary-contrast-50-950: light-dark(
+		var(--color-primary-contrast-50),
+		var(--color-primary-contrast-950)
+	);
 	--color-primary-100-900: light-dark(var(--color-primary-100), var(--color-primary-900));
-	--color-primary-contrast-100-900: light-dark(var(--color-primary-contrast-100), var(--color-primary-contrast-900));
+	--color-primary-contrast-100-900: light-dark(
+		var(--color-primary-contrast-100),
+		var(--color-primary-contrast-900)
+	);
 	--color-primary-200-800: light-dark(var(--color-primary-200), var(--color-primary-800));
-	--color-primary-contrast-200-800: light-dark(var(--color-primary-contrast-200), var(--color-primary-contrast-800));
+	--color-primary-contrast-200-800: light-dark(
+		var(--color-primary-contrast-200),
+		var(--color-primary-contrast-800)
+	);
 	--color-primary-300-700: light-dark(var(--color-primary-300), var(--color-primary-700));
-	--color-primary-contrast-300-700: light-dark(var(--color-primary-contrast-300), var(--color-primary-contrast-700));
+	--color-primary-contrast-300-700: light-dark(
+		var(--color-primary-contrast-300),
+		var(--color-primary-contrast-700)
+	);
 	--color-primary-400-600: light-dark(var(--color-primary-400), var(--color-primary-600));
-	--color-primary-contrast-400-600: light-dark(var(--color-primary-contrast-400), var(--color-primary-contrast-600));
+	--color-primary-contrast-400-600: light-dark(
+		var(--color-primary-contrast-400),
+		var(--color-primary-contrast-600)
+	);
 	--color-primary-600-400: light-dark(var(--color-primary-600), var(--color-primary-400));
-	--color-primary-contrast-600-400: light-dark(var(--color-primary-contrast-600), var(--color-primary-contrast-400));
+	--color-primary-contrast-600-400: light-dark(
+		var(--color-primary-contrast-600),
+		var(--color-primary-contrast-400)
+	);
 	--color-primary-700-300: light-dark(var(--color-primary-700), var(--color-primary-300));
-	--color-primary-contrast-700-300: light-dark(var(--color-primary-contrast-700), var(--color-primary-contrast-300));
+	--color-primary-contrast-700-300: light-dark(
+		var(--color-primary-contrast-700),
+		var(--color-primary-contrast-300)
+	);
 	--color-primary-800-200: light-dark(var(--color-primary-800), var(--color-primary-200));
-	--color-primary-contrast-800-200: light-dark(var(--color-primary-contrast-800), var(--color-primary-contrast-200));
+	--color-primary-contrast-800-200: light-dark(
+		var(--color-primary-contrast-800),
+		var(--color-primary-contrast-200)
+	);
 	--color-primary-900-100: light-dark(var(--color-primary-900), var(--color-primary-100));
-	--color-primary-contrast-900-100: light-dark(var(--color-primary-contrast-900), var(--color-primary-contrast-100));
+	--color-primary-contrast-900-100: light-dark(
+		var(--color-primary-contrast-900),
+		var(--color-primary-contrast-100)
+	);
 	--color-primary-950-50: light-dark(var(--color-primary-950), var(--color-primary-50));
-	--color-primary-contrast-950-50: light-dark(var(--color-primary-contrast-950), var(--color-primary-contrast-50));
+	--color-primary-contrast-950-50: light-dark(
+		var(--color-primary-contrast-950),
+		var(--color-primary-contrast-50)
+	);
 
 	/* Secondary pairings */
 	--color-secondary-50-950: light-dark(var(--color-secondary-50), var(--color-secondary-950));
-	--color-secondary-contrast-50-950: light-dark(var(--color-secondary-contrast-50), var(--color-secondary-contrast-950));
+	--color-secondary-contrast-50-950: light-dark(
+		var(--color-secondary-contrast-50),
+		var(--color-secondary-contrast-950)
+	);
 	--color-secondary-100-900: light-dark(var(--color-secondary-100), var(--color-secondary-900));
-	--color-secondary-contrast-100-900: light-dark(var(--color-secondary-contrast-100), var(--color-secondary-contrast-900));
+	--color-secondary-contrast-100-900: light-dark(
+		var(--color-secondary-contrast-100),
+		var(--color-secondary-contrast-900)
+	);
 	--color-secondary-200-800: light-dark(var(--color-secondary-200), var(--color-secondary-800));
-	--color-secondary-contrast-200-800: light-dark(var(--color-secondary-contrast-200), var(--color-secondary-contrast-800));
+	--color-secondary-contrast-200-800: light-dark(
+		var(--color-secondary-contrast-200),
+		var(--color-secondary-contrast-800)
+	);
 	--color-secondary-300-700: light-dark(var(--color-secondary-300), var(--color-secondary-700));
-	--color-secondary-contrast-300-700: light-dark(var(--color-secondary-contrast-300), var(--color-secondary-contrast-700));
+	--color-secondary-contrast-300-700: light-dark(
+		var(--color-secondary-contrast-300),
+		var(--color-secondary-contrast-700)
+	);
 	--color-secondary-400-600: light-dark(var(--color-secondary-400), var(--color-secondary-600));
-	--color-secondary-contrast-400-600: light-dark(var(--color-secondary-contrast-400), var(--color-secondary-contrast-600));
+	--color-secondary-contrast-400-600: light-dark(
+		var(--color-secondary-contrast-400),
+		var(--color-secondary-contrast-600)
+	);
 	--color-secondary-600-400: light-dark(var(--color-secondary-600), var(--color-secondary-400));
-	--color-secondary-contrast-600-400: light-dark(var(--color-secondary-contrast-600), var(--color-secondary-contrast-400));
+	--color-secondary-contrast-600-400: light-dark(
+		var(--color-secondary-contrast-600),
+		var(--color-secondary-contrast-400)
+	);
 	--color-secondary-700-300: light-dark(var(--color-secondary-700), var(--color-secondary-300));
-	--color-secondary-contrast-700-300: light-dark(var(--color-secondary-contrast-700), var(--color-secondary-contrast-300));
+	--color-secondary-contrast-700-300: light-dark(
+		var(--color-secondary-contrast-700),
+		var(--color-secondary-contrast-300)
+	);
 	--color-secondary-800-200: light-dark(var(--color-secondary-800), var(--color-secondary-200));
-	--color-secondary-contrast-800-200: light-dark(var(--color-secondary-contrast-800), var(--color-secondary-contrast-200));
+	--color-secondary-contrast-800-200: light-dark(
+		var(--color-secondary-contrast-800),
+		var(--color-secondary-contrast-200)
+	);
 	--color-secondary-900-100: light-dark(var(--color-secondary-900), var(--color-secondary-100));
-	--color-secondary-contrast-900-100: light-dark(var(--color-secondary-contrast-900), var(--color-secondary-contrast-100));
+	--color-secondary-contrast-900-100: light-dark(
+		var(--color-secondary-contrast-900),
+		var(--color-secondary-contrast-100)
+	);
 	--color-secondary-950-50: light-dark(var(--color-secondary-950), var(--color-secondary-50));
-	--color-secondary-contrast-950-50: light-dark(var(--color-secondary-contrast-950), var(--color-secondary-contrast-50));
+	--color-secondary-contrast-950-50: light-dark(
+		var(--color-secondary-contrast-950),
+		var(--color-secondary-contrast-50)
+	);
 
 	/* Tertiary pairings */
 	--color-tertiary-50-950: light-dark(var(--color-tertiary-50), var(--color-tertiary-950));
-	--color-tertiary-contrast-50-950: light-dark(var(--color-tertiary-contrast-50), var(--color-tertiary-contrast-950));
+	--color-tertiary-contrast-50-950: light-dark(
+		var(--color-tertiary-contrast-50),
+		var(--color-tertiary-contrast-950)
+	);
 	--color-tertiary-100-900: light-dark(var(--color-tertiary-100), var(--color-tertiary-900));
-	--color-tertiary-contrast-100-900: light-dark(var(--color-tertiary-contrast-100), var(--color-tertiary-contrast-900));
+	--color-tertiary-contrast-100-900: light-dark(
+		var(--color-tertiary-contrast-100),
+		var(--color-tertiary-contrast-900)
+	);
 	--color-tertiary-200-800: light-dark(var(--color-tertiary-200), var(--color-tertiary-800));
-	--color-tertiary-contrast-200-800: light-dark(var(--color-tertiary-contrast-200), var(--color-tertiary-contrast-800));
+	--color-tertiary-contrast-200-800: light-dark(
+		var(--color-tertiary-contrast-200),
+		var(--color-tertiary-contrast-800)
+	);
 	--color-tertiary-300-700: light-dark(var(--color-tertiary-300), var(--color-tertiary-700));
-	--color-tertiary-contrast-300-700: light-dark(var(--color-tertiary-contrast-300), var(--color-tertiary-contrast-700));
+	--color-tertiary-contrast-300-700: light-dark(
+		var(--color-tertiary-contrast-300),
+		var(--color-tertiary-contrast-700)
+	);
 	--color-tertiary-400-600: light-dark(var(--color-tertiary-400), var(--color-tertiary-600));
-	--color-tertiary-contrast-400-600: light-dark(var(--color-tertiary-contrast-400), var(--color-tertiary-contrast-600));
+	--color-tertiary-contrast-400-600: light-dark(
+		var(--color-tertiary-contrast-400),
+		var(--color-tertiary-contrast-600)
+	);
 	--color-tertiary-600-400: light-dark(var(--color-tertiary-600), var(--color-tertiary-400));
-	--color-tertiary-contrast-600-400: light-dark(var(--color-tertiary-contrast-600), var(--color-tertiary-contrast-400));
+	--color-tertiary-contrast-600-400: light-dark(
+		var(--color-tertiary-contrast-600),
+		var(--color-tertiary-contrast-400)
+	);
 	--color-tertiary-700-300: light-dark(var(--color-tertiary-700), var(--color-tertiary-300));
-	--color-tertiary-contrast-700-300: light-dark(var(--color-tertiary-contrast-700), var(--color-tertiary-contrast-300));
+	--color-tertiary-contrast-700-300: light-dark(
+		var(--color-tertiary-contrast-700),
+		var(--color-tertiary-contrast-300)
+	);
 	--color-tertiary-800-200: light-dark(var(--color-tertiary-800), var(--color-tertiary-200));
-	--color-tertiary-contrast-800-200: light-dark(var(--color-tertiary-contrast-800), var(--color-tertiary-contrast-200));
+	--color-tertiary-contrast-800-200: light-dark(
+		var(--color-tertiary-contrast-800),
+		var(--color-tertiary-contrast-200)
+	);
 	--color-tertiary-900-100: light-dark(var(--color-tertiary-900), var(--color-tertiary-100));
-	--color-tertiary-contrast-900-100: light-dark(var(--color-tertiary-contrast-900), var(--color-tertiary-contrast-100));
+	--color-tertiary-contrast-900-100: light-dark(
+		var(--color-tertiary-contrast-900),
+		var(--color-tertiary-contrast-100)
+	);
 	--color-tertiary-950-50: light-dark(var(--color-tertiary-950), var(--color-tertiary-50));
-	--color-tertiary-contrast-950-50: light-dark(var(--color-tertiary-contrast-950), var(--color-tertiary-contrast-50));
+	--color-tertiary-contrast-950-50: light-dark(
+		var(--color-tertiary-contrast-950),
+		var(--color-tertiary-contrast-50)
+	);
 
 	/* Success pairings */
 	--color-success-50-950: light-dark(var(--color-success-50), var(--color-success-950));
-	--color-success-contrast-50-950: light-dark(var(--color-success-contrast-50), var(--color-success-contrast-950));
+	--color-success-contrast-50-950: light-dark(
+		var(--color-success-contrast-50),
+		var(--color-success-contrast-950)
+	);
 	--color-success-100-900: light-dark(var(--color-success-100), var(--color-success-900));
-	--color-success-contrast-100-900: light-dark(var(--color-success-contrast-100), var(--color-success-contrast-900));
+	--color-success-contrast-100-900: light-dark(
+		var(--color-success-contrast-100),
+		var(--color-success-contrast-900)
+	);
 	--color-success-200-800: light-dark(var(--color-success-200), var(--color-success-800));
-	--color-success-contrast-200-800: light-dark(var(--color-success-contrast-200), var(--color-success-contrast-800));
+	--color-success-contrast-200-800: light-dark(
+		var(--color-success-contrast-200),
+		var(--color-success-contrast-800)
+	);
 	--color-success-300-700: light-dark(var(--color-success-300), var(--color-success-700));
-	--color-success-contrast-300-700: light-dark(var(--color-success-contrast-300), var(--color-success-contrast-700));
+	--color-success-contrast-300-700: light-dark(
+		var(--color-success-contrast-300),
+		var(--color-success-contrast-700)
+	);
 	--color-success-400-600: light-dark(var(--color-success-400), var(--color-success-600));
-	--color-success-contrast-400-600: light-dark(var(--color-success-contrast-400), var(--color-success-contrast-600));
+	--color-success-contrast-400-600: light-dark(
+		var(--color-success-contrast-400),
+		var(--color-success-contrast-600)
+	);
 	--color-success-600-400: light-dark(var(--color-success-600), var(--color-success-400));
-	--color-success-contrast-600-400: light-dark(var(--color-success-contrast-600), var(--color-success-contrast-400));
+	--color-success-contrast-600-400: light-dark(
+		var(--color-success-contrast-600),
+		var(--color-success-contrast-400)
+	);
 	--color-success-700-300: light-dark(var(--color-success-700), var(--color-success-300));
-	--color-success-contrast-700-300: light-dark(var(--color-success-contrast-700), var(--color-success-contrast-300));
+	--color-success-contrast-700-300: light-dark(
+		var(--color-success-contrast-700),
+		var(--color-success-contrast-300)
+	);
 	--color-success-800-200: light-dark(var(--color-success-800), var(--color-success-200));
-	--color-success-contrast-800-200: light-dark(var(--color-success-contrast-800), var(--color-success-contrast-200));
+	--color-success-contrast-800-200: light-dark(
+		var(--color-success-contrast-800),
+		var(--color-success-contrast-200)
+	);
 	--color-success-900-100: light-dark(var(--color-success-900), var(--color-success-100));
-	--color-success-contrast-900-100: light-dark(var(--color-success-contrast-900), var(--color-success-contrast-100));
+	--color-success-contrast-900-100: light-dark(
+		var(--color-success-contrast-900),
+		var(--color-success-contrast-100)
+	);
 	--color-success-950-50: light-dark(var(--color-success-950), var(--color-success-50));
-	--color-success-contrast-950-50: light-dark(var(--color-success-contrast-950), var(--color-success-contrast-50));
+	--color-success-contrast-950-50: light-dark(
+		var(--color-success-contrast-950),
+		var(--color-success-contrast-50)
+	);
 
 	/* Warning pairings */
 	--color-warning-50-950: light-dark(var(--color-warning-50), var(--color-warning-950));
-	--color-warning-contrast-50-950: light-dark(var(--color-warning-contrast-50), var(--color-warning-contrast-950));
+	--color-warning-contrast-50-950: light-dark(
+		var(--color-warning-contrast-50),
+		var(--color-warning-contrast-950)
+	);
 	--color-warning-100-900: light-dark(var(--color-warning-100), var(--color-warning-900));
-	--color-warning-contrast-100-900: light-dark(var(--color-warning-contrast-100), var(--color-warning-contrast-900));
+	--color-warning-contrast-100-900: light-dark(
+		var(--color-warning-contrast-100),
+		var(--color-warning-contrast-900)
+	);
 	--color-warning-200-800: light-dark(var(--color-warning-200), var(--color-warning-800));
-	--color-warning-contrast-200-800: light-dark(var(--color-warning-contrast-200), var(--color-warning-contrast-800));
+	--color-warning-contrast-200-800: light-dark(
+		var(--color-warning-contrast-200),
+		var(--color-warning-contrast-800)
+	);
 	--color-warning-300-700: light-dark(var(--color-warning-300), var(--color-warning-700));
-	--color-warning-contrast-300-700: light-dark(var(--color-warning-contrast-300), var(--color-warning-contrast-700));
+	--color-warning-contrast-300-700: light-dark(
+		var(--color-warning-contrast-300),
+		var(--color-warning-contrast-700)
+	);
 	--color-warning-400-600: light-dark(var(--color-warning-400), var(--color-warning-600));
-	--color-warning-contrast-400-600: light-dark(var(--color-warning-contrast-400), var(--color-warning-contrast-600));
+	--color-warning-contrast-400-600: light-dark(
+		var(--color-warning-contrast-400),
+		var(--color-warning-contrast-600)
+	);
 	--color-warning-600-400: light-dark(var(--color-warning-600), var(--color-warning-400));
-	--color-warning-contrast-600-400: light-dark(var(--color-warning-contrast-600), var(--color-warning-contrast-400));
+	--color-warning-contrast-600-400: light-dark(
+		var(--color-warning-contrast-600),
+		var(--color-warning-contrast-400)
+	);
 	--color-warning-700-300: light-dark(var(--color-warning-700), var(--color-warning-300));
-	--color-warning-contrast-700-300: light-dark(var(--color-warning-contrast-700), var(--color-warning-contrast-300));
+	--color-warning-contrast-700-300: light-dark(
+		var(--color-warning-contrast-700),
+		var(--color-warning-contrast-300)
+	);
 	--color-warning-800-200: light-dark(var(--color-warning-800), var(--color-warning-200));
-	--color-warning-contrast-800-200: light-dark(var(--color-warning-contrast-800), var(--color-warning-contrast-200));
+	--color-warning-contrast-800-200: light-dark(
+		var(--color-warning-contrast-800),
+		var(--color-warning-contrast-200)
+	);
 	--color-warning-900-100: light-dark(var(--color-warning-900), var(--color-warning-100));
-	--color-warning-contrast-900-100: light-dark(var(--color-warning-contrast-900), var(--color-warning-contrast-100));
+	--color-warning-contrast-900-100: light-dark(
+		var(--color-warning-contrast-900),
+		var(--color-warning-contrast-100)
+	);
 	--color-warning-950-50: light-dark(var(--color-warning-950), var(--color-warning-50));
-	--color-warning-contrast-950-50: light-dark(var(--color-warning-contrast-950), var(--color-warning-contrast-50));
+	--color-warning-contrast-950-50: light-dark(
+		var(--color-warning-contrast-950),
+		var(--color-warning-contrast-50)
+	);
 
 	/* Error pairings */
 	--color-error-50-950: light-dark(var(--color-error-50), var(--color-error-950));
-	--color-error-contrast-50-950: light-dark(var(--color-error-contrast-50), var(--color-error-contrast-950));
+	--color-error-contrast-50-950: light-dark(
+		var(--color-error-contrast-50),
+		var(--color-error-contrast-950)
+	);
 	--color-error-100-900: light-dark(var(--color-error-100), var(--color-error-900));
-	--color-error-contrast-100-900: light-dark(var(--color-error-contrast-100), var(--color-error-contrast-900));
+	--color-error-contrast-100-900: light-dark(
+		var(--color-error-contrast-100),
+		var(--color-error-contrast-900)
+	);
 	--color-error-200-800: light-dark(var(--color-error-200), var(--color-error-800));
-	--color-error-contrast-200-800: light-dark(var(--color-error-contrast-200), var(--color-error-contrast-800));
+	--color-error-contrast-200-800: light-dark(
+		var(--color-error-contrast-200),
+		var(--color-error-contrast-800)
+	);
 	--color-error-300-700: light-dark(var(--color-error-300), var(--color-error-700));
-	--color-error-contrast-300-700: light-dark(var(--color-error-contrast-300), var(--color-error-contrast-700));
+	--color-error-contrast-300-700: light-dark(
+		var(--color-error-contrast-300),
+		var(--color-error-contrast-700)
+	);
 	--color-error-400-600: light-dark(var(--color-error-400), var(--color-error-600));
-	--color-error-contrast-400-600: light-dark(var(--color-error-contrast-400), var(--color-error-contrast-600));
+	--color-error-contrast-400-600: light-dark(
+		var(--color-error-contrast-400),
+		var(--color-error-contrast-600)
+	);
 	--color-error-600-400: light-dark(var(--color-error-600), var(--color-error-400));
-	--color-error-contrast-600-400: light-dark(var(--color-error-contrast-600), var(--color-error-contrast-400));
+	--color-error-contrast-600-400: light-dark(
+		var(--color-error-contrast-600),
+		var(--color-error-contrast-400)
+	);
 	--color-error-700-300: light-dark(var(--color-error-700), var(--color-error-300));
-	--color-error-contrast-700-300: light-dark(var(--color-error-contrast-700), var(--color-error-contrast-300));
+	--color-error-contrast-700-300: light-dark(
+		var(--color-error-contrast-700),
+		var(--color-error-contrast-300)
+	);
 	--color-error-800-200: light-dark(var(--color-error-800), var(--color-error-200));
-	--color-error-contrast-800-200: light-dark(var(--color-error-contrast-800), var(--color-error-contrast-200));
+	--color-error-contrast-800-200: light-dark(
+		var(--color-error-contrast-800),
+		var(--color-error-contrast-200)
+	);
 	--color-error-900-100: light-dark(var(--color-error-900), var(--color-error-100));
-	--color-error-contrast-900-100: light-dark(var(--color-error-contrast-900), var(--color-error-contrast-100));
+	--color-error-contrast-900-100: light-dark(
+		var(--color-error-contrast-900),
+		var(--color-error-contrast-100)
+	);
 	--color-error-950-50: light-dark(var(--color-error-950), var(--color-error-50));
-	--color-error-contrast-950-50: light-dark(var(--color-error-contrast-950), var(--color-error-contrast-50));
+	--color-error-contrast-950-50: light-dark(
+		var(--color-error-contrast-950),
+		var(--color-error-contrast-50)
+	);
 
 	/* Surface pairings */
 	--color-surface-50-950: light-dark(var(--color-surface-50), var(--color-surface-950));
-	--color-surface-contrast-50-950: light-dark(var(--color-surface-contrast-50), var(--color-surface-contrast-950));
+	--color-surface-contrast-50-950: light-dark(
+		var(--color-surface-contrast-50),
+		var(--color-surface-contrast-950)
+	);
 	--color-surface-100-900: light-dark(var(--color-surface-100), var(--color-surface-900));
-	--color-surface-contrast-100-900: light-dark(var(--color-surface-contrast-100), var(--color-surface-contrast-900));
+	--color-surface-contrast-100-900: light-dark(
+		var(--color-surface-contrast-100),
+		var(--color-surface-contrast-900)
+	);
 	--color-surface-200-800: light-dark(var(--color-surface-200), var(--color-surface-800));
-	--color-surface-contrast-200-800: light-dark(var(--color-surface-contrast-200), var(--color-surface-contrast-800));
+	--color-surface-contrast-200-800: light-dark(
+		var(--color-surface-contrast-200),
+		var(--color-surface-contrast-800)
+	);
 	--color-surface-300-700: light-dark(var(--color-surface-300), var(--color-surface-700));
-	--color-surface-contrast-300-700: light-dark(var(--color-surface-contrast-300), var(--color-surface-contrast-700));
+	--color-surface-contrast-300-700: light-dark(
+		var(--color-surface-contrast-300),
+		var(--color-surface-contrast-700)
+	);
 	--color-surface-400-600: light-dark(var(--color-surface-400), var(--color-surface-600));
-	--color-surface-contrast-400-600: light-dark(var(--color-surface-contrast-400), var(--color-surface-contrast-600));
+	--color-surface-contrast-400-600: light-dark(
+		var(--color-surface-contrast-400),
+		var(--color-surface-contrast-600)
+	);
 	--color-surface-600-400: light-dark(var(--color-surface-600), var(--color-surface-400));
-	--color-surface-contrast-600-400: light-dark(var(--color-surface-contrast-600), var(--color-surface-contrast-400));
+	--color-surface-contrast-600-400: light-dark(
+		var(--color-surface-contrast-600),
+		var(--color-surface-contrast-400)
+	);
 	--color-surface-700-300: light-dark(var(--color-surface-700), var(--color-surface-300));
-	--color-surface-contrast-700-300: light-dark(var(--color-surface-contrast-700), var(--color-surface-contrast-300));
+	--color-surface-contrast-700-300: light-dark(
+		var(--color-surface-contrast-700),
+		var(--color-surface-contrast-300)
+	);
 	--color-surface-800-200: light-dark(var(--color-surface-800), var(--color-surface-200));
-	--color-surface-contrast-800-200: light-dark(var(--color-surface-contrast-800), var(--color-surface-contrast-200));
+	--color-surface-contrast-800-200: light-dark(
+		var(--color-surface-contrast-800),
+		var(--color-surface-contrast-200)
+	);
 	--color-surface-900-100: light-dark(var(--color-surface-900), var(--color-surface-100));
-	--color-surface-contrast-900-100: light-dark(var(--color-surface-contrast-900), var(--color-surface-contrast-100));
+	--color-surface-contrast-900-100: light-dark(
+		var(--color-surface-contrast-900),
+		var(--color-surface-contrast-100)
+	);
 	--color-surface-950-50: light-dark(var(--color-surface-950), var(--color-surface-50));
-	--color-surface-contrast-950-50: light-dark(var(--color-surface-contrast-950), var(--color-surface-contrast-50));
+	--color-surface-contrast-950-50: light-dark(
+		var(--color-surface-contrast-950),
+		var(--color-surface-contrast-50)
+	);
 
 	/* Typography sizes */
 	--text-xs: calc(0.75rem * var(--text-scaling));

--- a/frontend/src/app.html
+++ b/frontend/src/app.html
@@ -1,15 +1,15 @@
 <!doctype html>
 <html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		%sveltekit.head%
+	</head>
 
-<head>
-	<meta charset="utf-8" />
-	<link rel="icon" href="%sveltekit.assets%/favicon.png" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	%sveltekit.head%
-</head>
-
-<body data-sveltekit-preload-data="hover" data-theme="mona">
-	<div style="display: contents" class="h-full grid grid-rows-[auto-1fr] overflow-hidden">%sveltekit.body%</div>
-</body>
-
+	<body data-sveltekit-preload-data="hover" data-theme="mona">
+		<div style="display: contents" class="grid h-full grid-rows-[auto-1fr] overflow-hidden">
+			%sveltekit.body%
+		</div>
+	</body>
 </html>

--- a/frontend/src/lib/api/gen_types.ts
+++ b/frontend/src/lib/api/gen_types.ts
@@ -4,1699 +4,1699 @@
  */
 
 export interface paths {
-    "/api/graph": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get attack graph
-         * @description Returns the current attack graph with nodes and edges
-         */
-        get: operations["getGraph"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/campaign-state": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get campaign state
-         * @description Returns the current campaign state with entities and relations
-         */
-        get: operations["getCampaignState"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/kubetier": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get the offline KubeTier catalog
-         * @description Returns the bundled metadata snapshot or configured private/full local snapshot. This endpoint never fetches kubetier.com.
-         */
-        get: operations["getKubetierCatalog"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/armory": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get armory
-         * @description Returns all available TTPs (Tactics, Techniques, and Procedures). Optionally filter by tactic.
-         */
-        get: operations["getArmory"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/applicable-ttps": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get applicable TTPs for a target
-         * @description Returns TTPs that can be applied to the specified target. If targetId is omitted or empty, returns TTPs for all targets.
-         */
-        get: operations["getApplicableTTPs"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/eligible-auth-identities": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get eligible Kubernetes authentication identities
-         * @description Returns identities satisfying the action's authentication and RBAC requirements for the selected target.
-         */
-        get: operations["getEligibleAuthIdentities"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/recommendations": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Rank recommended next actions
-         * @description Returns applicable (TTP × target) actions ranked by utility for the current campaign state, using the default scoring profile. Advisory only - the caller decides what to execute. Each candidate includes a per-consideration breakdown for explainability.
-         */
-        get: operations["getRecommendations"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/scoring/profile": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get the live scoring profile
-         * @description Returns the current scoring profile - combination mode, the tuning feature flag, and every registered consideration's weight, response curve, and enabled/veto flags.
-         */
-        get: operations["getScoringProfile"];
-        /**
-         * Update the live scoring profile
-         * @description Replace the live scoring profile (runtime tuning). Gated on the scoring.tuning_ui feature flag; returns 403 when disabled.
-         */
-        put: operations["updateScoringProfile"];
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/scoring/profile/save": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Persist the live scoring profile
-         * @description Writes the live scoring profile to its sidecar file (ran.scoring.yaml) so it survives restarts. Gated on the scoring.tuning_ui flag.
-         */
-        post: operations["saveScoringProfile"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/scoring/profile/reset": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reset the live scoring profile
-         * @description Reverts the live scoring profile to the configured base and removes any persisted overrides. Gated on the scoring.tuning_ui flag.
-         */
-        post: operations["resetScoringProfile"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/scoring/calibrate": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Calibrate the scoring profile from captured operator decisions
-         * @description Fit consideration weights from the operator decisions captured during this and prior sessions, so the utility AI reproduces those choices under the same conditions. Returns the fitted profile as a *preview* (not applied) plus fit-quality metrics; apply it via PUT /api/scoring/profile. Gated on the scoring.tuning_ui flag. Returns 409 if no decisions have been captured yet.
-         */
-        post: operations["calibrateScoring"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/flow": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get campaign flow
-         * @description Returns Ran's campaign flow JSON with execution steps and causal edges
-         */
-        get: operations["getFlow"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/action/execute": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Execute action
-         * @description Execute a TTP action on a target. The action is queued and executed asynchronously, with final status sent via SSE. For the initial valid-accounts-kubeconfig action, targetId may identify an exact ready Pod returned by /api/pods/running that is not yet in campaign knowledge; Ran stages only that Pod before execution.
-         */
-        post: operations["executeAction"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/campaign/reset": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Reset campaign
-         * @description Reset the current campaign state
-         */
-        post: operations["resetCampaign"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/pods/running": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get running pods
-         * @description Returns list of running pods in the specified namespace
-         */
-        get: operations["getRunningPods"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/execution-records": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get execution records
-         * @description Returns all execution records for the current campaign session.
-         *     Each record includes the full raw stdout/stderr in `results`, resolved
-         *     arguments, timing, and the parse audits produced by each declared TTP
-         *     effect. Intended for use by Shuhari's Gap 2 scanner,
-         *     which cross-references raw stdout against declared effects to detect
-         *     undeclared structured output.
-         */
-        get: operations["getExecutionRecords"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/execution-records/{id}": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get execution record by ID
-         * @description Returns a single execution record by command ID, joined with its parse audits.
-         */
-        get: operations["getExecutionRecordById"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/files": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Get file content
-         * @description Returns the content of a previously read file
-         */
-        get: operations["getFileContent"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/plans/available": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * List available plans
-         * @description Lists pre-defined plans found in the configured plans directory (ran.yaml `plans.dir`, defaulting to `plans/`).
-         */
-        get: operations["listPlans"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/plans/load": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Load and execute a plan
-         * @description Reads a plan by file name from the configured plans directory and starts executing it. Returns the started plan's id.
-         */
-        post: operations["loadPlan"];
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
-    "/api/plans/export": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        /**
-         * Export the execution history as a plan
-         * @description Builds a reusable plan YAML from completed campaign actions, in execution order. Cleanup actions are omitted.
-         */
-        get: operations["exportPlan"];
-        put?: never;
-        post?: never;
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+	'/api/graph': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get attack graph
+		 * @description Returns the current attack graph with nodes and edges
+		 */
+		get: operations['getGraph'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/campaign-state': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get campaign state
+		 * @description Returns the current campaign state with entities and relations
+		 */
+		get: operations['getCampaignState'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/kubetier': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get the offline KubeTier catalog
+		 * @description Returns the bundled metadata snapshot or configured private/full local snapshot. This endpoint never fetches kubetier.com.
+		 */
+		get: operations['getKubetierCatalog'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/armory': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get armory
+		 * @description Returns all available TTPs (Tactics, Techniques, and Procedures). Optionally filter by tactic.
+		 */
+		get: operations['getArmory'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/applicable-ttps': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get applicable TTPs for a target
+		 * @description Returns TTPs that can be applied to the specified target. If targetId is omitted or empty, returns TTPs for all targets.
+		 */
+		get: operations['getApplicableTTPs'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/eligible-auth-identities': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get eligible Kubernetes authentication identities
+		 * @description Returns identities satisfying the action's authentication and RBAC requirements for the selected target.
+		 */
+		get: operations['getEligibleAuthIdentities'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/recommendations': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Rank recommended next actions
+		 * @description Returns applicable (TTP × target) actions ranked by utility for the current campaign state, using the default scoring profile. Advisory only - the caller decides what to execute. Each candidate includes a per-consideration breakdown for explainability.
+		 */
+		get: operations['getRecommendations'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/scoring/profile': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get the live scoring profile
+		 * @description Returns the current scoring profile - combination mode, the tuning feature flag, and every registered consideration's weight, response curve, and enabled/veto flags.
+		 */
+		get: operations['getScoringProfile'];
+		/**
+		 * Update the live scoring profile
+		 * @description Replace the live scoring profile (runtime tuning). Gated on the scoring.tuning_ui feature flag; returns 403 when disabled.
+		 */
+		put: operations['updateScoringProfile'];
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/scoring/profile/save': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Persist the live scoring profile
+		 * @description Writes the live scoring profile to its sidecar file (ran.scoring.yaml) so it survives restarts. Gated on the scoring.tuning_ui flag.
+		 */
+		post: operations['saveScoringProfile'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/scoring/profile/reset': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Reset the live scoring profile
+		 * @description Reverts the live scoring profile to the configured base and removes any persisted overrides. Gated on the scoring.tuning_ui flag.
+		 */
+		post: operations['resetScoringProfile'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/scoring/calibrate': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Calibrate the scoring profile from captured operator decisions
+		 * @description Fit consideration weights from the operator decisions captured during this and prior sessions, so the utility AI reproduces those choices under the same conditions. Returns the fitted profile as a *preview* (not applied) plus fit-quality metrics; apply it via PUT /api/scoring/profile. Gated on the scoring.tuning_ui flag. Returns 409 if no decisions have been captured yet.
+		 */
+		post: operations['calibrateScoring'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/flow': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get campaign flow
+		 * @description Returns Ran's campaign flow JSON with execution steps and causal edges
+		 */
+		get: operations['getFlow'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/action/execute': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Execute action
+		 * @description Execute a TTP action on a target. The action is queued and executed asynchronously, with final status sent via SSE. For the initial valid-accounts-kubeconfig action, targetId may identify an exact ready Pod returned by /api/pods/running that is not yet in campaign knowledge; Ran stages only that Pod before execution.
+		 */
+		post: operations['executeAction'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/campaign/reset': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Reset campaign
+		 * @description Reset the current campaign state
+		 */
+		post: operations['resetCampaign'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/pods/running': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get running pods
+		 * @description Returns list of running pods in the specified namespace
+		 */
+		get: operations['getRunningPods'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/execution-records': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get execution records
+		 * @description Returns all execution records for the current campaign session.
+		 *     Each record includes the full raw stdout/stderr in `results`, resolved
+		 *     arguments, timing, and the parse audits produced by each declared TTP
+		 *     effect. Intended for use by Shuhari's Gap 2 scanner,
+		 *     which cross-references raw stdout against declared effects to detect
+		 *     undeclared structured output.
+		 */
+		get: operations['getExecutionRecords'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/execution-records/{id}': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get execution record by ID
+		 * @description Returns a single execution record by command ID, joined with its parse audits.
+		 */
+		get: operations['getExecutionRecordById'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/files': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Get file content
+		 * @description Returns the content of a previously read file
+		 */
+		get: operations['getFileContent'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/plans/available': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * List available plans
+		 * @description Lists pre-defined plans found in the configured plans directory (ran.yaml `plans.dir`, defaulting to `plans/`).
+		 */
+		get: operations['listPlans'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/plans/load': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Load and execute a plan
+		 * @description Reads a plan by file name from the configured plans directory and starts executing it. Returns the started plan's id.
+		 */
+		post: operations['loadPlan'];
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
+	'/api/plans/export': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		/**
+		 * Export the execution history as a plan
+		 * @description Builds a reusable plan YAML from completed campaign actions, in execution order. Cleanup actions are omitted.
+		 */
+		get: operations['exportPlan'];
+		put?: never;
+		post?: never;
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 }
 export interface webhooks {
-    "armory-loaded": {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        get?: never;
-        put?: never;
-        /**
-         * Armory loaded webhook
-         * @description Triggered when the armory is successfully loaded
-         */
-        post: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody: {
-                content: {
-                    "application/json": {
-                        /** Format: date-time */
-                        timestamp?: string;
-                    };
-                };
-            };
-            responses: {
-                /** @description Webhook received successfully */
-                200: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-                /** @description Invalid webhook payload */
-                400: {
-                    headers: {
-                        [name: string]: unknown;
-                    };
-                    content?: never;
-                };
-            };
-        };
-        delete?: never;
-        options?: never;
-        head?: never;
-        patch?: never;
-        trace?: never;
-    };
+	'armory-loaded': {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		get?: never;
+		put?: never;
+		/**
+		 * Armory loaded webhook
+		 * @description Triggered when the armory is successfully loaded
+		 */
+		post: {
+			parameters: {
+				query?: never;
+				header?: never;
+				path?: never;
+				cookie?: never;
+			};
+			requestBody: {
+				content: {
+					'application/json': {
+						/** Format: date-time */
+						timestamp?: string;
+					};
+				};
+			};
+			responses: {
+				/** @description Webhook received successfully */
+				200: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content?: never;
+				};
+				/** @description Invalid webhook payload */
+				400: {
+					headers: {
+						[name: string]: unknown;
+					};
+					content?: never;
+				};
+			};
+		};
+		delete?: never;
+		options?: never;
+		head?: never;
+		patch?: never;
+		trace?: never;
+	};
 }
 export interface components {
-    schemas: {
-        PlanSummary: {
-            /** @description File name within the plans directory (pass to /api/plans/load) */
-            filename: string;
-            id: string;
-            name: string;
-            description?: string | null;
-            /** @description Number of steps in the plan */
-            steps: number;
-        };
-        LoadPlanRequest: {
-            /** @description File name of the plan within the configured plans directory */
-            filename: string;
-        };
-        Graph: {
-            nodes: components["schemas"]["Node"][];
-            edges: components["schemas"]["Edge"][];
-            rootNodeId: string;
-        };
-        Node: {
-            id: string;
-            name: string;
-            kind: string;
-            parent?: string;
-            accessLevel?: string;
-            entityId: string;
-            entity?: {
-                [key: string]: unknown;
-            };
-            compromised?: boolean;
-            isRunning?: boolean;
-            provenance?: ("scenario" | "operator" | "action" | "inference")[];
-        };
-        Edge: {
-            id: string;
-            name: string;
-            /** Format: float */
-            weight?: number;
-            relation?: {
-                [key: string]: unknown;
-            };
-            sourceId: string;
-            targetId: string;
-            /** @description Backend ID of the active persistent session on this exec-channel edge, if any. */
-            sessionId?: string;
-            /** @description True when the session backing this exec-channel edge has died. The edge is kept (rendered as broken) and is non-traversable until a session reconnects and recovers it. */
-            broken?: boolean;
-            provenance?: ("scenario" | "operator" | "action" | "inference")[];
-        };
-        CampaignState: {
-            entities: {
-                [key: string]: Record<string, never>;
-            };
-            relations: {
-                [key: string]: unknown;
-            }[];
-            bootstrapOperations?: components["schemas"]["BootstrapOperation"][];
-        };
-        BootstrapOperation: {
-            id: string;
-            name: string;
-            detail: string;
-            effects: components["schemas"]["BootstrapEffect"][];
-        };
-        BootstrapEffect: {
-            entityId: string;
-            entityName: string;
-            entityKind: string;
-            /** @enum {string} */
-            category: "credential" | "discovery";
-        };
-        /** @description Ran's internal campaign-flow representation. This is not MITRE Attack Flow/STIX. */
-        AttackFlow: {
-            steps: components["schemas"]["AttackStep"][];
-            edges: components["schemas"]["FlowEdge"][];
-        };
-        FlowEdge: {
-            id: string;
-            sourceId: string;
-            targetId: string;
-        };
-        AttackStep: {
-            id: string;
-            targetId: string;
-            command: string;
-            /** @description Per-hop breakdown of a multi-system command traversal, ordered from the C2 entry point (outermost envelope) to the final target (innermost). Empty for direct/single-hop commands. */
-            traversal: components["schemas"]["TraversalHop"][];
-            /** @description The bare inner command as it runs on the final target system, before any hop envelopes wrap it. Empty when there is no multi-hop traversal. */
-            innerCommand: string;
-            /** @description Short, human-readable explanation of why this execution route was chosen (e.g. a live session vs. a multi-hop path), including a note when a broken session edge to the target was skipped. Empty for direct/local commands with no joined traversal. */
-            routeReason?: string;
-            args: {
-                [key: string]: string;
-            };
-            procedureId: string;
-            TTP: components["schemas"]["AttackStepTTP"];
-            results: string[];
-            /** Format: date-time */
-            startedAt: string;
-            /** @description Completion timestamp in RFC 3339 format, or an empty string while ongoing */
-            completedAt: string;
-            executedOn: string;
-            /** @enum {string} */
-            status: "Unknown" | "Failed" | "Success" | "Ongoing";
-            success: boolean;
-        };
-        AttackStepTTP: {
-            id: string;
-            name: string;
-            description: string;
-            tactic: string;
-            techniques: string[];
-        };
-        /** @description One segment of a multi-hop command traversal: the command as it is handed from `fromId` to `toId`, and the envelope template applied at this layer. */
-        TraversalHop: {
-            /** @description Entity executing this segment; the C2 backend id for the first hop. */
-            fromId: string;
-            /** @description Entity reached by this segment. */
-            toId: string;
-            /** @description Relation/channel name driving this hop (e.g. `kubelet-exec`, `rce.can-exec`, `kubectl-exec`, or `builtin-exec` for the C2 entry). */
-            relation: string;
-            /** @description The command-wrapping template with `${CMD}` placeholder applied at this hop. Absent for the C2 entry hop and pass-through segments. */
-            envelope?: string;
-            /** @description The full command string sent across this segment - what `fromId` runs. */
-            command: string;
-        };
-        TTP: {
-            id: string;
-            name: string;
-            description: string;
-            tactic: string;
-            techniques: string[];
-            status: components["schemas"]["TTPStatus"];
-            params: components["schemas"]["TTPParam"][];
-            requires: components["schemas"]["Requirements"];
-            effects?: string[];
-            procedures: components["schemas"]["Procedure"][];
-        };
-        Procedure: {
-            id: string;
-            command: string;
-            tool?: string;
-            isLocalCommand?: boolean;
-        };
-        TTPParam: {
-            name: string;
-            type: string;
-            description: string;
-            required: boolean;
-            default: string;
-        };
-        TTPDefense: {
-            id: string;
-            name: string;
-            url?: string;
-            description?: string;
-            sigma?: components["schemas"]["SigmaRule"];
-            d3efend?: string;
-        };
-        SigmaRule: {
-            title: string;
-            id?: string;
-            description?: string;
-            status?: string;
-            logsource: {
-                [key: string]: unknown;
-            };
-            detection: {
-                [key: string]: unknown;
-            };
-            tags: string[];
-            references?: string[];
-            /** Format: date-time */
-            date: string;
-        };
-        ExecuteActionCmd: {
-            actionId: string;
-            execSystemId?: string;
-            /** @description Entity ID selected through the TTP's K8S_AUTH parameter. Required for Kubernetes procedures and must identify an eligible captured ServiceAccount or the active K8sCredential. */
-            authIdentityId?: string;
-            targetId: string;
-            procedureId?: string;
-            args?: {
-                [key: string]: string;
-            };
-            /**
-             * Format: int64
-             * @description Maximum wall-clock time allowed for the complete command.
-             * @default 60
-             */
-            executionTimeoutSeconds: number;
-            /** @description Free-text rationale for choosing this action at this point in the assessment - why this TTP against this target now. Optional, but strongly encouraged when driving the campaign programmatically: it is stored on the resulting execution record so the timeline is self-explaining and auditable. */
-            reasoning?: string;
-        };
-        AuthIdentity: {
-            id: string;
-            name: string;
-            kind: string;
-        };
-        K8sResource: {
-            id: string;
-            name: string;
-            namespace?: string;
-            kind: string;
-            /** @description Pod phase (Running, Pending, Succeeded, Failed, Unknown) */
-            phase?: string;
-            /** @description Whether all containers in the pod are ready */
-            ready?: boolean;
-            /** @description Container-level state reason (e.g. CrashLoopBackOff, ImagePullBackOff) */
-            stateReason?: string;
-        };
-        Requirements: {
-            kind?: string;
-            rbacPermissions?: components["schemas"]["RBACPermission"][];
-            accessLevel?: string;
-            activeSession?: boolean;
-            exists?: string[];
-        };
-        RBACPermission: {
-            resource: string;
-            resourceName: string;
-            resourceType: string;
-            apiGroup: string;
-            verb: string;
-            scope: string;
-            sourceRole: string;
-            /** @default true */
-            isNamespaced: boolean;
-            /** @enum {string} */
-            scopeKind?: "cluster" | "namespace" | "unknown";
-            evaluatedNamespace?: string;
-            /** @enum {string} */
-            scopeSource?: "binding" | "role" | "ssrr";
-            kubetier?: components["schemas"]["KubetierPermissionAssessment"];
-        };
-        KubetierPermissionAssessment: {
-            /** @enum {string} */
-            provider: "kubetier";
-            tierMin?: components["schemas"]["KubetierTier"];
-            tierMax?: components["schemas"]["KubetierTier"];
-            unassessed?: boolean;
-            scopeUnverified: boolean;
-            matches: components["schemas"]["KubetierPermission"][];
-        };
-        /** @enum {string} */
-        KubetierTier: "T0" | "T1" | "T2" | "T3";
-        /** @enum {string} */
-        KubetierScope: "cluster" | "namespaced";
-        KubetierEscalationPath: {
-            name: string;
-            tier: components["schemas"]["KubetierTier"];
-            sourceUrl: string;
-            steps: string[];
-        };
-        KubetierPermission: {
-            id: string;
-            verb: string;
-            resource: string;
-            apiGroup: string;
-            scope: components["schemas"]["KubetierScope"];
-            tier: components["schemas"]["KubetierTier"];
-            escalationCount: number;
-            sourceUrl: string;
-            kubernetesDocUrl?: string;
-            description?: string;
-            escalationPaths: components["schemas"]["KubetierEscalationPath"][];
-        };
-        KubetierRoleRule: {
-            apiGroups: string[];
-            resources: string[];
-            nonResourceUrls: string[];
-            verbs: string[];
-        };
-        KubetierRole: {
-            id: string;
-            name: string;
-            scope: components["schemas"]["KubetierScope"];
-            tier: components["schemas"]["KubetierTier"];
-            sourceUrl: string;
-            kubernetesDocUrl?: string;
-            description?: string;
-            notes: string[];
-            rules: components["schemas"]["KubetierRoleRule"][];
-        };
-        KubetierCatalog: {
-            schemaVersion: number;
-            attribution: string;
-            sourceUrl: string;
-            fetchedAt: string;
-            sourceEtag?: string;
-            sourceSha256: string;
-            validatedKubernetesVersion?: string;
-            full: boolean;
-            permissions: components["schemas"]["KubetierPermission"][];
-            roles: components["schemas"]["KubetierRole"][];
-        };
-        /**
-         * @description A completed TTP execution joined with the parse audits produced by its
-         *     declared effects. The record fields are flattened at the top level;
-         *     `parseAudits` is the list of per-effect audit entries.
-         */
-        ExecutionRecordEntry: {
-            /** @description Unique command ID, correlates with SSE `ttp-executed` and `parse-audited` events */
-            id: string;
-            ttp_id: string;
-            ttp_name: string;
-            tactic: string;
-            target_id: string;
-            /** @description ID of the system that ran the command; empty for direct builtin exec */
-            exec_system_id: string;
-            /** @description ID of the Kubernetes authentication identity selected for the action */
-            auth_identity_id?: string;
-            procedure_id: string;
-            /** @description Fully grounded command string sent to the C2 backend */
-            command: string;
-            /** @description Resolved arguments after default-filling and template substitution */
-            args: {
-                [key: string]: string;
-            };
-            success: boolean;
-            exit_code: number;
-            /** @description Raw output lines - first element is stdout, second (if present) is stderr */
-            results: string[];
-            fail_reason: string;
-            /**
-             * Format: int64
-             * @description Unix timestamp in milliseconds when the command was dispatched
-             */
-            started_at_ms: number;
-            /**
-             * Format: int64
-             * @description Unix timestamp in milliseconds when the result was received
-             */
-            completed_at_ms: number;
-            /** @description Entities produced by this execution, retained for operation timeline replay */
-            discovered_entities: components["schemas"]["ExecutionEntity"][];
-            /** @description Caller-supplied rationale for why this action was run, as passed to the execute-action request. Empty when none was given. */
-            reasoning?: string;
-            parseAudits: components["schemas"]["ParseAudit"][];
-        };
-        ExecutionEntity: {
-            id: string;
-            name: string;
-            kind: string;
-            /**
-             * @description What the execution did to this entity. `observed` means the campaign learned of it for the first time; `created` means the action brought it into existence (a deployed pod, a bound listener); `updated` means it was already known and this run only refined its fields. Only `observed` is a discovery — consumers must not report the other two as one. Absent on records written before outcomes were tracked.
-             * @default observed
-             * @enum {string}
-             */
-            outcome: "observed" | "created" | "updated";
-            /**
-             * @description What sort of news this fact is. Independent of `outcome`: gaining exec access to a host the campaign already knew is `access-gained` with an outcome of `updated`, and is still worth showing. Decided by the producer, so clients must not re-derive it from `kind`.
-             * @default discovery
-             * @enum {string}
-             */
-            category: "discovery" | "credential" | "access-gained";
-        };
-        /**
-         * @description Audit record for a single effect parse attempt. `parse_result` indicates
-         *     whether the effect was parsed successfully; `NoParser` and `UnknownFormat`
-         *     are the two signals used by Shuhari's Gap 1 classifier.
-         */
-        ParseAudit: {
-            /** @description Command ID of the execution that produced this audit */
-            cmd_id: string;
-            /** @description Effect identifier as declared in the TTP (e.g. `sys.envvar`, `k8s.podlist`) */
-            effect_id: string;
-            ttp_id: string;
-            target_id: string;
-            parser_version: string;
-            /** @description SHA-256 of the raw stdout+stderr, for deduplication across episodes */
-            raw_output_hash: string;
-            /** @description First 1024 characters of combined stdout+stderr */
-            raw_output_preview: string;
-            /**
-             * @description - `Parsed`: effect was handled and facts were written to the campaign
-             *     - `KnownFailure`: effect ran but produced expected-empty output (e.g. command not found)
-             *     - `UnknownFormat`: output was present but the parser could not interpret it
-             *     - `NoParser`: no compiled or external parser is registered for this effect (Gap 1 signal)
-             *     - `ParserBug`: parser crashed or panicked
-             * @enum {string}
-             */
-            parse_result: "Parsed" | "KnownFailure" | "UnknownFormat" | "NoParser" | "ParserBug";
-            /** @description Human-readable explanation of the parse outcome */
-            detail: string;
-            /** @description Number of new entities or field updates written to the campaign graph */
-            inferred_facts_written: number;
-        };
-        Error: {
-            error: string;
-            details?: string;
-        };
-        /** @description One consideration's contribution to a candidate's score. */
-        ConsiderationScore: {
-            /** @description Consideration identifier (e.g. "privilege_gain"). */
-            name: string;
-            /**
-             * @description Whether this consideration contributes to utility or belief state.
-             * @enum {string}
-             */
-            kind: "utility" | "belief";
-            /**
-             * Format: float
-             * @description Raw measurement in [0, 1].
-             */
-            raw: number;
-            /**
-             * Format: float
-             * @description Measurement after the profile's response curve.
-             */
-            curved: number;
-            /**
-             * Format: float
-             * @description Weight applied from the profile.
-             */
-            weight: number;
-            /** @description Whether this consideration acted as a multiplicative veto. */
-            veto: boolean;
-        };
-        /** @description A scored, grounded (TTP × target) action. */
-        ScoredCandidate: {
-            ttp_id: string;
-            target_id: string;
-            /**
-             * Format: float
-             * @description Final ranking score in [0, 1], equal to utility_score × success_probability.
-             */
-            utility: number;
-            /**
-             * Format: float
-             * @description Intrinsic desirability of the action if it succeeds.
-             */
-            utility_score: number;
-            /**
-             * Format: float
-             * @description Belief-state probability that the action can be grounded and succeed.
-             */
-            success_probability: number;
-            breakdown: components["schemas"]["ConsiderationScore"][];
-        };
-        /**
-         * @description How per-consideration scores are combined into one utility.
-         * @enum {string}
-         */
-        CombinationMode: "weighted_arithmetic" | "weighted_geometric" | "iaus_multiplicative";
-        /** @description A response curve mapping a raw measurement in [0,1] to a tuned score in [0,1], internally tagged by `type`. Only the fields for the active type are meaningful (linear: slope/intercept; polynomial: exponent/slope/ intercept; logistic: steepness/midpoint; step: threshold). */
-        ResponseCurve: {
-            /** @enum {string} */
-            type: "linear" | "polynomial" | "logistic" | "step";
-            /** Format: float */
-            slope?: number;
-            /** Format: float */
-            intercept?: number;
-            /** Format: float */
-            exponent?: number;
-            /** Format: float */
-            steepness?: number;
-            /** Format: float */
-            midpoint?: number;
-            /** Format: float */
-            threshold?: number;
-        };
-        /** @description A consideration's tunable config, tagged with its name. */
-        NamedConsideration: {
-            name: string;
-            /** Format: float */
-            weight: number;
-            curve: components["schemas"]["ResponseCurve"];
-            enabled: boolean;
-            veto: boolean;
-        };
-        /** @description The live scoring profile. */
-        ScoringProfile: {
-            /** @description Whether utility-AI recommendations and action scoring are enabled. */
-            enabled: boolean;
-            combination: components["schemas"]["CombinationMode"];
-            /** @description Whether scoring and the tuning UI feature flag are both enabled. */
-            tuningEnabled: boolean;
-            considerations: components["schemas"]["NamedConsideration"][];
-        };
-        /** @description A scoring-profile update (runtime tuning). */
-        ScoringProfileUpdate: {
-            combination: components["schemas"]["CombinationMode"];
-            considerations: components["schemas"]["NamedConsideration"][];
-        };
-        /** @description Fit-quality metrics from a calibration run. */
-        CalibrationMetrics: {
-            /** @description Number of captured decisions the fit used. */
-            decisions: number;
-            /**
-             * Format: float
-             * @description Fraction of decisions where the operator's choice ranks first.
-             */
-            top1Accuracy: number;
-            /**
-             * Format: float
-             * @description Mean probability the fitted model assigns the operator's choices.
-             */
-            meanChosenProb: number;
-            /**
-             * Format: float
-             * @description Worst per-decision probability assigned to an operator choice.
-             */
-            minChosenProb: number;
-            /** Format: float */
-            logLikelihood: number;
-            /** @description Decisions whose choice is Pareto-dominated - unreproducible by any non-negative weighting, signalling a missing consideration. */
-            infeasible: number;
-            converged: boolean;
-        };
-        /** @description A calibration preview - the fitted profile plus fit metrics. */
-        CalibrationResult: {
-            profile: components["schemas"]["ScoringProfile"];
-            metrics: components["schemas"]["CalibrationMetrics"];
-        };
-        /** @description Reference to the Kubernetes owner of a resource (e.g. ReplicaSet → Pod). */
-        OwnerRef: {
-            name: string;
-            kind: string;
-            uid: string;
-        };
-        /** @description A volume mount on a pod - either a projected volume or a host-path bind mount. */
-        VolumeMount: {
-            name: string;
-            /** @description Path inside the container where the volume appears. */
-            mount_point: string;
-            /** @description Path on the host that is bound (for hostPath mounts). */
-            mount_root: string;
-            mount_type?: string;
-            read_only: boolean;
-            is_host_path: boolean;
-        };
-        /**
-         * @description Status of a TTP - whether it is enabled or disabled
-         * @enum {string}
-         */
-        TTPStatus: "enabled" | "disabled";
-    };
-    responses: never;
-    parameters: never;
-    requestBodies: never;
-    headers: never;
-    pathItems: never;
+	schemas: {
+		PlanSummary: {
+			/** @description File name within the plans directory (pass to /api/plans/load) */
+			filename: string;
+			id: string;
+			name: string;
+			description?: string | null;
+			/** @description Number of steps in the plan */
+			steps: number;
+		};
+		LoadPlanRequest: {
+			/** @description File name of the plan within the configured plans directory */
+			filename: string;
+		};
+		Graph: {
+			nodes: components['schemas']['Node'][];
+			edges: components['schemas']['Edge'][];
+			rootNodeId: string;
+		};
+		Node: {
+			id: string;
+			name: string;
+			kind: string;
+			parent?: string;
+			accessLevel?: string;
+			entityId: string;
+			entity?: {
+				[key: string]: unknown;
+			};
+			compromised?: boolean;
+			isRunning?: boolean;
+			provenance?: ('scenario' | 'operator' | 'action' | 'inference')[];
+		};
+		Edge: {
+			id: string;
+			name: string;
+			/** Format: float */
+			weight?: number;
+			relation?: {
+				[key: string]: unknown;
+			};
+			sourceId: string;
+			targetId: string;
+			/** @description Backend ID of the active persistent session on this exec-channel edge, if any. */
+			sessionId?: string;
+			/** @description True when the session backing this exec-channel edge has died. The edge is kept (rendered as broken) and is non-traversable until a session reconnects and recovers it. */
+			broken?: boolean;
+			provenance?: ('scenario' | 'operator' | 'action' | 'inference')[];
+		};
+		CampaignState: {
+			entities: {
+				[key: string]: Record<string, never>;
+			};
+			relations: {
+				[key: string]: unknown;
+			}[];
+			bootstrapOperations?: components['schemas']['BootstrapOperation'][];
+		};
+		BootstrapOperation: {
+			id: string;
+			name: string;
+			detail: string;
+			effects: components['schemas']['BootstrapEffect'][];
+		};
+		BootstrapEffect: {
+			entityId: string;
+			entityName: string;
+			entityKind: string;
+			/** @enum {string} */
+			category: 'credential' | 'discovery';
+		};
+		/** @description Ran's internal campaign-flow representation. This is not MITRE Attack Flow/STIX. */
+		AttackFlow: {
+			steps: components['schemas']['AttackStep'][];
+			edges: components['schemas']['FlowEdge'][];
+		};
+		FlowEdge: {
+			id: string;
+			sourceId: string;
+			targetId: string;
+		};
+		AttackStep: {
+			id: string;
+			targetId: string;
+			command: string;
+			/** @description Per-hop breakdown of a multi-system command traversal, ordered from the C2 entry point (outermost envelope) to the final target (innermost). Empty for direct/single-hop commands. */
+			traversal: components['schemas']['TraversalHop'][];
+			/** @description The bare inner command as it runs on the final target system, before any hop envelopes wrap it. Empty when there is no multi-hop traversal. */
+			innerCommand: string;
+			/** @description Short, human-readable explanation of why this execution route was chosen (e.g. a live session vs. a multi-hop path), including a note when a broken session edge to the target was skipped. Empty for direct/local commands with no joined traversal. */
+			routeReason?: string;
+			args: {
+				[key: string]: string;
+			};
+			procedureId: string;
+			TTP: components['schemas']['AttackStepTTP'];
+			results: string[];
+			/** Format: date-time */
+			startedAt: string;
+			/** @description Completion timestamp in RFC 3339 format, or an empty string while ongoing */
+			completedAt: string;
+			executedOn: string;
+			/** @enum {string} */
+			status: 'Unknown' | 'Failed' | 'Success' | 'Ongoing';
+			success: boolean;
+		};
+		AttackStepTTP: {
+			id: string;
+			name: string;
+			description: string;
+			tactic: string;
+			techniques: string[];
+		};
+		/** @description One segment of a multi-hop command traversal: the command as it is handed from `fromId` to `toId`, and the envelope template applied at this layer. */
+		TraversalHop: {
+			/** @description Entity executing this segment; the C2 backend id for the first hop. */
+			fromId: string;
+			/** @description Entity reached by this segment. */
+			toId: string;
+			/** @description Relation/channel name driving this hop (e.g. `kubelet-exec`, `rce.can-exec`, `kubectl-exec`, or `builtin-exec` for the C2 entry). */
+			relation: string;
+			/** @description The command-wrapping template with `${CMD}` placeholder applied at this hop. Absent for the C2 entry hop and pass-through segments. */
+			envelope?: string;
+			/** @description The full command string sent across this segment - what `fromId` runs. */
+			command: string;
+		};
+		TTP: {
+			id: string;
+			name: string;
+			description: string;
+			tactic: string;
+			techniques: string[];
+			status: components['schemas']['TTPStatus'];
+			params: components['schemas']['TTPParam'][];
+			requires: components['schemas']['Requirements'];
+			effects?: string[];
+			procedures: components['schemas']['Procedure'][];
+		};
+		Procedure: {
+			id: string;
+			command: string;
+			tool?: string;
+			isLocalCommand?: boolean;
+		};
+		TTPParam: {
+			name: string;
+			type: string;
+			description: string;
+			required: boolean;
+			default: string;
+		};
+		TTPDefense: {
+			id: string;
+			name: string;
+			url?: string;
+			description?: string;
+			sigma?: components['schemas']['SigmaRule'];
+			d3efend?: string;
+		};
+		SigmaRule: {
+			title: string;
+			id?: string;
+			description?: string;
+			status?: string;
+			logsource: {
+				[key: string]: unknown;
+			};
+			detection: {
+				[key: string]: unknown;
+			};
+			tags: string[];
+			references?: string[];
+			/** Format: date-time */
+			date: string;
+		};
+		ExecuteActionCmd: {
+			actionId: string;
+			execSystemId?: string;
+			/** @description Entity ID selected through the TTP's K8S_AUTH parameter. Required for Kubernetes procedures and must identify an eligible captured ServiceAccount or the active K8sCredential. */
+			authIdentityId?: string;
+			targetId: string;
+			procedureId?: string;
+			args?: {
+				[key: string]: string;
+			};
+			/**
+			 * Format: int64
+			 * @description Maximum wall-clock time allowed for the complete command.
+			 * @default 60
+			 */
+			executionTimeoutSeconds: number;
+			/** @description Free-text rationale for choosing this action at this point in the assessment - why this TTP against this target now. Optional, but strongly encouraged when driving the campaign programmatically: it is stored on the resulting execution record so the timeline is self-explaining and auditable. */
+			reasoning?: string;
+		};
+		AuthIdentity: {
+			id: string;
+			name: string;
+			kind: string;
+		};
+		K8sResource: {
+			id: string;
+			name: string;
+			namespace?: string;
+			kind: string;
+			/** @description Pod phase (Running, Pending, Succeeded, Failed, Unknown) */
+			phase?: string;
+			/** @description Whether all containers in the pod are ready */
+			ready?: boolean;
+			/** @description Container-level state reason (e.g. CrashLoopBackOff, ImagePullBackOff) */
+			stateReason?: string;
+		};
+		Requirements: {
+			kind?: string;
+			rbacPermissions?: components['schemas']['RBACPermission'][];
+			accessLevel?: string;
+			activeSession?: boolean;
+			exists?: string[];
+		};
+		RBACPermission: {
+			resource: string;
+			resourceName: string;
+			resourceType: string;
+			apiGroup: string;
+			verb: string;
+			scope: string;
+			sourceRole: string;
+			/** @default true */
+			isNamespaced: boolean;
+			/** @enum {string} */
+			scopeKind?: 'cluster' | 'namespace' | 'unknown';
+			evaluatedNamespace?: string;
+			/** @enum {string} */
+			scopeSource?: 'binding' | 'role' | 'ssrr';
+			kubetier?: components['schemas']['KubetierPermissionAssessment'];
+		};
+		KubetierPermissionAssessment: {
+			/** @enum {string} */
+			provider: 'kubetier';
+			tierMin?: components['schemas']['KubetierTier'];
+			tierMax?: components['schemas']['KubetierTier'];
+			unassessed?: boolean;
+			scopeUnverified: boolean;
+			matches: components['schemas']['KubetierPermission'][];
+		};
+		/** @enum {string} */
+		KubetierTier: 'T0' | 'T1' | 'T2' | 'T3';
+		/** @enum {string} */
+		KubetierScope: 'cluster' | 'namespaced';
+		KubetierEscalationPath: {
+			name: string;
+			tier: components['schemas']['KubetierTier'];
+			sourceUrl: string;
+			steps: string[];
+		};
+		KubetierPermission: {
+			id: string;
+			verb: string;
+			resource: string;
+			apiGroup: string;
+			scope: components['schemas']['KubetierScope'];
+			tier: components['schemas']['KubetierTier'];
+			escalationCount: number;
+			sourceUrl: string;
+			kubernetesDocUrl?: string;
+			description?: string;
+			escalationPaths: components['schemas']['KubetierEscalationPath'][];
+		};
+		KubetierRoleRule: {
+			apiGroups: string[];
+			resources: string[];
+			nonResourceUrls: string[];
+			verbs: string[];
+		};
+		KubetierRole: {
+			id: string;
+			name: string;
+			scope: components['schemas']['KubetierScope'];
+			tier: components['schemas']['KubetierTier'];
+			sourceUrl: string;
+			kubernetesDocUrl?: string;
+			description?: string;
+			notes: string[];
+			rules: components['schemas']['KubetierRoleRule'][];
+		};
+		KubetierCatalog: {
+			schemaVersion: number;
+			attribution: string;
+			sourceUrl: string;
+			fetchedAt: string;
+			sourceEtag?: string;
+			sourceSha256: string;
+			validatedKubernetesVersion?: string;
+			full: boolean;
+			permissions: components['schemas']['KubetierPermission'][];
+			roles: components['schemas']['KubetierRole'][];
+		};
+		/**
+		 * @description A completed TTP execution joined with the parse audits produced by its
+		 *     declared effects. The record fields are flattened at the top level;
+		 *     `parseAudits` is the list of per-effect audit entries.
+		 */
+		ExecutionRecordEntry: {
+			/** @description Unique command ID, correlates with SSE `ttp-executed` and `parse-audited` events */
+			id: string;
+			ttp_id: string;
+			ttp_name: string;
+			tactic: string;
+			target_id: string;
+			/** @description ID of the system that ran the command; empty for direct builtin exec */
+			exec_system_id: string;
+			/** @description ID of the Kubernetes authentication identity selected for the action */
+			auth_identity_id?: string;
+			procedure_id: string;
+			/** @description Fully grounded command string sent to the C2 backend */
+			command: string;
+			/** @description Resolved arguments after default-filling and template substitution */
+			args: {
+				[key: string]: string;
+			};
+			success: boolean;
+			exit_code: number;
+			/** @description Raw output lines - first element is stdout, second (if present) is stderr */
+			results: string[];
+			fail_reason: string;
+			/**
+			 * Format: int64
+			 * @description Unix timestamp in milliseconds when the command was dispatched
+			 */
+			started_at_ms: number;
+			/**
+			 * Format: int64
+			 * @description Unix timestamp in milliseconds when the result was received
+			 */
+			completed_at_ms: number;
+			/** @description Entities produced by this execution, retained for operation timeline replay */
+			discovered_entities: components['schemas']['ExecutionEntity'][];
+			/** @description Caller-supplied rationale for why this action was run, as passed to the execute-action request. Empty when none was given. */
+			reasoning?: string;
+			parseAudits: components['schemas']['ParseAudit'][];
+		};
+		ExecutionEntity: {
+			id: string;
+			name: string;
+			kind: string;
+			/**
+			 * @description What the execution did to this entity. `observed` means the campaign learned of it for the first time; `created` means the action brought it into existence (a deployed pod, a bound listener); `updated` means it was already known and this run only refined its fields. Only `observed` is a discovery — consumers must not report the other two as one. Absent on records written before outcomes were tracked.
+			 * @default observed
+			 * @enum {string}
+			 */
+			outcome: 'observed' | 'created' | 'updated';
+			/**
+			 * @description What sort of news this fact is. Independent of `outcome`: gaining exec access to a host the campaign already knew is `access-gained` with an outcome of `updated`, and is still worth showing. Decided by the producer, so clients must not re-derive it from `kind`.
+			 * @default discovery
+			 * @enum {string}
+			 */
+			category: 'discovery' | 'credential' | 'access-gained';
+		};
+		/**
+		 * @description Audit record for a single effect parse attempt. `parse_result` indicates
+		 *     whether the effect was parsed successfully; `NoParser` and `UnknownFormat`
+		 *     are the two signals used by Shuhari's Gap 1 classifier.
+		 */
+		ParseAudit: {
+			/** @description Command ID of the execution that produced this audit */
+			cmd_id: string;
+			/** @description Effect identifier as declared in the TTP (e.g. `sys.envvar`, `k8s.podlist`) */
+			effect_id: string;
+			ttp_id: string;
+			target_id: string;
+			parser_version: string;
+			/** @description SHA-256 of the raw stdout+stderr, for deduplication across episodes */
+			raw_output_hash: string;
+			/** @description First 1024 characters of combined stdout+stderr */
+			raw_output_preview: string;
+			/**
+			 * @description - `Parsed`: effect was handled and facts were written to the campaign
+			 *     - `KnownFailure`: effect ran but produced expected-empty output (e.g. command not found)
+			 *     - `UnknownFormat`: output was present but the parser could not interpret it
+			 *     - `NoParser`: no compiled or external parser is registered for this effect (Gap 1 signal)
+			 *     - `ParserBug`: parser crashed or panicked
+			 * @enum {string}
+			 */
+			parse_result: 'Parsed' | 'KnownFailure' | 'UnknownFormat' | 'NoParser' | 'ParserBug';
+			/** @description Human-readable explanation of the parse outcome */
+			detail: string;
+			/** @description Number of new entities or field updates written to the campaign graph */
+			inferred_facts_written: number;
+		};
+		Error: {
+			error: string;
+			details?: string;
+		};
+		/** @description One consideration's contribution to a candidate's score. */
+		ConsiderationScore: {
+			/** @description Consideration identifier (e.g. "privilege_gain"). */
+			name: string;
+			/**
+			 * @description Whether this consideration contributes to utility or belief state.
+			 * @enum {string}
+			 */
+			kind: 'utility' | 'belief';
+			/**
+			 * Format: float
+			 * @description Raw measurement in [0, 1].
+			 */
+			raw: number;
+			/**
+			 * Format: float
+			 * @description Measurement after the profile's response curve.
+			 */
+			curved: number;
+			/**
+			 * Format: float
+			 * @description Weight applied from the profile.
+			 */
+			weight: number;
+			/** @description Whether this consideration acted as a multiplicative veto. */
+			veto: boolean;
+		};
+		/** @description A scored, grounded (TTP × target) action. */
+		ScoredCandidate: {
+			ttp_id: string;
+			target_id: string;
+			/**
+			 * Format: float
+			 * @description Final ranking score in [0, 1], equal to utility_score × success_probability.
+			 */
+			utility: number;
+			/**
+			 * Format: float
+			 * @description Intrinsic desirability of the action if it succeeds.
+			 */
+			utility_score: number;
+			/**
+			 * Format: float
+			 * @description Belief-state probability that the action can be grounded and succeed.
+			 */
+			success_probability: number;
+			breakdown: components['schemas']['ConsiderationScore'][];
+		};
+		/**
+		 * @description How per-consideration scores are combined into one utility.
+		 * @enum {string}
+		 */
+		CombinationMode: 'weighted_arithmetic' | 'weighted_geometric' | 'iaus_multiplicative';
+		/** @description A response curve mapping a raw measurement in [0,1] to a tuned score in [0,1], internally tagged by `type`. Only the fields for the active type are meaningful (linear: slope/intercept; polynomial: exponent/slope/ intercept; logistic: steepness/midpoint; step: threshold). */
+		ResponseCurve: {
+			/** @enum {string} */
+			type: 'linear' | 'polynomial' | 'logistic' | 'step';
+			/** Format: float */
+			slope?: number;
+			/** Format: float */
+			intercept?: number;
+			/** Format: float */
+			exponent?: number;
+			/** Format: float */
+			steepness?: number;
+			/** Format: float */
+			midpoint?: number;
+			/** Format: float */
+			threshold?: number;
+		};
+		/** @description A consideration's tunable config, tagged with its name. */
+		NamedConsideration: {
+			name: string;
+			/** Format: float */
+			weight: number;
+			curve: components['schemas']['ResponseCurve'];
+			enabled: boolean;
+			veto: boolean;
+		};
+		/** @description The live scoring profile. */
+		ScoringProfile: {
+			/** @description Whether utility-AI recommendations and action scoring are enabled. */
+			enabled: boolean;
+			combination: components['schemas']['CombinationMode'];
+			/** @description Whether scoring and the tuning UI feature flag are both enabled. */
+			tuningEnabled: boolean;
+			considerations: components['schemas']['NamedConsideration'][];
+		};
+		/** @description A scoring-profile update (runtime tuning). */
+		ScoringProfileUpdate: {
+			combination: components['schemas']['CombinationMode'];
+			considerations: components['schemas']['NamedConsideration'][];
+		};
+		/** @description Fit-quality metrics from a calibration run. */
+		CalibrationMetrics: {
+			/** @description Number of captured decisions the fit used. */
+			decisions: number;
+			/**
+			 * Format: float
+			 * @description Fraction of decisions where the operator's choice ranks first.
+			 */
+			top1Accuracy: number;
+			/**
+			 * Format: float
+			 * @description Mean probability the fitted model assigns the operator's choices.
+			 */
+			meanChosenProb: number;
+			/**
+			 * Format: float
+			 * @description Worst per-decision probability assigned to an operator choice.
+			 */
+			minChosenProb: number;
+			/** Format: float */
+			logLikelihood: number;
+			/** @description Decisions whose choice is Pareto-dominated - unreproducible by any non-negative weighting, signalling a missing consideration. */
+			infeasible: number;
+			converged: boolean;
+		};
+		/** @description A calibration preview - the fitted profile plus fit metrics. */
+		CalibrationResult: {
+			profile: components['schemas']['ScoringProfile'];
+			metrics: components['schemas']['CalibrationMetrics'];
+		};
+		/** @description Reference to the Kubernetes owner of a resource (e.g. ReplicaSet → Pod). */
+		OwnerRef: {
+			name: string;
+			kind: string;
+			uid: string;
+		};
+		/** @description A volume mount on a pod - either a projected volume or a host-path bind mount. */
+		VolumeMount: {
+			name: string;
+			/** @description Path inside the container where the volume appears. */
+			mount_point: string;
+			/** @description Path on the host that is bound (for hostPath mounts). */
+			mount_root: string;
+			mount_type?: string;
+			read_only: boolean;
+			is_host_path: boolean;
+		};
+		/**
+		 * @description Status of a TTP - whether it is enabled or disabled
+		 * @enum {string}
+		 */
+		TTPStatus: 'enabled' | 'disabled';
+	};
+	responses: never;
+	parameters: never;
+	requestBodies: never;
+	headers: never;
+	pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-    getGraph: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Graph"];
-                };
-            };
-        };
-    };
-    getCampaignState: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CampaignState"];
-                };
-            };
-        };
-    };
-    getKubetierCatalog: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Offline KubeTier catalog */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["KubetierCatalog"];
-                };
-            };
-        };
-    };
-    getArmory: {
-        parameters: {
-            query?: {
-                /** @description Optional tactic to filter by (e.g., "Execution", "CredentialAccess") */
-                tactic?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TTP"][];
-                };
-            };
-        };
-    };
-    getApplicableTTPs: {
-        parameters: {
-            query?: {
-                /** @description ID of the target entity (optional, can be empty for all targets) */
-                targetId?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["TTP"][];
-                };
-            };
-            /** @description Target not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getEligibleAuthIdentities: {
-        parameters: {
-            query: {
-                actionId: string;
-                targetId: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Eligible identities */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AuthIdentity"][];
-                };
-            };
-            /** @description Action or target not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getRecommendations: {
-        parameters: {
-            query?: {
-                /** @description Optional - restrict recommendations to a single target entity. */
-                targetId?: string;
-                /** @description Optional - cap the number of ranked candidates returned. */
-                limit?: number;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ScoredCandidate"][];
-                };
-            };
-        };
-    };
-    getScoringProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ScoringProfile"];
-                };
-            };
-        };
-    };
-    updateScoringProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ScoringProfileUpdate"];
-            };
-        };
-        responses: {
-            /** @description Updated profile */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ScoringProfile"];
-                };
-            };
-            /** @description Tuning disabled */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    saveScoringProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Saved profile */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ScoringProfile"];
-                };
-            };
-            /** @description Tuning disabled */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    resetScoringProfile: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Reset profile */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ScoringProfile"];
-                };
-            };
-            /** @description Tuning disabled */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    calibrateScoring: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Fitted profile preview and metrics */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["CalibrationResult"];
-                };
-            };
-            /** @description Tuning disabled */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description No captured decisions to calibrate from */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getFlow: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["AttackFlow"];
-                };
-            };
-        };
-    };
-    executeAction: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["ExecuteActionCmd"];
-            };
-        };
-        responses: {
-            /** @description Action executed successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        status?: string;
-                    };
-                };
-            };
-            /** @description Action queued for execution, pending asynchronous processing. The final status will be sent via SSE. */
-            202: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        status?: string;
-                        taskId?: string;
-                    };
-                };
-            };
-            /** @description Invalid request */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description The specified action or target was not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description The action was executed, but failed for some reason */
-            409: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    resetCampaign: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Campaign reset successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        status?: string;
-                    };
-                };
-            };
-            /** @description Reset failed */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getRunningPods: {
-        parameters: {
-            query?: {
-                /** @description Kubernetes namespace (optional, defaults to all namespaces) */
-                namespace?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["K8sResource"][];
-                };
-            };
-            /** @description Failed to retrieve pods */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getExecutionRecords: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExecutionRecordEntry"][];
-                };
-            };
-        };
-    };
-    getExecutionRecordById: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                /** @description Command ID (matches the `id` field in SSE `ttp-executed` and `parse-audited` events) */
-                id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Successful response */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ExecutionRecordEntry"];
-                };
-            };
-            /** @description No record found for the given ID */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    getFileContent: {
-        parameters: {
-            query: {
-                /** @description The file path to retrieve content for */
-                path: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description File content retrieved successfully */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        path?: string;
-                        content?: string;
-                    };
-                };
-            };
-            /** @description File content not found */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    listPlans: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Available plans */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["PlanSummary"][];
-                };
-            };
-            /** @description Failed to read the plans directory */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    loadPlan: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody: {
-            content: {
-                "application/json": components["schemas"]["LoadPlanRequest"];
-            };
-        };
-        responses: {
-            /** @description Plan started */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": {
-                        plan_id?: string;
-                    };
-                };
-            };
-            /** @description Invalid plan filename or plan failed to parse */
-            400: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-            /** @description Plan not found in the plans directory */
-            404: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
-    exportPlan: {
-        parameters: {
-            query?: {
-                /** @description Include failed actions as well as successful actions. */
-                include_failed?: boolean;
-                /** @description Human-readable name stored in the exported plan. */
-                name?: string;
-                /** @description Description stored in the exported plan. */
-                description?: string;
-            };
-            header?: never;
-            path?: never;
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description Exported plan YAML */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/yaml": string;
-                };
-            };
-            /** @description Failed to export the plan */
-            500: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["Error"];
-                };
-            };
-        };
-    };
+	getGraph: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Graph'];
+				};
+			};
+		};
+	};
+	getCampaignState: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['CampaignState'];
+				};
+			};
+		};
+	};
+	getKubetierCatalog: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Offline KubeTier catalog */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['KubetierCatalog'];
+				};
+			};
+		};
+	};
+	getArmory: {
+		parameters: {
+			query?: {
+				/** @description Optional tactic to filter by (e.g., "Execution", "CredentialAccess") */
+				tactic?: string;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['TTP'][];
+				};
+			};
+		};
+	};
+	getApplicableTTPs: {
+		parameters: {
+			query?: {
+				/** @description ID of the target entity (optional, can be empty for all targets) */
+				targetId?: string;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['TTP'][];
+				};
+			};
+			/** @description Target not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	getEligibleAuthIdentities: {
+		parameters: {
+			query: {
+				actionId: string;
+				targetId: string;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Eligible identities */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['AuthIdentity'][];
+				};
+			};
+			/** @description Action or target not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	getRecommendations: {
+		parameters: {
+			query?: {
+				/** @description Optional - restrict recommendations to a single target entity. */
+				targetId?: string;
+				/** @description Optional - cap the number of ranked candidates returned. */
+				limit?: number;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ScoredCandidate'][];
+				};
+			};
+		};
+	};
+	getScoringProfile: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ScoringProfile'];
+				};
+			};
+		};
+	};
+	updateScoringProfile: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['ScoringProfileUpdate'];
+			};
+		};
+		responses: {
+			/** @description Updated profile */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ScoringProfile'];
+				};
+			};
+			/** @description Tuning disabled */
+			403: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	saveScoringProfile: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Saved profile */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ScoringProfile'];
+				};
+			};
+			/** @description Tuning disabled */
+			403: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	resetScoringProfile: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Reset profile */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ScoringProfile'];
+				};
+			};
+			/** @description Tuning disabled */
+			403: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	calibrateScoring: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Fitted profile preview and metrics */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['CalibrationResult'];
+				};
+			};
+			/** @description Tuning disabled */
+			403: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+			/** @description No captured decisions to calibrate from */
+			409: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	getFlow: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['AttackFlow'];
+				};
+			};
+		};
+	};
+	executeAction: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['ExecuteActionCmd'];
+			};
+		};
+		responses: {
+			/** @description Action executed successfully */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						status?: string;
+					};
+				};
+			};
+			/** @description Action queued for execution, pending asynchronous processing. The final status will be sent via SSE. */
+			202: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						status?: string;
+						taskId?: string;
+					};
+				};
+			};
+			/** @description Invalid request */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+			/** @description The specified action or target was not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+			/** @description The action was executed, but failed for some reason */
+			409: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	resetCampaign: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Campaign reset successfully */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						status?: string;
+					};
+				};
+			};
+			/** @description Reset failed */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	getRunningPods: {
+		parameters: {
+			query?: {
+				/** @description Kubernetes namespace (optional, defaults to all namespaces) */
+				namespace?: string;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['K8sResource'][];
+				};
+			};
+			/** @description Failed to retrieve pods */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	getExecutionRecords: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ExecutionRecordEntry'][];
+				};
+			};
+		};
+	};
+	getExecutionRecordById: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path: {
+				/** @description Command ID (matches the `id` field in SSE `ttp-executed` and `parse-audited` events) */
+				id: string;
+			};
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Successful response */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['ExecutionRecordEntry'];
+				};
+			};
+			/** @description No record found for the given ID */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	getFileContent: {
+		parameters: {
+			query: {
+				/** @description The file path to retrieve content for */
+				path: string;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description File content retrieved successfully */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						path?: string;
+						content?: string;
+					};
+				};
+			};
+			/** @description File content not found */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	listPlans: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Available plans */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['PlanSummary'][];
+				};
+			};
+			/** @description Failed to read the plans directory */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	loadPlan: {
+		parameters: {
+			query?: never;
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody: {
+			content: {
+				'application/json': components['schemas']['LoadPlanRequest'];
+			};
+		};
+		responses: {
+			/** @description Plan started */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': {
+						plan_id?: string;
+					};
+				};
+			};
+			/** @description Invalid plan filename or plan failed to parse */
+			400: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+			/** @description Plan not found in the plans directory */
+			404: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
+	exportPlan: {
+		parameters: {
+			query?: {
+				/** @description Include failed actions as well as successful actions. */
+				include_failed?: boolean;
+				/** @description Human-readable name stored in the exported plan. */
+				name?: string;
+				/** @description Description stored in the exported plan. */
+				description?: string;
+			};
+			header?: never;
+			path?: never;
+			cookie?: never;
+		};
+		requestBody?: never;
+		responses: {
+			/** @description Exported plan YAML */
+			200: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/yaml': string;
+				};
+			};
+			/** @description Failed to export the plan */
+			500: {
+				headers: {
+					[name: string]: unknown;
+				};
+				content: {
+					'application/json': components['schemas']['Error'];
+				};
+			};
+		};
+	};
 }

--- a/frontend/src/lib/components/AttackStepDrawer.svelte
+++ b/frontend/src/lib/components/AttackStepDrawer.svelte
@@ -24,11 +24,11 @@
 >
 	<Portal>
 		<Dialog.Backdrop
-			class="fixed inset-0 z-50 bg-surface-50-950/50 transition transition-discrete {animBackdrop}"
+			class="bg-surface-50-950/50 fixed inset-0 z-50 transition transition-discrete {animBackdrop}"
 		/>
 		<Dialog.Positioner class="fixed inset-0 z-50 flex justify-end">
 			<Dialog.Content
-				class="h-screen w-xl space-y-4 overflow-auto bg-surface-100-900 p-4 shadow-xl {animDrawer}"
+				class="bg-surface-100-900 h-screen w-xl space-y-4 overflow-auto p-4 shadow-xl {animDrawer}"
 			>
 				{#if step}
 					<AttackStepDetails {step} />

--- a/frontend/src/lib/components/CampaignState.svelte.ts
+++ b/frontend/src/lib/components/CampaignState.svelte.ts
@@ -1,20 +1,12 @@
 import { getContext, setContext } from 'svelte';
-import type { ArmoryType, Node } from '$lib/model';
-import type {
-	AttackFlow,
-	CampaignState as State,
-	Graph,
-	TTP,
-	ExecuteActionRequest
-} from '$lib/api/index';
+import type { ArmoryType } from '$lib/model';
+import type { AttackFlow, CampaignState as State, Graph, TTP } from '$lib/api/index';
 import type { KubetierCatalog } from '$lib/api/index';
 import { showToast, type ToastType } from '$lib/components/toaster';
 import { getRanAPI, RanAPI } from '$lib/ran_api';
 import { timeline } from '$lib/stores/timelineStore.svelte';
 
 // Great video how to build stores in Svelte 5: https://www.youtube.com/watch?v=kMBDsyozllk
-
-type Conditions = {};
 
 export type Entity = {
 	id: string;
@@ -48,11 +40,6 @@ type ErrorMsg = {
 	Msg: string;
 };
 
-type BackendError = {
-	code: string;
-	message: string;
-};
-
 type ParseAuditUI = {
 	effectId: string;
 	parseResult: string;
@@ -71,7 +58,6 @@ function normalizeParseAudit(raw: any): ParseAuditUI {
 
 class CampaignState {
 	campaignId: number = $state(0);
-	activeConditions: Conditions = $state({});
 	entities = $state<Entity[]>([]);
 	relations = $state<Map<string, Relation>>(new Map());
 	namespaces = $state<Entity[]>([]);
@@ -87,13 +73,13 @@ class CampaignState {
 	private factsChangedCounter = 0;
 	private getCampaignStateCounter = 0;
 
-	init(url?: string): Promise<void> {
-		// If no URL provided, it will auto-construct from window.location
+	init(): Promise<void> {
+		// The API URL is constructed from window.location.
 
 		this.api.on('armory-loaded', (data) => {
 			this.armory = parseArmory(data);
 		});
-		this.api.on('facts-changed', (data: any) => {
+		this.api.on('facts-changed', () => {
 			const eventId = ++this.factsChangedCounter;
 			this.api.GetGraph().then((g: Graph) => {
 				this.graph = g;
@@ -141,7 +127,7 @@ class CampaignState {
 		});
 		this.api.on('reset-campaign', () => this.onReset());
 		this.api.on('error-msg', (rawMsg: string) => {
-			let msg: ErrorMsg = JSON.parse(rawMsg);
+			const msg: ErrorMsg = JSON.parse(rawMsg);
 
 			// Map msg.Level to ToastType
 			let toastType: ToastType;
@@ -160,7 +146,7 @@ class CampaignState {
 			showToast('Error', msg.Msg, toastType);
 		});
 		console.log('CampaignState connecting to backend...');
-		return this.api.connect().then((a) => {
+		return this.api.connect().then(() => {
 			this.api
 				.GetKubetierCatalog()
 				.then((catalog) => {
@@ -185,7 +171,7 @@ class CampaignState {
 
 	showError(msg: string | object) {
 		if (typeof msg === 'object') {
-			if (msg.hasOwnProperty('message')) {
+			if (Object.hasOwn(msg, 'message')) {
 				msg = (msg as any).message;
 			} else {
 				// fallback handling to show full object (may allow later refinement)
@@ -230,12 +216,11 @@ class CampaignState {
 	}
 
 	#setState(state: State): void {
-		let entities = [];
-		let namespaces = [];
-		let pods = [];
-		let serviceAccounts = [];
+		const entities = [];
+		const namespaces = [];
+		const pods = [];
+		const serviceAccounts = [];
 
-		const timestamp = new Date().toISOString();
 		for (const [id, entity] of Object.entries(state.entities || {})) {
 			const typedEntity = entity as unknown as Entity;
 			if (typedEntity === null) {
@@ -314,7 +299,7 @@ class CampaignState {
 	// }
 
 	getTtpById(id: string): TTP | undefined {
-		for (const [group, ttps] of this.armory) {
+		for (const [, ttps] of this.armory) {
 			const ttp = ttps.find((t) => t.id === id);
 			if (ttp) {
 				return ttp;
@@ -323,12 +308,12 @@ class CampaignState {
 	}
 
 	getNamespaces(): Entity[] {
-		let ns = this.entities.filter((entity) => entity.kind === 'Namespace');
+		const ns = this.entities.filter((entity) => entity.kind === 'Namespace');
 		return ns || [];
 	}
 
 	getPods(ns?: string): Entity[] {
-		let pods = this.entities.filter(
+		const pods = this.entities.filter(
 			(entity) => entity.kind === 'Pod' && (!ns || entity.namespace === ns)
 		);
 		return pods || [];
@@ -388,7 +373,7 @@ class CampaignState {
 		);
 	}
 
-	getServiceAccounts(ns?: string, permissions?: string[], includeUnkwnon?: boolean): Entity[] {
+	getServiceAccounts(ns?: string): Entity[] {
 		let serviceAccounts = this.entities.filter((entity) => entity.kind === 'ServiceAccount');
 		if (ns) {
 			serviceAccounts = serviceAccounts.filter((entity) => entity.namespace === ns);
@@ -401,7 +386,7 @@ class CampaignState {
 		const tokens = this.entities.filter(
 			(entity) =>
 				entity.kind === 'ServiceAccountToken' ||
-				(entity.kind === 'ServiceAccount' && entity.hasOwnProperty('token'))
+				(entity.kind === 'ServiceAccount' && Object.hasOwn(entity, 'token'))
 		); // Include ServiceAccounts that have token binaries
 
 		// Extract the ServiceAccount IDs from tokens (tokens have ID format: ns/{namespace}/sa/{saName}/token)
@@ -453,8 +438,8 @@ export const setCampaignState = (key = DEFAULT_KEY) => {
 
 export function parseArmory(data: TTP[]): ArmoryType {
 	// this comes from the backend must be converted
-	let armoryMap = new Map<string, TTP[]>();
-	for (let ttp of data) {
+	const armoryMap = new Map<string, TTP[]>();
+	for (const ttp of data) {
 		let groupName = ttp.tactic;
 		if (groupName === '') {
 			groupName = 'Other';

--- a/frontend/src/lib/components/OperationTimeline.svelte
+++ b/frontend/src/lib/components/OperationTimeline.svelte
@@ -1,401 +1,431 @@
 <script lang="ts">
-    import Icon from '@iconify/svelte';
-    import type { TopEntry, EntityEntry, ActionGroup } from '$lib/stores/timelineStore.svelte';
+	import Icon from '@iconify/svelte';
+	import type { TopEntry, EntityEntry, ActionGroup } from '$lib/stores/timelineStore.svelte';
 
-    interface Props {
-        entries: TopEntry[];
-        onfocusentity: (targetId: string) => void;
-        ontogglegroup: (cmdId: string) => void;
-        onviewaction: (cmdId: string) => void;
-    }
+	interface Props {
+		entries: TopEntry[];
+		onfocusentity: (targetId: string) => void;
+		ontogglegroup: (cmdId: string) => void;
+		onviewaction: (cmdId: string) => void;
+	}
 
-    let { entries, onfocusentity, ontogglegroup, onviewaction }: Props = $props();
+	let { entries, onfocusentity, ontogglegroup, onviewaction }: Props = $props();
 
-    const MIN_HEIGHT = 120;
-    const MAX_HEIGHT = 800;
-    const DEFAULT_HEIGHT = 240; // matches the previous fixed h-60
-    const STORAGE_KEY = 'operationTimeline.height';
+	const MIN_HEIGHT = 120;
+	const MAX_HEIGHT = 800;
+	const DEFAULT_HEIGHT = 240; // matches the previous fixed h-60
+	const STORAGE_KEY = 'operationTimeline.height';
 
-    function loadHeight(): number {
-        if (typeof localStorage === 'undefined') return DEFAULT_HEIGHT;
-        const raw = Number(localStorage.getItem(STORAGE_KEY));
-        if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_HEIGHT;
-        return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, raw));
-    }
+	function loadHeight(): number {
+		if (typeof localStorage === 'undefined') return DEFAULT_HEIGHT;
+		const raw = Number(localStorage.getItem(STORAGE_KEY));
+		if (!Number.isFinite(raw) || raw <= 0) return DEFAULT_HEIGHT;
+		return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, raw));
+	}
 
-    let height = $state(loadHeight());
+	let height = $state(loadHeight());
 
-    function startResize(event: PointerEvent) {
-        event.preventDefault();
-        const startY = event.clientY;
-        const startHeight = height;
+	function startResize(event: PointerEvent) {
+		event.preventDefault();
+		const startY = event.clientY;
+		const startHeight = height;
 
-        function onMove(e: PointerEvent) {
-            // Dragging up (smaller clientY) grows the panel.
-            const next = startHeight + (startY - e.clientY);
-            height = Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, next));
-        }
-        function onUp() {
-            window.removeEventListener('pointermove', onMove);
-            window.removeEventListener('pointerup', onUp);
-            document.body.style.cursor = '';
-            document.body.style.userSelect = '';
-            if (typeof localStorage !== 'undefined') {
-                localStorage.setItem(STORAGE_KEY, String(Math.round(height)));
-            }
-        }
+		function onMove(e: PointerEvent) {
+			// Dragging up (smaller clientY) grows the panel.
+			const next = startHeight + (startY - e.clientY);
+			height = Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, next));
+		}
+		function onUp() {
+			window.removeEventListener('pointermove', onMove);
+			window.removeEventListener('pointerup', onUp);
+			document.body.style.cursor = '';
+			document.body.style.userSelect = '';
+			if (typeof localStorage !== 'undefined') {
+				localStorage.setItem(STORAGE_KEY, String(Math.round(height)));
+			}
+		}
 
-        window.addEventListener('pointermove', onMove);
-        window.addEventListener('pointerup', onUp);
-        document.body.style.cursor = 'row-resize';
-        document.body.style.userSelect = 'none';
-    }
+		window.addEventListener('pointermove', onMove);
+		window.addEventListener('pointerup', onUp);
+		document.body.style.cursor = 'row-resize';
+		document.body.style.userSelect = 'none';
+	}
 
-    function onHandleKeydown(event: KeyboardEvent) {
-        const step = event.shiftKey ? 48 : 16;
-        if (event.key === 'ArrowUp') {
-            height = Math.min(MAX_HEIGHT, height + step);
-        } else if (event.key === 'ArrowDown') {
-            height = Math.max(MIN_HEIGHT, height - step);
-        } else {
-            return;
-        }
-        event.preventDefault();
-        if (typeof localStorage !== 'undefined') {
-            localStorage.setItem(STORAGE_KEY, String(Math.round(height)));
-        }
-    }
+	function onHandleKeydown(event: KeyboardEvent) {
+		const step = event.shiftKey ? 48 : 16;
+		if (event.key === 'ArrowUp') {
+			height = Math.min(MAX_HEIGHT, height + step);
+		} else if (event.key === 'ArrowDown') {
+			height = Math.max(MIN_HEIGHT, height - step);
+		} else {
+			return;
+		}
+		event.preventDefault();
+		if (typeof localStorage !== 'undefined') {
+			localStorage.setItem(STORAGE_KEY, String(Math.round(height)));
+		}
+	}
 
-    function formatCompactTime(d: Date): string {
-        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
-    }
+	function formatCompactTime(d: Date): string {
+		return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+	}
 
-    function formatFullTime(d: Date): string {
-        return d.toLocaleString([], { dateStyle: 'medium', timeStyle: 'long' });
-    }
+	function formatFullTime(d: Date): string {
+		return d.toLocaleString([], { dateStyle: 'medium', timeStyle: 'long' });
+	}
 
-    let timestampTooltip = $state<{ text: string; left: number; top: number }>();
+	let timestampTooltip = $state<{ text: string; left: number; top: number }>();
 
-    function showTimestampTooltip(event: MouseEvent | FocusEvent, timestamp: Date) {
-        const trigger = event.currentTarget;
-        if (!(trigger instanceof HTMLElement)) return;
-        const bounds = trigger.getBoundingClientRect();
-        timestampTooltip = {
-            text: formatFullTime(timestamp),
-            left: bounds.left + bounds.width / 2,
-            top: bounds.top - 6
-        };
-    }
+	function showTimestampTooltip(event: MouseEvent | FocusEvent, timestamp: Date) {
+		const trigger = event.currentTarget;
+		if (!(trigger instanceof HTMLElement)) return;
+		const bounds = trigger.getBoundingClientRect();
+		timestampTooltip = {
+			text: formatFullTime(timestamp),
+			left: bounds.left + bounds.width / 2,
+			top: bounds.top - 6
+		};
+	}
 
-    function hideTimestampTooltip() {
-        timestampTooltip = undefined;
-    }
+	function hideTimestampTooltip() {
+		timestampTooltip = undefined;
+	}
 
-    /** Lower-cased for prose, but only for the kinds that read naturally that way. */
-    const SPELLED_OUT_KINDS: Record<string, string> = {
-        Pod: 'pod',
-        Namespace: 'namespace',
-        ServiceAccount: 'service account',
-        Listener: 'listener'
-    };
+	/** Lower-cased for prose, but only for the kinds that read naturally that way. */
+	const SPELLED_OUT_KINDS: Record<string, string> = {
+		Pod: 'pod',
+		Namespace: 'namespace',
+		ServiceAccount: 'service account',
+		Listener: 'listener'
+	};
 
-    function entityNoun(entry: EntityEntry): string {
-        return SPELLED_OUT_KINDS[entry.entityKind] ?? entry.entityKind;
-    }
+	function entityNoun(entry: EntityEntry): string {
+		return SPELLED_OUT_KINDS[entry.entityKind] ?? entry.entityKind;
+	}
 
-    function entityPrefix(entry: EntityEntry): string {
-        if (entry.kind === 'credential') {
-            if (entry.entityKind === 'Secret') return 'Found secret';
-            return 'Found credential';
-        }
-        if (entry.kind === 'access-gained') return 'Gained exec access to';
-        // The verb has to match what actually happened. Calling the listener an
-        // action just bound "discovered" is the kind of claim that makes the
-        // whole timeline harder to trust.
-        const noun = entityNoun(entry);
-        switch (entry.outcome ?? 'observed') {
-            case 'created':
-                return `Created ${noun}`;
-            case 'updated':
-                return `Updated ${noun}`;
-            default:
-                return `Discovered ${noun}`;
-        }
-    }
+	function entityPrefix(entry: EntityEntry): string {
+		if (entry.kind === 'credential') {
+			if (entry.entityKind === 'Secret') return 'Found secret';
+			return 'Found credential';
+		}
+		if (entry.kind === 'access-gained') return 'Gained exec access to';
+		// The verb has to match what actually happened. Calling the listener an
+		// action just bound "discovered" is the kind of claim that makes the
+		// whole timeline harder to trust.
+		const noun = entityNoun(entry);
+		switch (entry.outcome ?? 'observed') {
+			case 'created':
+				return `Created ${noun}`;
+			case 'updated':
+				return `Updated ${noun}`;
+			default:
+				return `Discovered ${noun}`;
+		}
+	}
 
-    function effectCounts(group: ActionGroup) {
-        const counts = { discovery: 0, created: 0, credential: 0, access: 0 };
-        for (const e of group.effects) {
-            const outcome = e.outcome ?? 'observed';
-            if (e.kind === 'credential') counts.credential++;
-            else if (e.kind === 'access-gained') counts.access++;
-            else if (outcome === 'created') counts.created++;
-            else if (outcome === 'observed') counts.discovery++;
-            // 'updated' effects are deliberately uncounted: the badge row
-            // summarises what the action yielded, not what it re-stated.
-        }
-        return counts;
-    }
+	function effectCounts(group: ActionGroup) {
+		const counts = { discovery: 0, created: 0, credential: 0, access: 0 };
+		for (const e of group.effects) {
+			const outcome = e.outcome ?? 'observed';
+			if (e.kind === 'credential') counts.credential++;
+			else if (e.kind === 'access-gained') counts.access++;
+			else if (outcome === 'created') counts.created++;
+			else if (outcome === 'observed') counts.discovery++;
+			// 'updated' effects are deliberately uncounted: the badge row
+			// summarises what the action yielded, not what it re-stated.
+		}
+		return counts;
+	}
 
-    function entityIcon(entry: EntityEntry): string {
-        if (entry.kind === 'credential') return 'mdi:key';
-        if (entry.kind === 'access-gained') return 'mdi:shield-check';
-        if ((entry.outcome ?? 'observed') === 'created') return 'mdi:plus-circle-outline';
-        return 'mdi:magnify';
-    }
+	function entityIcon(entry: EntityEntry): string {
+		if (entry.kind === 'credential') return 'mdi:key';
+		if (entry.kind === 'access-gained') return 'mdi:shield-check';
+		if ((entry.outcome ?? 'observed') === 'created') return 'mdi:plus-circle-outline';
+		return 'mdi:magnify';
+	}
 
-    function entityIconClass(entry: EntityEntry): string {
-        if (entry.kind === 'credential') return 'size-4 text-warning-500';
-        if (entry.kind === 'access-gained') return 'size-4 text-success-400';
-        if ((entry.outcome ?? 'observed') === 'created') return 'size-4 text-tertiary-400';
-        return 'size-4 text-primary-400';
-    }
+	function entityIconClass(entry: EntityEntry): string {
+		if (entry.kind === 'credential') return 'size-4 text-warning-500';
+		if (entry.kind === 'access-gained') return 'size-4 text-success-400';
+		if ((entry.outcome ?? 'observed') === 'created') return 'size-4 text-tertiary-400';
+		return 'size-4 text-primary-400';
+	}
 
-    let totalEvents = $derived(
-        entries.reduce((n, e) => {
-            if (e.kind === 'action-group') return n + 1 + e.effects.length;
-            return n + 1;
-        }, 0)
-    );
+	let totalEvents = $derived(
+		entries.reduce((n, e) => {
+			if (e.kind === 'action-group') return n + 1 + e.effects.length;
+			return n + 1;
+		}, 0)
+	);
 
-    // The store keeps entries newest-first; render oldest→newest so the latest
-    // sits at the bottom, like a log/chat view.
-    let ordered = $derived([...entries].reverse());
+	// The store keeps entries newest-first; render oldest→newest so the latest
+	// sits at the bottom, like a log/chat view.
+	let ordered = $derived([...entries].reverse());
 
-    let scrollEl: HTMLDivElement | undefined = $state();
-    // Pinned to the bottom by default so the newest events stay in view. Flips
-    // off once the user scrolls up into the history, and back on when they
-    // return to the bottom.
-    let stickToBottom = $state(true);
+	let scrollEl: HTMLDivElement | undefined = $state();
+	// Pinned to the bottom by default so the newest events stay in view. Flips
+	// off once the user scrolls up into the history, and back on when they
+	// return to the bottom.
+	let stickToBottom = $state(true);
 
-    function onTimelineScroll() {
-        if (!scrollEl) return;
-        hideTimestampTooltip();
-        const slack = 24; // px tolerance - near-bottom still counts as bottom
-        stickToBottom =
-            scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - slack;
-    }
+	function onTimelineScroll() {
+		if (!scrollEl) return;
+		hideTimestampTooltip();
+		const slack = 24; // px tolerance - near-bottom still counts as bottom
+		stickToBottom = scrollEl.scrollTop + scrollEl.clientHeight >= scrollEl.scrollHeight - slack;
+	}
 
-    // Follow new events to the bottom while pinned. Depends on totalEvents so it
-    // also fires when an expanded group gains child effect rows, and on scrollEl
-    // so the initial (backfilled) list lands at the bottom once mounted.
-    $effect(() => {
-        totalEvents;
-        if (stickToBottom && scrollEl) {
-            scrollEl.scrollTop = scrollEl.scrollHeight;
-        }
-    });
+	// Follow new events to the bottom while pinned. Depends on totalEvents so it
+	// also fires when an expanded group gains child effect rows, and on scrollEl
+	// so the initial (backfilled) list lands at the bottom once mounted.
+	$effect(() => {
+		totalEvents;
+		if (stickToBottom && scrollEl) {
+			scrollEl.scrollTop = scrollEl.scrollHeight;
+		}
+	});
 </script>
 
 {#snippet timestamp(value?: Date, startup = false)}
-    {#if value}
-        {@const fullTimestamp = formatFullTime(value)}
-        <button
-            type="button"
-            class="text-surface-500 text-xs shrink-0 mt-0.5 cursor-help"
-            aria-label={fullTimestamp}
-            onmouseenter={(event) => showTimestampTooltip(event, value)}
-            onmouseleave={hideTimestampTooltip}
-            onfocus={(event) => showTimestampTooltip(event, value)}
-            onblur={hideTimestampTooltip}
-            onclick={(event) => event.stopPropagation()}
-        >
-            {startup ? 'Startup' : formatCompactTime(value)}
-        </button>
-    {:else}
-        <span class="text-surface-500 text-xs shrink-0 mt-0.5">Startup</span>
-    {/if}
+	{#if value}
+		{@const fullTimestamp = formatFullTime(value)}
+		<button
+			type="button"
+			class="text-surface-500 mt-0.5 shrink-0 cursor-help text-xs"
+			aria-label={fullTimestamp}
+			onmouseenter={(event) => showTimestampTooltip(event, value)}
+			onmouseleave={hideTimestampTooltip}
+			onfocus={(event) => showTimestampTooltip(event, value)}
+			onblur={hideTimestampTooltip}
+			onclick={(event) => event.stopPropagation()}
+		>
+			{startup ? 'Startup' : formatCompactTime(value)}
+		</button>
+	{:else}
+		<span class="text-surface-500 mt-0.5 shrink-0 text-xs">Startup</span>
+	{/if}
 {/snippet}
 
 <div
-    class="shrink-0 bg-surface-100-900 border-t border-surface-200-800 flex flex-col relative"
-    style="height: {height}px"
-    role="region"
-    aria-label="Operation timeline"
+	class="bg-surface-100-900 border-surface-200-800 relative flex shrink-0 flex-col border-t"
+	style="height: {height}px"
+	role="region"
+	aria-label="Operation timeline"
 >
-    <!-- Resize handle -->
+	<!-- Resize handle -->
 	<div
-        class="absolute -top-1 left-0 right-0 h-2 cursor-row-resize z-10 group"
+		class="group absolute -top-1 right-0 left-0 z-10 h-2 cursor-row-resize"
 		role="slider"
-        aria-orientation="horizontal"
-        aria-label="Resize operation timeline"
-        aria-valuemin={MIN_HEIGHT}
-        aria-valuemax={MAX_HEIGHT}
-        aria-valuenow={Math.round(height)}
-        tabindex="0"
-        onpointerdown={startResize}
-        onkeydown={onHandleKeydown}
+		aria-orientation="horizontal"
+		aria-label="Resize operation timeline"
+		aria-valuemin={MIN_HEIGHT}
+		aria-valuemax={MAX_HEIGHT}
+		aria-valuenow={Math.round(height)}
+		tabindex="0"
+		onpointerdown={startResize}
+		onkeydown={onHandleKeydown}
 	>
-        <div class="absolute inset-x-0 top-1 h-0.5 bg-transparent group-hover:bg-primary-500 transition-colors"></div>
+		<div
+			class="group-hover:bg-primary-500 absolute inset-x-0 top-1 h-0.5 bg-transparent transition-colors"
+		></div>
 	</div>
 
-    <!-- Header -->
-    <div class="flex items-center px-3 py-1.5 border-b border-surface-200-800 shrink-0">
-        <span class="text-sm font-semibold">Operation Timeline</span>
-        <span class="ml-2 text-xs text-surface-500">{totalEvents} event{totalEvents === 1 ? '' : 's'}</span>
-    </div>
+	<!-- Header -->
+	<div class="border-surface-200-800 flex shrink-0 items-center border-b px-3 py-1.5">
+		<span class="text-sm font-semibold">Operation Timeline</span>
+		<span class="text-surface-500 ml-2 text-xs"
+			>{totalEvents} event{totalEvents === 1 ? '' : 's'}</span
+		>
+	</div>
 
-    <!-- Entry list -->
-    <div class="overflow-y-auto flex-1 flex flex-col" bind:this={scrollEl} onscroll={onTimelineScroll}>
-        {#if entries.length === 0}
-            <div class="flex items-center justify-center h-full text-surface-500 text-sm">
-                No events yet
-            </div>
-        {:else}
-            {#each ordered as entry (entry.kind === 'action-group' ? entry.action.id : entry.id)}
-                {#if entry.kind === 'action-group'}
-                    {@const counts = effectCounts(entry)}
-                    <!-- Action group header row -->
-                    <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-                    <div
-                        class="relative flex items-start gap-2 px-3 py-2 border-b border-surface-200-800 text-sm hover:bg-surface-200-800 cursor-pointer select-none"
+	<!-- Entry list -->
+	<div
+		class="flex flex-1 flex-col overflow-y-auto"
+		bind:this={scrollEl}
+		onscroll={onTimelineScroll}
+	>
+		{#if entries.length === 0}
+			<div class="text-surface-500 flex h-full items-center justify-center text-sm">
+				No events yet
+			</div>
+		{:else}
+			{#each ordered as entry (entry.kind === 'action-group' ? entry.action.id : entry.id)}
+				{#if entry.kind === 'action-group'}
+					{@const counts = effectCounts(entry)}
+					<!-- Action group header row -->
+					<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
+					<div
+						class="border-surface-200-800 hover:bg-surface-200-800 relative flex cursor-pointer items-start gap-2 border-b px-3 py-2 text-sm select-none"
 						role="button"
 						tabindex="0"
-                        onclick={() => ontogglegroup(entry.action.id)}
+						onclick={() => ontogglegroup(entry.action.id)}
 						onkeydown={(event) => {
 							if (event.key === 'Enter' || event.key === ' ') ontogglegroup(entry.action.id);
 						}}
-                        aria-expanded={!entry.collapsed}
-                    >
-                        <!-- Chevron: sits in the left gutter rather than taking a
+						aria-expanded={!entry.collapsed}
+					>
+						<!-- Chevron: sits in the left gutter rather than taking a
                              column, so the status icon stays aligned with the icon
                              of a standalone entity row. -->
-                        {#if entry.effects.length > 0}
-                            <Icon
-                                icon={entry.collapsed ? 'mdi:chevron-right' : 'mdi:chevron-down'}
-                                class="absolute left-0 top-3 size-3 text-surface-500"
-                                aria-hidden="true"
-                            />
-                        {/if}
+						{#if entry.effects.length > 0}
+							<Icon
+								icon={entry.collapsed ? 'mdi:chevron-right' : 'mdi:chevron-down'}
+								class="text-surface-500 absolute top-3 left-0 size-3"
+								aria-hidden="true"
+							/>
+						{/if}
 
-                        <!-- Status icon -->
-                        <div class="mt-0.5 shrink-0">
-                            {#if entry.action.status === 'pending'}
-                                <Icon icon="svg-spinners:90-ring-with-bg" class="size-4" aria-hidden="true" />
-                            {:else if entry.action.status === 'success'}
-                                <Icon icon="mdi:check-circle" class="size-4 text-success-500" aria-hidden="true" />
-                            {:else}
-                                <Icon icon="mdi:close-circle" class="size-4 text-error-500" aria-hidden="true" />
-                            {/if}
-                        </div>
+						<!-- Status icon -->
+						<div class="mt-0.5 shrink-0">
+							{#if entry.action.status === 'pending'}
+								<Icon icon="svg-spinners:90-ring-with-bg" class="size-4" aria-hidden="true" />
+							{:else if entry.action.status === 'success'}
+								<Icon icon="mdi:check-circle" class="text-success-500 size-4" aria-hidden="true" />
+							{:else}
+								<Icon icon="mdi:close-circle" class="text-error-500 size-4" aria-hidden="true" />
+							{/if}
+						</div>
 
-                        <!-- Label: ttpName on target [via execSystem] -->
-                        <div class="flex-1 min-w-0">
-                            <div class="flex items-center gap-1 flex-wrap leading-tight">
-                                {#if entry.action.startup}
-                                    <span class="font-medium">{entry.action.ttpName}</span>
-                                {:else}
-                                    <button
-                                        type="button"
-                                        class="font-medium text-primary-500 hover:underline"
-                                        onclick={(event) => {
-                                            event.stopPropagation();
-                                            onviewaction(entry.action.id);
-                                        }}
-                                    >
-                                        {entry.action.ttpName}
-                                    </button>
-                                {/if}
-                                {#if entry.action.startup}
-                                    <span class="text-surface-500 text-xs">{entry.action.detail}</span>
-                                {:else}
-                                    <span class="text-surface-500">on</span>
-                                    <button
-                                        type="button"
-                                        class="text-primary-500 hover:underline truncate"
-                                        title={entry.action.targetName}
-                                        onclick={(e) => { e.stopPropagation(); onfocusentity(entry.action.targetId); }}
-                                    >
-                                        {entry.action.targetName}
-                                    </button>
-                                    {#if entry.action.execSystemName}
-                                        <span class="text-surface-500 text-xs">via</span>
-                                        <span class="text-surface-500 text-xs truncate" title={entry.action.execSystemName}>
-                                            {entry.action.execSystemName}
-                                        </span>
-                                    {/if}
-                                {/if}
-                            </div>
-                            {#if entry.action.status === 'failed' && entry.action.failReason}
-                                <div class="text-error-500 text-xs mt-0.5 truncate" title={entry.action.failReason}>
-                                    {entry.action.failReason}
-                                </div>
-                            {/if}
-                        </div>
+						<!-- Label: ttpName on target [via execSystem] -->
+						<div class="min-w-0 flex-1">
+							<div class="flex flex-wrap items-center gap-1 leading-tight">
+								{#if entry.action.startup}
+									<span class="font-medium">{entry.action.ttpName}</span>
+								{:else}
+									<button
+										type="button"
+										class="text-primary-500 font-medium hover:underline"
+										onclick={(event) => {
+											event.stopPropagation();
+											onviewaction(entry.action.id);
+										}}
+									>
+										{entry.action.ttpName}
+									</button>
+								{/if}
+								{#if entry.action.startup}
+									<span class="text-surface-500 text-xs">{entry.action.detail}</span>
+								{:else}
+									<span class="text-surface-500">on</span>
+									<button
+										type="button"
+										class="text-primary-500 truncate hover:underline"
+										title={entry.action.targetName}
+										onclick={(e) => {
+											e.stopPropagation();
+											onfocusentity(entry.action.targetId);
+										}}
+									>
+										{entry.action.targetName}
+									</button>
+									{#if entry.action.execSystemName}
+										<span class="text-surface-500 text-xs">via</span>
+										<span
+											class="text-surface-500 truncate text-xs"
+											title={entry.action.execSystemName}
+										>
+											{entry.action.execSystemName}
+										</span>
+									{/if}
+								{/if}
+							</div>
+							{#if entry.action.status === 'failed' && entry.action.failReason}
+								<div class="text-error-500 mt-0.5 truncate text-xs" title={entry.action.failReason}>
+									{entry.action.failReason}
+								</div>
+							{/if}
+						</div>
 
-                        <!-- Effect chips -->
-                        <div class="flex items-center gap-1 shrink-0 mt-0.5">
-                            {#if counts.discovery > 0}
-                                <Icon icon="mdi:magnify" class="size-3.5 text-primary-400" aria-hidden="true" />
-                                <span class="text-xs text-surface-400">{counts.discovery}</span>
-                            {/if}
-                            {#if counts.created > 0}
-                                <Icon icon="mdi:plus-circle-outline" class="size-3.5 text-tertiary-400" aria-hidden="true" />
-                                <span class="text-xs text-surface-400">{counts.created}</span>
-                            {/if}
-                            {#if counts.credential > 0}
-                                <Icon icon="mdi:key" class="size-3.5 text-warning-500" aria-hidden="true" />
-                                <span class="text-xs text-surface-400">{counts.credential}</span>
-                            {/if}
-                            {#if counts.access > 0}
-                                <Icon icon="mdi:shield-check" class="size-3.5 text-success-400" aria-hidden="true" />
-                                <span class="text-xs text-surface-400">{counts.access}</span>
-                            {/if}
-                            {#if entry.score != null}
-                                <span class="text-xs text-surface-400 ml-1">★ {entry.score.toFixed(1)}</span>
-                            {/if}
-                        </div>
+						<!-- Effect chips -->
+						<div class="mt-0.5 flex shrink-0 items-center gap-1">
+							{#if counts.discovery > 0}
+								<Icon icon="mdi:magnify" class="text-primary-400 size-3.5" aria-hidden="true" />
+								<span class="text-surface-400 text-xs">{counts.discovery}</span>
+							{/if}
+							{#if counts.created > 0}
+								<Icon
+									icon="mdi:plus-circle-outline"
+									class="text-tertiary-400 size-3.5"
+									aria-hidden="true"
+								/>
+								<span class="text-surface-400 text-xs">{counts.created}</span>
+							{/if}
+							{#if counts.credential > 0}
+								<Icon icon="mdi:key" class="text-warning-500 size-3.5" aria-hidden="true" />
+								<span class="text-surface-400 text-xs">{counts.credential}</span>
+							{/if}
+							{#if counts.access > 0}
+								<Icon
+									icon="mdi:shield-check"
+									class="text-success-400 size-3.5"
+									aria-hidden="true"
+								/>
+								<span class="text-surface-400 text-xs">{counts.access}</span>
+							{/if}
+							{#if entry.score != null}
+								<span class="text-surface-400 ml-1 text-xs">★ {entry.score.toFixed(1)}</span>
+							{/if}
+						</div>
 
-                        <!-- Timestamp -->
-                        {@render timestamp(entry.action.timestamp, entry.action.startup)}
-                    </div>
+						<!-- Timestamp -->
+						{@render timestamp(entry.action.timestamp, entry.action.startup)}
+					</div>
 
-                    <!-- Expanded child effect rows -->
-                    {#if !entry.collapsed}
-                        {#each entry.effects as effect (effect.id)}
-                            <div class="flex items-start gap-2 ml-5 pl-3.5 pr-3 py-1.5 border-b border-surface-200-800 text-sm hover:bg-surface-200-800 border-l-2 border-l-surface-300-700">
-                                <div class="mt-0.5 shrink-0">
-                                    <Icon icon={entityIcon(effect)} class={entityIconClass(effect)} aria-hidden="true" />
-                                </div>
-                                <div class="flex-1 min-w-0">
-                                    <span class="font-medium">{entityPrefix(effect)}</span> <button
-                                        type="button"
-                                        class="font-medium text-left hover:underline text-primary-500"
-                                        onclick={() => onfocusentity(effect.entityId)}
-                                    >{effect.entityName}</button>
-                                </div>
-                                {@render timestamp(effect.timestamp)}
-                            </div>
-                        {/each}
-                    {/if}
+					<!-- Expanded child effect rows -->
+					{#if !entry.collapsed}
+						{#each entry.effects as effect (effect.id)}
+							<div
+								class="border-surface-200-800 hover:bg-surface-200-800 border-l-surface-300-700 ml-5 flex items-start gap-2 border-b border-l-2 py-1.5 pr-3 pl-3.5 text-sm"
+							>
+								<div class="mt-0.5 shrink-0">
+									<Icon
+										icon={entityIcon(effect)}
+										class={entityIconClass(effect)}
+										aria-hidden="true"
+									/>
+								</div>
+								<div class="min-w-0 flex-1">
+									<span class="font-medium">{entityPrefix(effect)}</span>
+									<button
+										type="button"
+										class="text-primary-500 text-left font-medium hover:underline"
+										onclick={() => onfocusentity(effect.entityId)}>{effect.entityName}</button
+									>
+								</div>
+								{@render timestamp(effect.timestamp)}
+							</div>
+						{/each}
+					{/if}
+				{:else}
+					<!-- Standalone entity row (no parent action) -->
+					<div
+						class="border-surface-200-800 hover:bg-surface-200-800 flex items-start gap-2 border-b px-3 py-2 text-sm"
+					>
+						<div class="mt-0.5 shrink-0">
+							<Icon icon={entityIcon(entry)} class={entityIconClass(entry)} aria-hidden="true" />
+						</div>
+						<div class="min-w-0 flex-1">
+							<span class="font-medium">{entityPrefix(entry)}</span>
+							<button
+								type="button"
+								class="text-primary-500 text-left font-medium hover:underline"
+								onclick={() => onfocusentity(entry.entityId)}>{entry.entityName}</button
+							>
+						</div>
+						{@render timestamp(entry.timestamp)}
+					</div>
+				{/if}
+			{/each}
+		{/if}
+	</div>
 
-                {:else}
-                    <!-- Standalone entity row (no parent action) -->
-                    <div class="flex items-start gap-2 px-3 py-2 border-b border-surface-200-800 text-sm hover:bg-surface-200-800">
-                        <div class="mt-0.5 shrink-0">
-                            <Icon icon={entityIcon(entry)} class={entityIconClass(entry)} aria-hidden="true" />
-                        </div>
-                        <div class="flex-1 min-w-0">
-                            <span class="font-medium">{entityPrefix(entry)}</span> <button
-                                type="button"
-                                class="font-medium text-left hover:underline text-primary-500"
-                                onclick={() => onfocusentity(entry.entityId)}
-                            >{entry.entityName}</button>
-                        </div>
-                        {@render timestamp(entry.timestamp)}
-                    </div>
-                {/if}
-            {/each}
-        {/if}
-    </div>
-
-    {#if timestampTooltip}
-        <div
-            role="tooltip"
-            class="fixed z-[100] pointer-events-none -translate-x-1/2 -translate-y-full whitespace-nowrap bg-surface-100-900 border border-surface-300-700 rounded px-2 py-1 shadow-lg text-xs"
-            style="left: {timestampTooltip.left}px; top: {timestampTooltip.top}px"
-        >
-            {timestampTooltip.text}
-        </div>
-    {/if}
+	{#if timestampTooltip}
+		<div
+			role="tooltip"
+			class="bg-surface-100-900 border-surface-300-700 pointer-events-none fixed z-[100] -translate-x-1/2 -translate-y-full rounded border px-2 py-1 text-xs whitespace-nowrap shadow-lg"
+			style="left: {timestampTooltip.left}px; top: {timestampTooltip.top}px"
+		>
+			{timestampTooltip.text}
+		</div>
+	{/if}
 </div>

--- a/frontend/src/lib/components/OperationTimeline.svelte
+++ b/frontend/src/lib/components/OperationTimeline.svelte
@@ -179,7 +179,7 @@
 	// also fires when an expanded group gains child effect rows, and on scrollEl
 	// so the initial (backfilled) list lands at the bottom once mounted.
 	$effect(() => {
-		totalEvents;
+		void totalEvents;
 		if (stickToBottom && scrollEl) {
 			scrollEl.scrollTop = scrollEl.scrollHeight;
 		}
@@ -253,7 +253,6 @@
 				{#if entry.kind === 'action-group'}
 					{@const counts = effectCounts(entry)}
 					<!-- Action group header row -->
-					<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
 					<div
 						class="border-surface-200-800 hover:bg-surface-200-800 relative flex cursor-pointer items-start gap-2 border-b px-3 py-2 text-sm select-none"
 						role="button"

--- a/frontend/src/lib/components/app_menu.svelte
+++ b/frontend/src/lib/components/app_menu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { buildCampaignFlowDownload } from '$lib/campaignFlow';
 	import { getCampaignState } from '$lib/components/CampaignState.svelte';
-	import { showToast, toaster } from '$lib/components/toaster';
+	import { showToast } from '$lib/components/toaster';
 	import { saveFile } from '$lib/io';
 	import PlanPickerModal from '$lib/modals/PlanPickerModal.svelte';
 	import {

--- a/frontend/src/lib/components/app_menu.svelte
+++ b/frontend/src/lib/components/app_menu.svelte
@@ -1,26 +1,26 @@
 <script lang="ts">
-    import { buildCampaignFlowDownload } from '$lib/campaignFlow';
-    import { getCampaignState } from '$lib/components/CampaignState.svelte';
-    import { showToast, toaster } from '$lib/components/toaster';
-    import { saveFile } from '$lib/io';
-    import PlanPickerModal from '$lib/modals/PlanPickerModal.svelte';
+	import { buildCampaignFlowDownload } from '$lib/campaignFlow';
+	import { getCampaignState } from '$lib/components/CampaignState.svelte';
+	import { showToast, toaster } from '$lib/components/toaster';
+	import { saveFile } from '$lib/io';
+	import PlanPickerModal from '$lib/modals/PlanPickerModal.svelte';
 	import {
 		buildPlanDownload,
 		defaultPlanDescription,
 		defaultPlanName,
 		planFilename
 	} from '$lib/planDownload';
-    import { getRanAPI } from '$lib/ran_api';
-    import { timeline } from '$lib/stores/timelineStore.svelte';
-    import type { PlanSummary } from '$lib/api';
+	import { getRanAPI } from '$lib/ran_api';
+	import { timeline } from '$lib/stores/timelineStore.svelte';
+	import type { PlanSummary } from '$lib/api';
 	import Icon from '@iconify/svelte';
 	import { Dialog, Menu, Portal } from '@skeletonlabs/skeleton-svelte';
 	import { tick } from 'svelte';
 
-    const campaignState = getCampaignState();
-    const ranAPI = getRanAPI();
+	const campaignState = getCampaignState();
+	const ranAPI = getRanAPI();
 
-    let showPlanPicker = $state(false);
+	let showPlanPicker = $state(false);
 	let showSavePlan = $state(false);
 	let planName = $state('');
 	let planFileName = $state('');
@@ -29,33 +29,33 @@
 	let planIncludeFailed = $state(false);
 	let planSaving = $state(false);
 	let planNameInput: HTMLInputElement;
-    let plansLoading = $state(false);
-    let plans = $state<PlanSummary[]>([]);
+	let plansLoading = $state(false);
+	let plans = $state<PlanSummary[]>([]);
 
-    async function openPlanPicker() {
-        plans = [];
-        plansLoading = true;
-        showPlanPicker = true;
-        try {
-            plans = await ranAPI.ListPlans();
-        } catch (error) {
-            showToast('Failed to list plans', (error as Error).message, 'error');
-            showPlanPicker = false;
-        } finally {
-            plansLoading = false;
-        }
-    }
+	async function openPlanPicker() {
+		plans = [];
+		plansLoading = true;
+		showPlanPicker = true;
+		try {
+			plans = await ranAPI.ListPlans();
+		} catch (error) {
+			showToast('Failed to list plans', (error as Error).message, 'error');
+			showPlanPicker = false;
+		} finally {
+			plansLoading = false;
+		}
+	}
 
-    async function loadPlan(plan: PlanSummary) {
-        try {
-            await ranAPI.LoadPlan(plan.filename);
-            showToast('Plan started', plan.name, 'success');
-        } catch (error) {
-            showToast('Failed to load plan', (error as Error).message, 'error');
-        } finally {
-            showPlanPicker = false;
-        }
-    }
+	async function loadPlan(plan: PlanSummary) {
+		try {
+			await ranAPI.LoadPlan(plan.filename);
+			showToast('Plan started', plan.name, 'success');
+		} catch (error) {
+			showToast('Failed to load plan', (error as Error).message, 'error');
+		} finally {
+			showPlanPicker = false;
+		}
+	}
 
 	async function savePlan() {
 		const name = planName.trim();
@@ -97,95 +97,91 @@
 		planNameInput.select();
 	}
 
-    function onMenuClick(event: { value: string }) {
-        let { value } = event;
+	function onMenuClick(event: { value: string }) {
+		let { value } = event;
 
-        switch (value) {
-            case 'reset':
-                campaignState.reset();
-                timeline.clear();
-                break;
-            case 'load_plan':
-                openPlanPicker();
-                break;
+		switch (value) {
+			case 'reset':
+				campaignState.reset();
+				timeline.clear();
+				break;
+			case 'load_plan':
+				openPlanPicker();
+				break;
 			case 'save_plan':
 				openSavePlan();
 				break;
-            case 'save_flow':
-                campaignState
-                    .GetFlow()
-                    .then((flow) => {
-                        const download = buildCampaignFlowDownload(flow);
-                        saveFile(download.data, download.filename, download.mimeType);
-                    })
-                    .catch((error) => {
-                        console.error('Error getting flow:', error);
-                        showToast(
-                            'Failed to save flow',
-                            `Could not get flow: ${error.message}`,
-                            'error'
-                        );
-                    });
-                break;
-            default:
-                console.log('Unknown menu item:', value);
-                break;
-        }
-    }
+			case 'save_flow':
+				campaignState
+					.GetFlow()
+					.then((flow) => {
+						const download = buildCampaignFlowDownload(flow);
+						saveFile(download.data, download.filename, download.mimeType);
+					})
+					.catch((error) => {
+						console.error('Error getting flow:', error);
+						showToast('Failed to save flow', `Could not get flow: ${error.message}`, 'error');
+					});
+				break;
+			default:
+				console.log('Unknown menu item:', value);
+				break;
+		}
+	}
 </script>
 
 <Menu onSelect={onMenuClick}>
-    <Menu.Trigger class="btn hover:preset-tonal text-xl">
+	<Menu.Trigger class="btn hover:preset-tonal text-xl">
 		<Icon icon="game-icons:fishing-net" rotate={90} class="fill-token h-6 w-6 -scale-x-100" />
-        Ran
-    </Menu.Trigger>
-    <Portal>
-        <Menu.Positioner class="z-[110]">
-            <Menu.Content class="z-[110]">
-                <Menu.ItemGroup>
-                    <Menu.ItemGroupLabel>Campaign</Menu.ItemGroupLabel>
-                    <Menu.Item value="reset">
-                        <Menu.ItemText>Reset</Menu.ItemText>
-                    </Menu.Item>
-                    <Menu.Item value="load_plan">
-                        <Menu.ItemText>Load Plan</Menu.ItemText>
-                    </Menu.Item>
+		Ran
+	</Menu.Trigger>
+	<Portal>
+		<Menu.Positioner class="z-[110]">
+			<Menu.Content class="z-[110]">
+				<Menu.ItemGroup>
+					<Menu.ItemGroupLabel>Campaign</Menu.ItemGroupLabel>
+					<Menu.Item value="reset">
+						<Menu.ItemText>Reset</Menu.ItemText>
+					</Menu.Item>
+					<Menu.Item value="load_plan">
+						<Menu.ItemText>Load Plan</Menu.ItemText>
+					</Menu.Item>
 					<Menu.Item value="save_plan">
 						<Menu.ItemText>Save Plan</Menu.ItemText>
 					</Menu.Item>
-                </Menu.ItemGroup>
-                <Menu.Separator />
-                <Menu.ItemGroup>
-                    <Menu.ItemGroupLabel>Flow</Menu.ItemGroupLabel>
-                    <Menu.Item value="save_flow">
-                        <!-- <Menu.ItemIndicator>💾</Menu.ItemIndicator> -->
-                        <Menu.ItemText>Save Ran JSON</Menu.ItemText>
-                    </Menu.Item>
-                </Menu.ItemGroup>
-            </Menu.Content>
-        </Menu.Positioner>
-    </Portal>
+				</Menu.ItemGroup>
+				<Menu.Separator />
+				<Menu.ItemGroup>
+					<Menu.ItemGroupLabel>Flow</Menu.ItemGroupLabel>
+					<Menu.Item value="save_flow">
+						<!-- <Menu.ItemIndicator>💾</Menu.ItemIndicator> -->
+						<Menu.ItemText>Save Ran JSON</Menu.ItemText>
+					</Menu.Item>
+				</Menu.ItemGroup>
+			</Menu.Content>
+		</Menu.Positioner>
+	</Portal>
 </Menu>
 
 <Dialog open={showPlanPicker} onOpenChange={(e) => (showPlanPicker = e.open)}>
-    <Portal>
-        <Dialog.Backdrop class="fixed inset-0 z-50 bg-surface-50-950/50" />
-        <Dialog.Positioner class="fixed inset-0 z-50 flex justify-center items-center">
-            <Dialog.Content class="card bg-surface-100-900 p-4 space-y-2 shadow-xl max-w-2xl w-full">
-                <PlanPickerModal
-                    {plans}
-                    loading={plansLoading}
-                    onLoad={loadPlan}
-                    onClose={() => (showPlanPicker = false)}
-                />
-            </Dialog.Content>
-        </Dialog.Positioner>
-    </Portal>
+	<Portal>
+		<Dialog.Backdrop class="bg-surface-50-950/50 fixed inset-0 z-50" />
+		<Dialog.Positioner class="fixed inset-0 z-50 flex items-center justify-center">
+			<Dialog.Content class="card bg-surface-100-900 w-full max-w-2xl space-y-2 p-4 shadow-xl">
+				<PlanPickerModal
+					{plans}
+					loading={plansLoading}
+					onLoad={loadPlan}
+					onClose={() => (showPlanPicker = false)}
+				/>
+			</Dialog.Content>
+		</Dialog.Positioner>
+	</Portal>
 </Dialog>
 
 <Dialog open={showSavePlan} onOpenChange={(e) => (showSavePlan = e.open)}>
 	<Portal>
-		<Dialog.Backdrop class="fixed inset-0 z-50 bg-surface-50-950/50" />
+		<Dialog.Backdrop class="bg-surface-50-950/50 fixed inset-0 z-50" />
 		<Dialog.Positioner class="fixed inset-0 z-50 flex items-center justify-center">
 			<Dialog.Content class="card bg-surface-100-900 w-full max-w-sm space-y-4 p-5 shadow-xl">
 				<form
@@ -236,7 +232,9 @@
 						<span>Include failed actions</span>
 					</label>
 					<div class="flex justify-end gap-2">
-						<button class="btn preset-tonal" type="button" onclick={() => (showSavePlan = false)}>Cancel</button>
+						<button class="btn preset-tonal" type="button" onclick={() => (showSavePlan = false)}
+							>Cancel</button
+						>
 						<button
 							class="btn preset-filled-primary-500"
 							type="submit"

--- a/frontend/src/lib/components/attack_step_details.svelte
+++ b/frontend/src/lib/components/attack_step_details.svelte
@@ -79,7 +79,6 @@
 	}
 </script>
 
-
 {#if step != null}
 	<header class="flex-none justify-between">
 		<h4 class="h4">{step.TTP.name}</h4>
@@ -102,22 +101,22 @@
 
 		<div class="mt-4 flex items-center justify-start">
 			<div class="pr-2">Target:</div>
-			<code class="text-base inline">{target?.name}</code>
+			<code class="inline text-base">{target?.name}</code>
 		</div>
-		{#if step.executedOn != target?.name }
-		<div class="mt-4 flex items-center justify-start">
-			<div class="pr-2">Executed On:</div>
-			<code class="text-base inline">{step.executedOn}</code>
-		</div>
+		{#if step.executedOn != target?.name}
+			<div class="mt-4 flex items-center justify-start">
+				<div class="pr-2">Executed On:</div>
+				<code class="inline text-base">{step.executedOn}</code>
+			</div>
 		{/if}
 
-		<div class="mt-4 flex justify-start items-center">
-			<div class="pr-2">Started: </div>
-			<code class="text-base inline">{step.startedAt}</code>
+		<div class="mt-4 flex items-center justify-start">
+			<div class="pr-2">Started:</div>
+			<code class="inline text-base">{step.startedAt}</code>
 		</div>
-		<div class=" flex justify-start items-center">
-			<div class="pr-2">Completed: </div>
-			<code class="text-base inline">{step.completedAt}</code>
+		<div class=" flex items-center justify-start">
+			<div class="pr-2">Completed:</div>
+			<code class="inline text-base">{step.completedAt}</code>
 		</div>
 		<div class="mt-4 flex justify-start">
 			<div class="pr-2">Status</div>
@@ -125,15 +124,15 @@
 		</div>
 	</header>
 	<article class="flex min-h-10 flex-auto flex-col overflow-auto">
-			{#if step.routeReason}
-				<div class="mt-4 justify-start">
-					<div class="pr-2 mb-1">Route</div>
-					<p class="text-xs opacity-80">{step.routeReason}</p>
-				</div>
-			{/if}
+		{#if step.routeReason}
+			<div class="mt-4 justify-start">
+				<div class="mb-1 pr-2">Route</div>
+				<p class="text-xs opacity-80">{step.routeReason}</p>
+			</div>
+		{/if}
 		<div class="mt-4 justify-start">
 			{#if hasTraversal}
-				<div class="pr-2 mb-2">Traversal</div>
+				<div class="mb-2 pr-2">Traversal</div>
 				<!-- System chain: click a system to inspect the command + envelope at that hop -->
 				<div class="flex flex-wrap items-center gap-y-1">
 					{#each chainNodes as node, i}
@@ -143,21 +142,21 @@
 						<button
 							type="button"
 							class={[
-								'text-xs px-2 py-1 rounded transition-colors max-w-full truncate',
+								'max-w-full truncate rounded px-2 py-1 text-xs transition-colors',
 								selectedNodeIdx === i
 									? 'preset-filled-primary-500'
 									: 'bg-surface-200-800/50 hover:bg-surface-200-800'
 							]}
 							onclick={() => (selectedNodeIdx = i)}
-							title={node || 'C2'}
-						>{nodeLabel(node)}</button>
+							title={node || 'C2'}>{nodeLabel(node)}</button
+						>
 					{/each}
 				</div>
 
 				<!-- Detail for the selected hop (or the target's inner command) -->
-				<div class="bg-surface-100-900 rounded p-2 mt-2 space-y-2">
+				<div class="bg-surface-100-900 mt-2 space-y-2 rounded p-2">
 					{#if selectedHop}
-						<div class="flex items-center gap-2 flex-wrap text-sm">
+						<div class="flex flex-wrap items-center gap-2 text-sm">
 							<span class="opacity-70">{shortName(selectedHop.fromId)}</span>
 							<Icon icon="material-symbols:arrow-forward" width="14" class="opacity-50" />
 							<span class="opacity-70">{shortName(selectedHop.toId)}</span>
@@ -165,32 +164,32 @@
 						</div>
 						{#if selectedHop.envelope}
 							<div>
-								<div class="label opacity-60 text-xs mb-0.5">Envelope</div>
-								<code class="block text-xs whitespace-pre-wrap break-all"
+								<div class="label mb-0.5 text-xs opacity-60">Envelope</div>
+								<code class="block text-xs break-all whitespace-pre-wrap"
 									>{#each selectedHop.envelope.split('${CMD}') as part, pi}{#if pi > 0}<span
-												class="px-1 mx-0.5 rounded bg-primary-500/30 text-primary-400 font-semibold"
+												class="bg-primary-500/30 text-primary-400 mx-0.5 rounded px-1 font-semibold"
 												>{'${CMD}'}</span
 											>{/if}{redactJwt(part)}{/each}</code
 								>
 							</div>
 						{/if}
 					{:else}
-						<div class="flex items-center gap-2 flex-wrap text-sm">
+						<div class="flex flex-wrap items-center gap-2 text-sm">
 							<span class="badge preset-filled-success-500 text-xs">runs on target</span>
 							<span class="opacity-70">{shortName(chainNodes[chainNodes.length - 1])}</span>
 						</div>
 					{/if}
 					<div>
-						<div class="label opacity-60 text-xs mb-0.5">
+						<div class="label mb-0.5 text-xs opacity-60">
 							{selectedHop ? 'Command sent over this hop' : 'Command on target'}
 						</div>
-						<div class="bg-surface-50-950 relative group">
+						<div class="bg-surface-50-950 group relative">
 							<code
-								class="block w-full overflow-y-auto text-sm overflow-x-hidden whitespace-pre-wrap break-all"
+								class="block w-full overflow-x-hidden overflow-y-auto text-sm break-all whitespace-pre-wrap"
 								data-source={selectedCommand}>{redactJwt(selectedCommand)}</code
 							>
 							<button
-								class="btn absolute top-1 right-1 opacity-0 group-hover:opacity-90 transition-opacity px-1 py-0.5 bg-surface-200-800/40 hover:bg-surface-200-800/70"
+								class="btn bg-surface-200-800/40 hover:bg-surface-200-800/70 absolute top-1 right-1 px-1 py-0.5 opacity-0 transition-opacity group-hover:opacity-90"
 								data-trigger
 								onclick={handleCopy}
 								><Icon icon="material-symbols:content-copy" width="16" /></button
@@ -200,14 +199,16 @@
 				</div>
 			{:else}
 				<div class="pr-2">Command</div>
-				<div class="bg-surface-50-950 relative group">
-					<code class="h-10 w-full overflow-y-auto text-base overflow-x-hidden whitespace-pre-wrap break-all" data-source={step.command}
-						>{redactJwt(step.command)}</code>
+				<div class="bg-surface-50-950 group relative">
+					<code
+						class="h-10 w-full overflow-x-hidden overflow-y-auto text-base break-all whitespace-pre-wrap"
+						data-source={step.command}>{redactJwt(step.command)}</code
+					>
 					<button
-						class="btn absolute top-1 right-1 opacity-0 group-hover:opacity-90 transition-opacity px-1 py-0.5 bg-surface-200-800/40 hover:bg-surface-200-800/70"
+						class="btn bg-surface-200-800/40 hover:bg-surface-200-800/70 absolute top-1 right-1 px-1 py-0.5 opacity-0 transition-opacity group-hover:opacity-90"
 						data-trigger
-						onclick={handleCopy}
-						><Icon icon="material-symbols:content-copy" width="16" /></button>
+						onclick={handleCopy}><Icon icon="material-symbols:content-copy" width="16" /></button
+					>
 				</div>
 			{/if}
 		</div>
@@ -215,20 +216,22 @@
 			<span class="label mb-1 flex-none">Result:</span>
 			{#each step.results as result}
 				{#if result}
-				<div class="bg-surface-50-950 relative group">
-					<code class="w-full text-sm overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-all" data-source>
-						{result}
-					</code>
-					<button
-						class="btn absolute top-1 right-1 opacity-0 group-hover:opacity-90 transition-opacity px-1 py-0.5 bg-surface-200-800/40 hover:bg-surface-200-800/70"
-						data-trigger
-						onclick={handleCopy}
-					><Icon icon="material-symbols:content-copy" width="16" /></button>
-				</div>
+					<div class="bg-surface-50-950 group relative">
+						<code
+							class="w-full overflow-x-hidden overflow-y-auto text-sm break-all whitespace-pre-wrap"
+							data-source
+						>
+							{result}
+						</code>
+						<button
+							class="btn bg-surface-200-800/40 hover:bg-surface-200-800/70 absolute top-1 right-1 px-1 py-0.5 opacity-0 transition-opacity group-hover:opacity-90"
+							data-trigger
+							onclick={handleCopy}><Icon icon="material-symbols:content-copy" width="16" /></button
+						>
+					</div>
 				{/if}
 			{/each}
 		</div>
-
 	</article>
 	<footer class="flex-none"></footer>
 {/if}

--- a/frontend/src/lib/components/attack_step_details.svelte
+++ b/frontend/src/lib/components/attack_step_details.svelte
@@ -5,7 +5,6 @@
 
 	interface ActionDetailProps {
 		step: AttackStep;
-		icon?: any;
 	}
 
 	let { step }: ActionDetailProps = $props();

--- a/frontend/src/lib/components/flow/attack_node.svelte
+++ b/frontend/src/lib/components/flow/attack_node.svelte
@@ -3,7 +3,7 @@
 	import { iconMap } from '$lib/tactic_icons';
 	import Icon from '@iconify/svelte';
 	import type { AttackStep } from '$lib/api';
-	import {getCampaignState, type Entity} from '$lib/components/CampaignState.svelte';
+	import { getCampaignState, type Entity } from '$lib/components/CampaignState.svelte';
 
 	const campaignState = getCampaignState();
 
@@ -25,38 +25,50 @@
 	const label = $derived(data.label);
 	const step = $derived(data.step);
 	const target: Entity = $derived.by(() => {
-		const id = (step?.targetId || step?.executedOn);
-		const e = campaignState.getEntityById(id) ?? { id: "?", name: 'Unknown' };
-		return e
+		const id = step?.targetId || step?.executedOn;
+		const e = campaignState.getEntityById(id) ?? { id: '?', name: 'Unknown' };
+		return e;
 	});
 
 	const statusMap = {
 		Success: { statusBorder: 'border-green-500', icon: 'lucide:check', color: 'text-success-500' },
 		Failed: { statusBorder: 'border-red-500', icon: 'lucide:x', color: 'text-error-500' },
-		Ongoing: { statusBorder: 'border-yellow-500', icon: 'lucide:loader', color: 'text-warning-500' },
-		Unknown: { statusBorder: 'border-surface-500', icon: 'lucide:help-circle', color: 'text-surface-500' },
+		Ongoing: {
+			statusBorder: 'border-yellow-500',
+			icon: 'lucide:loader',
+			color: 'text-warning-500'
+		},
+		Unknown: {
+			statusBorder: 'border-surface-500',
+			icon: 'lucide:help-circle',
+			color: 'text-surface-500'
+		}
 	};
 	const statusInfo = $derived(statusMap[step?.status] ?? statusMap.Unknown);
 </script>
 
-<div class={['bg-surface-50-950 border-1 rounded-md border-solid px-2 py-2', statusInfo.statusBorder]}>
-		<span class="text-base">{label}</span>
-		<div class="flex items-center space-x-1">
-		<Icon icon={"game-icons:bullseye"} width="16" />
-		<pre class="max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap" title={target.name ?? 'no target'}>{target.name ?? 'no target'}</pre>
-		</div>
-		<div class="w-full flex items-left mt-2">
+<div
+	class={['bg-surface-50-950 rounded-md border-1 border-solid px-2 py-2', statusInfo.statusBorder]}
+>
+	<span class="text-base">{label}</span>
+	<div class="flex items-center space-x-1">
+		<Icon icon={'game-icons:bullseye'} width="16" />
+		<pre
+			class="max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap"
+			title={target.name ?? 'no target'}>{target.name ?? 'no target'}</pre>
+	</div>
+	<div class="items-left mt-2 flex w-full">
 		<div class="flex">
 			<span class="badge bg-surface-100-900 text-tertiary-contrast-200-800">
-				<Icon icon={iconMap[step.TTP.tactic]} width="16"/>
+				<Icon icon={iconMap[step.TTP.tactic]} width="16" />
 				{step.TTP.tactic}
 			</span>
 		</div>
 		<div class="flex-1"></div>
 		<div class="flex items-center space-x-1">
 			{#if step?.status && step.status !== 'Unknown'}
-					<Icon class={statusInfo.color} icon={statusInfo.icon} width="16" />
-				{/if}
+				<Icon class={statusInfo.color} icon={statusInfo.icon} width="16" />
+			{/if}
 		</div>
 	</div>
 

--- a/frontend/src/lib/components/flow/attack_node.svelte
+++ b/frontend/src/lib/components/flow/attack_node.svelte
@@ -9,7 +9,6 @@
 
 	interface ActionNodeData extends Record<string, unknown> {
 		step: AttackStep;
-		color: string;
 	}
 
 	interface ActionNodeProps extends NodeProps {
@@ -52,7 +51,7 @@
 >
 	<span class="text-base">{label}</span>
 	<div class="flex items-center space-x-1">
-		<Icon icon={'game-icons:bullseye'} width="16" />
+		<Icon icon="game-icons:bullseye" width="16" />
 		<pre
 			class="max-w-[200px] overflow-hidden text-ellipsis whitespace-nowrap"
 			title={target.name ?? 'no target'}>{target.name ?? 'no target'}</pre>

--- a/frontend/src/lib/components/toaster.ts
+++ b/frontend/src/lib/components/toaster.ts
@@ -3,15 +3,19 @@
 import * as toast from '@zag-js/toast';
 import { createToaster } from '@skeletonlabs/skeleton-svelte';
 
-
 export const toaster: toast.Store<any> = createToaster({
-    placement: 'bottom-end',
+	placement: 'bottom-end'
 });
 
 export type ToastType = 'info' | 'error' | 'success' | undefined;
 // export const toaster: ToastContext = getContext('toast');
 
 export function showToast(title: string, description: string, toastType: ToastType): string {
-    console.log('Showing toast', title, description, toastType);
-    return toaster.create({ title: title, description: description, type: toastType, duration: 5000 });
+	console.log('Showing toast', title, description, toastType);
+	return toaster.create({
+		title: title,
+		description: description,
+		type: toastType,
+		duration: 5000
+	});
 }

--- a/frontend/src/lib/components/tree.svelte
+++ b/frontend/src/lib/components/tree.svelte
@@ -3,7 +3,6 @@
 	import { mergeAttrs } from 'melt';
 	import Self from './tree.svelte'; // import itself for recursive rendering
 
-	type Icon = 'svelte' | 'folder' | 'js';
 	type TreeNode = {
 		id: string;
 		name?: string;
@@ -14,7 +13,6 @@
 		root?: Record<string, unknown>;
 		trigger?: Record<string, unknown>;
 		content?: Record<string, unknown>;
-		// icon: Icon;
 		children?: TreeNode[];
 	};
 

--- a/frontend/src/lib/components/tree.svelte
+++ b/frontend/src/lib/components/tree.svelte
@@ -83,19 +83,23 @@
 	{#each tree.items as item}
 		<div {...mergeAttrs(item.root ?? {}, { class: `tree-item ${level > 0 ? 'ml-2' : ''}` })}>
 			{#if item.children && item.children.length > 0}
-				<button {...(item.trigger ?? {})} class="flex" onclick={() => tree.toggleExpand(item.id)}>
+				<button {...item.trigger ?? {}} class="flex" onclick={() => tree.toggleExpand(item.id)}>
 					<span class="mx-2">{tree.isExpanded(item.id) ? '-' : '+'}</span>
 					<pre>{getNodeName(item)}</pre>
 				</button>
 			{:else if onLeafClick}
-				<button type="button" class="ml-4 chip preset-outline-surface-500" onclick={() => onLeafClick(item.mountPoint ?? '')}>{getNodeName(item)}</button>
+				<button
+					type="button"
+					class="chip preset-outline-surface-500 ml-4"
+					onclick={() => onLeafClick(item.mountPoint ?? '')}>{getNodeName(item)}</button
+				>
 			{:else}
 				<pre class="ml-6">{getNodeName(item)}</pre>
 			{/if}
 			{#if item.children && tree.isExpanded(item.id)}
-				<div {...(item.content ?? {})}>
+				<div {...item.content ?? {}}>
 					{#each item.children as child}
-						<Self node={child} level={level + 1} onLeafClick={onLeafClick} />
+						<Self node={child} level={level + 1} {onLeafClick} />
 					{/each}
 				</div>
 			{/if}

--- a/frontend/src/lib/modals/ActionParamsModal.svelte
+++ b/frontend/src/lib/modals/ActionParamsModal.svelte
@@ -14,7 +14,14 @@
 		targetId: string;
 		ttp: TTP;
 		argContext: Record<string, any>;
-		onExecute: (ttpId: string, execSystemId: string, authIdentityId: string, procedureId: string, args: Record<string, string>, executionTimeoutSeconds: number) => void;
+		onExecute: (
+			ttpId: string,
+			execSystemId: string,
+			authIdentityId: string,
+			procedureId: string,
+			args: Record<string, string>,
+			executionTimeoutSeconds: number
+		) => void;
 		onCancel: () => void;
 	}
 	let { targetId = $bindable(), ttp, argContext, onExecute, onCancel }: ParamProps = $props();
@@ -46,7 +53,7 @@
 	let procedureId = $state('');
 	let args = $state<Arg[]>([]);
 	let availableEntities: Entity[] = $state([]);
-	let namespaceArgName: string = "";
+	let namespaceArgName: string = '';
 	let selectedExecSystemId = $state('');
 	let eligibleAuthIdentities = $state<AuthIdentity[]>([]);
 	let selectedAuthIdentityId = $state('');
@@ -56,38 +63,40 @@
 	const compromisedSystems = $derived(campaignState.getCompromisedSystems());
 	const execSystemOptions = $derived<ComboboxOption[]>(
 		compromisedSystems
-			.map(e => ({ label: e.name, value: e.id, group: e.namespace }))
+			.map((e) => ({ label: e.name, value: e.id, group: e.namespace }))
 			.sort((a, b) => a.label.localeCompare(b.label))
 	);
 	const selectedExecSystem = $derived(
-		compromisedSystems.find(e => e.id === selectedExecSystemId)
+		compromisedSystems.find((e) => e.id === selectedExecSystemId)
 	);
 	const hasAdvancedSettings = $derived.by(() => {
-		const procedure = ttp.procedures?.find(candidate => candidate.id === procedureId)
-			?? ttp.procedures?.[0];
+		const procedure =
+			ttp.procedures?.find((candidate) => candidate.id === procedureId) ?? ttp.procedures?.[0];
 		return !!procedure?.command?.trim() && !procedure.isLocalCommand;
 	});
 	$effect(() => {
 		const actionId = ttp?.id;
 		const selectedTargetId = targetId;
 		const hasAuthParameter = ttp?.params?.some(
-			param => param.name === 'K8S_AUTH' && param.type === 'K8sAuth'
+			(param) => param.name === 'K8S_AUTH' && param.type === 'K8sAuth'
 		);
 		if (!actionId || !selectedTargetId || !hasAuthParameter) {
 			eligibleAuthIdentities = [];
 			selectedAuthIdentityId = '';
 			return;
 		}
-		ranAPI.GetEligibleAuthIdentities(actionId, selectedTargetId)
+		ranAPI
+			.GetEligibleAuthIdentities(actionId, selectedTargetId)
 			.then((identities) => {
 				eligibleAuthIdentities = identities;
-				const declaredIdentity = args.find(arg => arg.Name === 'K8S_AUTH')?.Value;
-				if (declaredIdentity && identities.some(identity => identity.id === declaredIdentity)) {
+				const declaredIdentity = args.find((arg) => arg.Name === 'K8S_AUTH')?.Value;
+				if (declaredIdentity && identities.some((identity) => identity.id === declaredIdentity)) {
 					selectedAuthIdentityId = declaredIdentity;
 				}
-				if (!identities.some(identity => identity.id === selectedAuthIdentityId)) {
-					const eligibleServiceAccounts = campaignState.getServiceAccountsWithTokens()
-						.filter(entity => identities.some(identity => identity.id === entity.id));
+				if (!identities.some((identity) => identity.id === selectedAuthIdentityId)) {
+					const eligibleServiceAccounts = campaignState
+						.getServiceAccountsWithTokens()
+						.filter((entity) => identities.some((identity) => identity.id === entity.id));
 					const best = findBestTokenForTTP(
 						eligibleServiceAccounts,
 						ttp.requires,
@@ -98,12 +107,13 @@
 						selectedTargetId,
 						best?.entity.id
 					);
-					authAutoSelectSource = identities.some(identity => identity.id === selectedTargetId)
-						|| identities.length === 1
-						? null
-						: best?.source ?? null;
+					authAutoSelectSource =
+						identities.some((identity) => identity.id === selectedTargetId) ||
+						identities.length === 1
+							? null
+							: (best?.source ?? null);
 				}
-				const authArgIndex = args.findIndex(arg => arg.Name === 'K8S_AUTH');
+				const authArgIndex = args.findIndex((arg) => arg.Name === 'K8S_AUTH');
 				if (authArgIndex !== -1) {
 					args = args.with(authArgIndex, {
 						...args[authArgIndex],
@@ -117,13 +127,15 @@
 			});
 	});
 
-	const target = $derived.by(() => { return campaignState.getObjectById(targetId); });
+	const target = $derived.by(() => {
+		return campaignState.getObjectById(targetId);
+	});
 
 	let argOptions: Record<string, ComboboxOption[]> = $state({});
 	// Incremented when a combobox value is set programmatically (external update),
 	// used as a {#key} to force remount so defaultValue is re-applied.
 	let argExternalVersions: Record<string, number> = $state({});
-	
+
 	// Track which args have been auto-selected to prevent infinite loops
 	let autoSelectedArgs: Set<string> = new Set();
 
@@ -159,9 +171,9 @@
 
 		// Tier 1: RBAC-based matching
 		if (requiredPerms.length > 0) {
-			const matching = availableSAs.filter(sa => {
+			const matching = availableSAs.filter((sa) => {
 				const saPerms: any[] = (sa as any).can ?? [];
-				return requiredPerms.every(req => saPermSatisfies(saPerms, req));
+				return requiredPerms.every((req) => saPermSatisfies(saPerms, req));
 			});
 			if (matching.length === 1) return { entity: matching[0], source: 'rbac' };
 			if (matching.length > 1) {
@@ -188,12 +200,12 @@
 		execSystemId: string
 	): { entity: Entity; source: 'proximity' } | undefined {
 		if (!execSystemId) return undefined;
-		const saIds = new Set(availableSAs.map(sa => sa.id));
+		const saIds = new Set(availableSAs.map((sa) => sa.id));
 
 		// Check `uses` relation from exec system to a SA
 		for (const rel of campaignState.relations.values()) {
 			if (rel.source === execSystemId && rel.kind === 'uses' && saIds.has(rel.destination)) {
-				const sa = availableSAs.find(s => s.id === rel.destination);
+				const sa = availableSAs.find((s) => s.id === rel.destination);
 				if (sa) return { entity: sa, source: 'proximity' };
 			}
 		}
@@ -202,7 +214,7 @@
 		const execEntity = campaignState.getObjectById(execSystemId);
 		const saName = (execEntity as any)?.serviceAccountName;
 		if (saName) {
-			const sa = availableSAs.find(s => s.name === saName);
+			const sa = availableSAs.find((s) => s.name === saName);
 			if (sa) return { entity: sa, source: 'proximity' };
 		}
 
@@ -210,16 +222,17 @@
 	}
 
 	function defaultExecutionSystemId(targetId: string, systems: Entity[]): string {
-		if (systems.some(system => system.id === targetId)) return targetId;
+		if (systems.some((system) => system.id === targetId)) return targetId;
 
 		// Identity-targeted actions execute on a system linked to that identity.
 		// Mirror that graph relationship in the modal so procedure availability is
 		// checked against the pod where the command will physically run.
-		const linkedSystem = systems.find(system =>
-			Array.from(campaignState.relations.values()).some(relation =>
-				relation.source === system.id &&
-				relation.destination === targetId &&
-				relation.kind === 'uses'
+		const linkedSystem = systems.find((system) =>
+			Array.from(campaignState.relations.values()).some(
+				(relation) =>
+					relation.source === system.id &&
+					relation.destination === targetId &&
+					relation.kind === 'uses'
 			)
 		);
 		if (linkedSystem) return linkedSystem.id;
@@ -230,21 +243,21 @@
 	}
 
 	let selectedNamespace = $derived.by(() => {
-		const nsArg = args.find(arg => arg.Type === 'Namespace');
+		const nsArg = args.find((arg) => arg.Type === 'Namespace');
 		return nsArg ? nsArg.Value : '';
 	});
-	
+
 	// Track the last namespace we cleared for to prevent repeated clears
 	let lastClearedNamespace = $state('');
 
 	let isAllNamespaces = $derived.by(() => {
-		const allNsArg = args.find(arg => arg.Name === 'ALL_NS');
+		const allNsArg = args.find((arg) => arg.Name === 'ALL_NS');
 		return allNsArg ? allNsArg.IsTrue : false;
 	});
 
 	function selectNamespace(ns: string) {
 		// Update args immutably so Svelte's reactivity picks up the change
-		args = args.map(a => {
+		args = args.map((a) => {
 			if (a.Type === 'Namespace') {
 				bumpArgVersion(a.Name);
 				return { ...a, Value: ns };
@@ -258,29 +271,29 @@
 		if (selectedNamespace === lastClearedNamespace) {
 			return;
 		}
-		
+
 		// Update tracking before processing
 		lastClearedNamespace = selectedNamespace;
-		
+
 		// Authentication identities can be cross-namespace and must remain stable.
 		let hasOutOfNsResources = false;
-		
+
 		for (const arg of args) {
 			if (arg.Type === 'Namespace' || arg.Name === 'TOKEN' || arg.Name === 'K8S_AUTH') continue;
-			
+
 			// Only check args that have a value
 			if (!arg.Value) continue;
-			
+
 			// Check if this arg has options (meaning it's an entity selector)
 			const options = argOptions[arg.Name];
 			if (options && options.length > 0) {
 				// Find the selected option to get its namespace (group)
-				const selectedOption = options.find(opt => opt.value === arg.Value);
+				const selectedOption = options.find((opt) => opt.value === arg.Value);
 				if (selectedOption && selectedOption.group && selectedOption.group !== selectedNamespace) {
 					hasOutOfNsResources = true;
 					break;
 				}
-			} else if (arg.Value.startsWith("ns/") && !arg.Value.startsWith(`ns/${selectedNamespace}`)) {
+			} else if (arg.Value.startsWith('ns/') && !arg.Value.startsWith(`ns/${selectedNamespace}`)) {
 				// Fallback: check ID-based resources
 				hasOutOfNsResources = true;
 				break;
@@ -288,28 +301,32 @@
 		}
 
 		if (hasOutOfNsResources) {
-			args = args.map(a => {
+			args = args.map((a) => {
 				if (a.Type === 'Namespace' || a.Name === 'TOKEN' || a.Name === 'K8S_AUTH') return a;
 				if (!a.Value) return a;
-				
+
 				// Check if this arg has options
 				const options = argOptions[a.Name];
 				if (options && options.length > 0) {
-					const selectedOption = options.find(opt => opt.value === a.Value);
-					if (selectedOption && selectedOption.group && selectedOption.group !== selectedNamespace) {
+					const selectedOption = options.find((opt) => opt.value === a.Value);
+					if (
+						selectedOption &&
+						selectedOption.group &&
+						selectedOption.group !== selectedNamespace
+					) {
 						bumpArgVersion(a.Name);
 						// Reset auto-select tracking so it can re-select in the new namespace
 						autoSelectedArgs.delete(a.Name);
-						return { ...a, Value: "" };
+						return { ...a, Value: '' };
 					}
-				} else if (a.Value.startsWith("ns/") && !a.Value.startsWith(`ns/${selectedNamespace}`)) {
+				} else if (a.Value.startsWith('ns/') && !a.Value.startsWith(`ns/${selectedNamespace}`)) {
 					// Fallback: clear ID-based resources
 					bumpArgVersion(a.Name);
 					// Reset auto-select tracking so it can re-select in the new namespace
 					autoSelectedArgs.delete(a.Name);
-					return { ...a, Value: "" };
+					return { ...a, Value: '' };
 				}
-				
+
 				return a;
 			});
 		}
@@ -319,40 +336,40 @@
 	$effect(() => {
 		// Only track args array changes, not derived values
 		const currentArgs = args;
-		
+
 		// Use untrack to avoid circular dependencies with selectedNamespace
 		untrack(() => {
 			// Check each arg to see if it has exactly one option
 			let needsUpdate = false;
 			const updates: Array<{ index: number; value: string; name: string }> = [];
-			
+
 			currentArgs.forEach((arg, i) => {
 				// Skip if it's a boolean or doesn't have options
 				if (arg.Type === 'bool') return;
-				
+
 				// Skip if we've already auto-selected this arg
 				if (autoSelectedArgs.has(arg.Name)) return;
-				
+
 				// Skip if already has a value
 				if (arg.Value && arg.Value !== '') return;
-				
+
 				const options = getArgOptions(arg.Name);
-				
+
 				// If there's exactly one option and current value doesn't match it
 				if (options.length === 1 && arg.Value !== options[0].value) {
 					updates.push({ index: i, value: options[0].value, name: arg.Name });
 					needsUpdate = true;
 				}
 			});
-			
+
 			if (needsUpdate) {
 				// Mark these args as auto-selected before updating
-				updates.forEach(u => autoSelectedArgs.add(u.name));
-				
+				updates.forEach((u) => autoSelectedArgs.add(u.name));
+
 				args = currentArgs.map((a, i) => {
-					const update = updates.find(u => u.index === i);
+					const update = updates.find((u) => u.index === i);
 					if (update) {
-						console.info("Auto-selecting single option for", update.name, ":", update.value);
+						console.info('Auto-selecting single option for', update.name, ':', update.value);
 						bumpArgVersion(update.name);
 						return { ...a, Value: update.value };
 					}
@@ -365,24 +382,24 @@
 	// Initialize args when TTP changes
 	$effect(() => {
 		const currentTtpId = ttp?.id;
-		
+
 		// Only re-initialize if TTP actually changed
 		if (currentTtpId === previousTtpId) {
 			return;
 		}
 		previousTtpId = currentTtpId;
-		
+
 		// Capture all reactive values we need before untrack
 		const ttpParams = ttp.params;
 		const ttpProcedures = ttp?.procedures;
 		const currentTargetId = targetId;
 		const currentArgContext = argContext;
-		
+
 		// Derive initial namespace from targetId, not from selectedNamespace (which depends on args)
-		const initialNamespace = currentTargetId.startsWith("ns/") ? currentTargetId.split("/")[1] : "";
-		
+		const initialNamespace = currentTargetId.startsWith('ns/') ? currentTargetId.split('/')[1] : '';
+
 		untrack(() => {
-			console.group("ActionParamsModal: Initializing args for TTP", currentTtpId);
+			console.group('ActionParamsModal: Initializing args for TTP', currentTtpId);
 
 			// Reset argOptions, external versions, auto-select tracking, and namespace tracking when TTP changes
 			argOptions = {};
@@ -392,7 +409,8 @@
 			tokenAutoSelectSource = null;
 			authAutoSelectSource = null;
 
-			args = ttpParams?.map((param: TTPParam) => {
+			args =
+				ttpParams?.map((param: TTPParam) => {
 					let value = param.default;
 					if (currentArgContext && param.name in currentArgContext) {
 						value = currentArgContext[param.name];
@@ -405,30 +423,31 @@
 							const e = parseEntityId(currentTargetId);
 							value = e?.name || '';
 						}
-						console.log("Setting target", param.name, "to value", value);
+						console.log('Setting target', param.name, 'to value', value);
 					} else if (value.indexOf('${TARGET.IP}') >= 0 && target?.ips?.[0]) {
-						value = value.replace("${TARGET.IP}", target.ips[0]);
+						value = value.replace('${TARGET.IP}', target.ips[0]);
 					}
 
 					if (param.type === 'Namespace') {
 						namespaceArgName = param.name;
 						if (
-							currentTargetId.startsWith("ns/")
-							&& (value === "" || value === "${NS}" || value === "${NAMESPACE}")
+							currentTargetId.startsWith('ns/') &&
+							(value === '' || value === '${NS}' || value === '${NAMESPACE}')
 						) {
-							value = currentTargetId.split("/")[1];
+							value = currentTargetId.split('/')[1];
 						}
 					} else if (param.type === 'Pod') {
-						availableEntities = campaignState.getPods("")
+						availableEntities = campaignState.getPods('');
 						argOptions[param.name] = availableEntities.map(entityToComboboxOption);
 					} else if (param.type === 'Listener') {
 						// Listeners are folded into their C2's node payload rather than
 						// being nodes themselves, so they are collected from there. The
 						// value is the entity id, which is what `${TARGET}` resolves to
 						// when the operator selected the listener in the graph.
-						argOptions[param.name] = allListeners(campaignState.graph?.nodes).map(
-							(listener) => ({ label: listener.entry, value: listener.id })
-						);
+						argOptions[param.name] = allListeners(campaignState.graph?.nodes).map((listener) => ({
+							label: listener.entry,
+							value: listener.id
+						}));
 					} else if (param.type === 'Redirector') {
 						// Same as Listener: redirectors ride on their C2's node payload,
 						// so the options come from there and the value is the entity id.
@@ -456,7 +475,7 @@
 				}) || [];
 
 			// Auto-select TOKEN based on RBAC requirements or exec system proximity
-			const tokenArg = args.find(a => a.Name === 'TOKEN');
+			const tokenArg = args.find((a) => a.Name === 'TOKEN');
 			if (tokenArg && !tokenArg.Value) {
 				const tokenSAs = campaignState.getServiceAccountsWithTokens();
 				const best = findBestTokenForTTP(tokenSAs, ttp.requires, selectedExecSystemId);
@@ -490,7 +509,7 @@
 			// Only re-evaluate if TOKEN was set via proximity (not RBAC or manual)
 			if (tokenAutoSelectSource !== 'proximity') return;
 
-			const tokenArgIdx = args.findIndex(a => a.Name === 'TOKEN');
+			const tokenArgIdx = args.findIndex((a) => a.Name === 'TOKEN');
 			if (tokenArgIdx === -1) return;
 
 			const tokenSAs = campaignState.getServiceAccountsWithTokens();
@@ -511,12 +530,13 @@
 		const identities = eligibleAuthIdentities;
 		untrack(() => {
 			if (authAutoSelectSource !== 'proximity') return;
-			const eligibleServiceAccounts = campaignState.getServiceAccountsWithTokens()
-				.filter(entity => identities.some(identity => identity.id === entity.id));
+			const eligibleServiceAccounts = campaignState
+				.getServiceAccountsWithTokens()
+				.filter((entity) => identities.some((identity) => identity.id === entity.id));
 			const best = findClosestToken(eligibleServiceAccounts, execId);
 			if (best && best.entity.id !== selectedAuthIdentityId) {
 				selectedAuthIdentityId = best.entity.id;
-				const authArgIndex = args.findIndex(arg => arg.Name === 'K8S_AUTH');
+				const authArgIndex = args.findIndex((arg) => arg.Name === 'K8S_AUTH');
 				if (authArgIndex !== -1) {
 					args = args.with(authArgIndex, {
 						...args[authArgIndex],
@@ -546,10 +566,15 @@
 	// namespace options
 	$effect(() => {
 		const uniqueNamespaces = availableEntities.reduce((nss: Set<string>, r) => {
-			if (r.namespace) { nss.add(r.namespace); }
+			if (r.namespace) {
+				nss.add(r.namespace);
+			}
 			return nss;
 		}, new Set<string>());
-		argOptions[namespaceArgName] = Array.from(uniqueNamespaces.values()).map(ns => ({ label: ns, value: ns }));
+		argOptions[namespaceArgName] = Array.from(uniqueNamespaces.values()).map((ns) => ({
+			label: ns,
+			value: ns
+		}));
 	});
 
 	// When the execution system changes, auto-switch to first available procedure if current is disabled
@@ -559,11 +584,11 @@
 		const procedures = ttp?.procedures;
 		if (!procedures || procedures.length <= 1) return;
 
-		const currentOk = executingSystemHasTool(procedureToolName(
-			procedures.find(p => p.id === procedureId) ?? procedures[0]
-		));
+		const currentOk = executingSystemHasTool(
+			procedureToolName(procedures.find((p) => p.id === procedureId) ?? procedures[0])
+		);
 		if (!currentOk) {
-			const first = procedures.find(p => executingSystemHasTool(procedureToolName(p)));
+			const first = procedures.find((p) => executingSystemHasTool(procedureToolName(p)));
 			if (first) {
 				procedureId = first.id;
 			}
@@ -587,12 +612,12 @@
 
 	// the args will be the final arguments used when executing the TTP
 	function onInternalExecute() {
-		const authArg = args.find(arg => arg.Name === 'K8S_AUTH');
+		const authArg = args.find((arg) => arg.Name === 'K8S_AUTH');
 		const authIdentityId = authArg?.Value || selectedAuthIdentityId;
 		const argsDict = args.reduce(
 			(acc: { [key: string]: string }, arg) => {
 				if (arg.Name === 'K8S_AUTH') return acc;
-				const isTemplateVar = arg.Value.startsWith("${") && arg.Value.endsWith("}");
+				const isTemplateVar = arg.Value.startsWith('${') && arg.Value.endsWith('}');
 				if (isTemplateVar) {
 					// if the value is a variable, do not do any conversion
 				} else if (arg.Type === 'bool') {
@@ -614,40 +639,73 @@
 					arg.Value = arg.Value.toString();
 				} else {
 					// for non-primitive types ensure the value is in the expected format
-					console.group("Processing arg", arg.Name);
-					console.info("Processing arg", arg.Name, "of type", arg.Type, "with value", arg.Value);
-					
+					console.group('Processing arg', arg.Name);
+					console.info('Processing arg', arg.Name, 'of type', arg.Type, 'with value', arg.Value);
+
 					// If parameter name ends with "Name", send the label (name) instead of the ID
-					if (arg.Name.endsWith("Name")) {
+					if (arg.Name.endsWith('Name')) {
 						const options = argOptions[arg.Name];
 						if (options) {
-							const matchingOption = options.find(opt => opt.value === arg.Value);
+							const matchingOption = options.find((opt) => opt.value === arg.Value);
 							if (matchingOption) {
 								arg.Value = matchingOption.label;
-								console.info("Parameter ends with 'Name': using label instead of ID:", matchingOption.label);
+								console.info(
+									"Parameter ends with 'Name': using label instead of ID:",
+									matchingOption.label
+								);
 							}
 						}
 					} else {
 						// Entity types should use the full ID (not just the name)
 						const entityTypes = [
-							'Pod', 'Namespace', 'ServiceAccount', 'Service', 'Deployment', 'Container',
-							'ConfigMap', 'Secret', 'Role', 'ClusterRole', 'RoleBinding', 'ClusterRoleBinding',
-							'Node', 'ClusterNode', 'Ingress', 'Daemonset', 'CronJob', 'Job', 'Statefulset',
-							'Volume', 'User', 'Group', 'KubeApiServer', 'ControlPlane', 'Listener', 'Redirector',
+							'Pod',
+							'Namespace',
+							'ServiceAccount',
+							'Service',
+							'Deployment',
+							'Container',
+							'ConfigMap',
+							'Secret',
+							'Role',
+							'ClusterRole',
+							'RoleBinding',
+							'ClusterRoleBinding',
+							'Node',
+							'ClusterNode',
+							'Ingress',
+							'Daemonset',
+							'CronJob',
+							'Job',
+							'Statefulset',
+							'Volume',
+							'User',
+							'Group',
+							'KubeApiServer',
+							'ControlPlane',
+							'Listener',
+							'Redirector',
 							// GCP resources
-							'GCPBucket', 'GCPServiceAccount', 'GCPServiceAccountToken', 'MetadataServer', 'GCPMetadataServer'
+							'GCPBucket',
+							'GCPServiceAccount',
+							'GCPServiceAccountToken',
+							'MetadataServer',
+							'GCPMetadataServer'
 						];
 						const isEntityType = entityTypes.includes(arg.Type);
-						
-						if (!isEntityType && arg.Name.toLowerCase().endsWith("name") && arg.Value.indexOf("/") !== -1) {
+
+						if (
+							!isEntityType &&
+							arg.Name.toLowerCase().endsWith('name') &&
+							arg.Value.indexOf('/') !== -1
+						) {
 							// For non-entity types, if the arg is a name, extract just the name part
-							const parts = arg.Value.split("/");
+							const parts = arg.Value.split('/');
 							arg.Value = parts[parts.length - 1];
 						}
 						// Otherwise keep the full value (ID for entities, or whatever was provided)
 					}
-					
-					console.info("Post Processed arg", arg.Name, "final value", arg.Value);
+
+					console.info('Post Processed arg', arg.Name, 'final value', arg.Value);
 					console.groupEnd();
 				}
 				acc[arg.Name] = arg.Value;
@@ -656,7 +714,14 @@
 			{} as { [key: string]: string }
 		);
 
-		onExecute(ttp.id, selectedExecSystemId, authIdentityId, procedureId, argsDict, executionTimeoutSeconds);
+		onExecute(
+			ttp.id,
+			selectedExecSystemId,
+			authIdentityId,
+			procedureId,
+			argsDict,
+			executionTimeoutSeconds
+		);
 	}
 
 	function executingSystemHasTool(tool: string): boolean {
@@ -678,39 +743,51 @@
 
 	function getArgOptions(argName: string): ComboboxOption[] {
 		let opts = argOptions[argName] ?? [];
-		if (selectedNamespace !== "" && argName !== namespaceArgName && argName !== "TOKEN" && argName !== "K8S_AUTH") {
-			opts = opts.filter(o => o.group === selectedNamespace);
+		if (
+			selectedNamespace !== '' &&
+			argName !== namespaceArgName &&
+			argName !== 'TOKEN' &&
+			argName !== 'K8S_AUTH'
+		) {
+			opts = opts.filter((o) => o.group === selectedNamespace);
 		}
-		return opts
+		return opts;
 	}
-	
+
 	function toComboBoxCollection(items: ComboboxOption[]) {
 		return useListCollection({
-		  items: items,
-		  itemToString: (item) => item.label,
-		  itemToValue: (item) => item.value,
-		  isItemDisabled: (item) => !!item.disabled,
-		  groupBy: (item) => item.group || ''
-		})
+			items: items,
+			itemToString: (item) => item.label,
+			itemToValue: (item) => item.value,
+			isItemDisabled: (item) => !!item.disabled,
+			groupBy: (item) => item.group || ''
+		});
 	}
 
 	function onArgChange(arg: Arg, e: any) {
-		console.info("Arg change event for", arg.Name, "new value", e.value[0], "selected item", e.items?.[0]);
-		
+		console.info(
+			'Arg change event for',
+			arg.Name,
+			'new value',
+			e.value[0],
+			'selected item',
+			e.items?.[0]
+		);
+
 		// Mark TOKEN as manually selected so auto-select doesn't override
 		if (arg.Name === 'TOKEN') {
 			tokenAutoSelectSource = 'manual';
 		}
 
 		// IMMUTABLE UPDATE so Svelte sees it:
-		const i = args.findIndex(a => a.Name === arg.Name);
+		const i = args.findIndex((a) => a.Name === arg.Name);
 		if (i !== -1) {
 			const newValue = e.value[0];
 			args = args.with(i, { ...args[i], Value: newValue });
 		} else {
-			console.warn("Could not find arg to update:", arg.Name);
+			console.warn('Could not find arg to update:', arg.Name);
 		}
-		
+
 		// If the chosen item carries a namespace in its group, and this is not the Namespace field itself,
 		// auto-select that namespace (but skip TOKEN which can be cross-namespace)
 		if (arg.Type !== 'Namespace' && arg.Name !== 'TOKEN') {
@@ -721,7 +798,7 @@
 			}
 		}
 
-		console.info("Updated args after change:", args);
+		console.info('Updated args after change:', args);
 
 		// arg.Value = e.value[0]
 		// if (e.items.length > 0 && e.items[0].group ) {
@@ -732,29 +809,29 @@
 	function onAuthIdentityChange(value: string) {
 		selectedAuthIdentityId = value;
 		authAutoSelectSource = 'manual';
-		const index = args.findIndex(arg => arg.Name === 'K8S_AUTH');
+		const index = args.findIndex((arg) => arg.Name === 'K8S_AUTH');
 		if (index !== -1) {
 			args = args.with(index, { ...args[index], Value: value });
 		}
 	}
 
 	function handleInputBlur(arg: Arg, inputValue: string) {
-		const i = args.findIndex(a => a.Name === arg.Name);
+		const i = args.findIndex((a) => a.Name === arg.Name);
 		if (i === -1) return;
 
 		const currentArg = args[i];
-		
+
 		// Get available options for this arg
 		let options = argOptions[arg.Name] ?? [];
-		if (selectedNamespace !== "" && arg.Name !== namespaceArgName && arg.Name !== "TOKEN") {
-			options = options.filter(o => o.group === selectedNamespace);
+		if (selectedNamespace !== '' && arg.Name !== namespaceArgName && arg.Name !== 'TOKEN') {
+			options = options.filter((o) => o.group === selectedNamespace);
 		}
-		
+
 		// Check if the input matches an option's label or value
-		const matchingOption = options.find((opt: ComboboxOption) => 
-			opt.label === inputValue || opt.value === inputValue
+		const matchingOption = options.find(
+			(opt: ComboboxOption) => opt.label === inputValue || opt.value === inputValue
 		);
-		
+
 		if (matchingOption) {
 			// Use the full value (ID) from the matching option
 			args = args.with(i, { ...currentArg, Value: matchingOption.value });
@@ -765,46 +842,68 @@
 	}
 </script>
 
-<form bind:this={formElement} class="w-full flex flex-col text-xs md:text-sm lg:text-base min-h-0" onsubmit={onInternalExecute}>
-	<header class="flex justify-between flex-shrink-0">
+<form
+	bind:this={formElement}
+	class="flex min-h-0 w-full flex-col text-xs md:text-sm lg:text-base"
+	onsubmit={onInternalExecute}
+>
+	<header class="flex flex-shrink-0 justify-between">
 		<h4 class="h4 text-sm md:text-base lg:text-lg">{ttp.name}</h4>
 	</header>
-	<article class="overflow-y-auto flex-1 min-h-0 space-y-4 pr-2">
+	<article class="min-h-0 flex-1 space-y-4 overflow-y-auto pr-2">
 		<div class="">
 			<span class="h6 label text-xs md:text-sm lg:text-base">Description</span>
 			{ttp.description}
 		</div>
-			{#if execSystemOptions.length > 0}
-				<label class="label mt-5">
-					<span class="h6 label-text text-xs md:text-sm lg:text-base">Execute On</span>
+		{#if execSystemOptions.length > 0}
+			<label class="label mt-5">
+				<span class="h6 label-text text-xs md:text-sm lg:text-base">Execute On</span>
 				{#if execSystemOptions.length === 1}
-					<input id="execSystem" class="input mt-2 text-xs md:text-sm lg:text-base" value="{execSystemOptions[0].group}/{execSystemOptions[0].label}" readonly />
+					<input
+						id="execSystem"
+						class="input mt-2 text-xs md:text-sm lg:text-base"
+						value="{execSystemOptions[0].group}/{execSystemOptions[0].label}"
+						readonly
+					/>
 				{:else if execSystemOptions.length > 1}
-					<select id="execSystem" class="input mt-2 text-xs md:text-sm lg:text-base" bind:value={selectedExecSystemId}>
+					<select
+						id="execSystem"
+						class="input mt-2 text-xs md:text-sm lg:text-base"
+						bind:value={selectedExecSystemId}
+					>
 						{#each execSystemOptions as sys (sys.value)}
 							<option value={sys.value}>{sys.group}/{sys.label}</option>
 						{/each}
 					</select>
 				{/if}
 			</label>
-			{/if}
+		{/if}
 
-			<label class="h6 label mt-5 text-xs md:text-sm lg:text-base" for="procedure">Procedure</label>
-			{#if ttp.procedures && ttp.procedures.length > 1}
-				<select id="procedure" class="input mt-2 text-xs md:text-sm lg:text-base" bind:value={procedureId} disabled={ttp.procedures.length <= 1}>
-					{#each ttp.procedures as procedure (procedure.id)}
-						<option
-							value={procedure.id}
-							disabled={!executingSystemHasTool(procedureToolName(procedure))}
-							title={unavailableToolReason(procedureToolName(procedure))}
-							>{procedureToolName(procedure)}{!executingSystemHasTool(procedureToolName(procedure)) ? ' ❌' : ''}
-						</option>
-					{/each}
-				</select>
-			{:else}
-				<code id="procedure" class="label mt-2 text-xs md:text-sm lg:text-base">{procedureToolName(ttp.procedures?.[0] ?? { id: procedureId })}</code>
-			{/if}
-			<!-- <label class="label mt-5">
+		<label class="h6 label mt-5 text-xs md:text-sm lg:text-base" for="procedure">Procedure</label>
+		{#if ttp.procedures && ttp.procedures.length > 1}
+			<select
+				id="procedure"
+				class="input mt-2 text-xs md:text-sm lg:text-base"
+				bind:value={procedureId}
+				disabled={ttp.procedures.length <= 1}
+			>
+				{#each ttp.procedures as procedure (procedure.id)}
+					<option
+						value={procedure.id}
+						disabled={!executingSystemHasTool(procedureToolName(procedure))}
+						title={unavailableToolReason(procedureToolName(procedure))}
+						>{procedureToolName(procedure)}{!executingSystemHasTool(procedureToolName(procedure))
+							? ' ❌'
+							: ''}
+					</option>
+				{/each}
+			</select>
+		{:else}
+			<code id="procedure" class="label mt-2 text-xs md:text-sm lg:text-base"
+				>{procedureToolName(ttp.procedures?.[0] ?? { id: procedureId })}</code
+			>
+		{/if}
+		<!-- <label class="label mt-5">
 				<span class="label-text">Target</span>
 				<input
 					class="input"
@@ -813,87 +912,100 @@
 					placeholder="Enter target IP or URL"
 				/>
 			</label> -->
-			{#if args.length > 0}
-					<span class="h5 text-xs md:text-sm lg:text-base">Params</span>
-{#each args as arg, index (arg.Name)}
-	<div class="input-group mt-2 grid-cols-[auto_1fr_auto] text-xs md:text-sm lg:text-base"
-		class:opacity-50={arg.Type === 'Namespace' && isAllNamespaces}
-		class:pointer-events-none={arg.Type === 'Namespace' && isAllNamespaces}
-	>
-		<div class="ig-cell preset-tonal">{arg.Name}</div>
-		{#if arg.Type === 'bool'}
-			<input
-				class="checkbox ml-8"
-				bind:checked={arg.IsTrue}
-				type="checkbox"
-				placeholder={arg.Description}
-			/>
-		{:else if arg.Type === 'K8sAuth'}
-			<select
-				id="authIdentity"
-				class="ig-input"
-				value={arg.Value}
-				onchange={(event) => onAuthIdentityChange(event.currentTarget.value)}
-				required={arg.Required}
-			>
-				{#if eligibleAuthIdentities.length !== 1}
-					<option value="" disabled>
-						{eligibleAuthIdentities.length === 0 ? 'No eligible identities' : 'Select an identity…'}
-					</option>
-				{/if}
-				{#each eligibleAuthIdentities as identity (identity.id)}
-					<option value={identity.id}>{identity.kind}: {identity.name}</option>
-				{/each}
-			</select>
-		{:else if getArgOptions(arg.Name).length > 0}
-			{#key argExternalVersions[arg.Name] ?? 0}
-				<Combobox
-					collection={toComboBoxCollection(getArgOptions(arg.Name))}
-					onValueChange={(e) => onArgChange(arg, e)}
-					inputBehavior="autocomplete"
-					allowCustomValue={true}
-					openOnChange={true}
-					defaultValue={[arg.Value]}
-					placeholder={arg.Name + "..."}
-					>
-					<Combobox.Control>
-						<Combobox.Input onblur={(e) => handleInputBlur(arg, e.currentTarget.value)} />
-						<Combobox.Trigger />
-					</Combobox.Control>
-					<Combobox.Positioner>
-						<Combobox.Content class="z-50 bg-surface-100-900 text-xs md:text-sm lg:text-base max-h-64 overflow-y-auto">
-							{#each getArgOptions(arg.Name) as item (item)}
-								<Combobox.Item {item} class="text-surface-contrast-100-900 data-[highlighted]:preset-tonal-surface data-[selected]:preset-tonal {item.disabled ? 'opacity-40 line-through' : ''}">
-									<Combobox.ItemText>{item.label}</Combobox.ItemText>
-									<Combobox.ItemIndicator />
-								</Combobox.Item>
+		{#if args.length > 0}
+			<span class="h5 text-xs md:text-sm lg:text-base">Params</span>
+			{#each args as arg, index (arg.Name)}
+				<div
+					class="input-group mt-2 grid-cols-[auto_1fr_auto] text-xs md:text-sm lg:text-base"
+					class:opacity-50={arg.Type === 'Namespace' && isAllNamespaces}
+					class:pointer-events-none={arg.Type === 'Namespace' && isAllNamespaces}
+				>
+					<div class="ig-cell preset-tonal">{arg.Name}</div>
+					{#if arg.Type === 'bool'}
+						<input
+							class="checkbox ml-8"
+							bind:checked={arg.IsTrue}
+							type="checkbox"
+							placeholder={arg.Description}
+						/>
+					{:else if arg.Type === 'K8sAuth'}
+						<select
+							id="authIdentity"
+							class="ig-input"
+							value={arg.Value}
+							onchange={(event) => onAuthIdentityChange(event.currentTarget.value)}
+							required={arg.Required}
+						>
+							{#if eligibleAuthIdentities.length !== 1}
+								<option value="" disabled>
+									{eligibleAuthIdentities.length === 0
+										? 'No eligible identities'
+										: 'Select an identity…'}
+								</option>
+							{/if}
+							{#each eligibleAuthIdentities as identity (identity.id)}
+								<option value={identity.id}>{identity.kind}: {identity.name}</option>
 							{/each}
-						</Combobox.Content>
-					</Combobox.Positioner>
-				</Combobox>
-			{/key}
-		{:else}
-			<input
-				class="ig-input"
-				bind:value={arg.Value}
-				type="text"
-				placeholder={arg.Description}
-			/>
-		{/if}
-		<!-- <input
+						</select>
+					{:else if getArgOptions(arg.Name).length > 0}
+						{#key argExternalVersions[arg.Name] ?? 0}
+							<Combobox
+								collection={toComboBoxCollection(getArgOptions(arg.Name))}
+								onValueChange={(e) => onArgChange(arg, e)}
+								inputBehavior="autocomplete"
+								allowCustomValue={true}
+								openOnChange={true}
+								defaultValue={[arg.Value]}
+								placeholder={arg.Name + '...'}
+							>
+								<Combobox.Control>
+									<Combobox.Input onblur={(e) => handleInputBlur(arg, e.currentTarget.value)} />
+									<Combobox.Trigger />
+								</Combobox.Control>
+								<Combobox.Positioner>
+									<Combobox.Content
+										class="bg-surface-100-900 z-50 max-h-64 overflow-y-auto text-xs md:text-sm lg:text-base"
+									>
+										{#each getArgOptions(arg.Name) as item (item)}
+											<Combobox.Item
+												{item}
+												class="text-surface-contrast-100-900 data-[highlighted]:preset-tonal-surface data-[selected]:preset-tonal {item.disabled
+													? 'line-through opacity-40'
+													: ''}"
+											>
+												<Combobox.ItemText>{item.label}</Combobox.ItemText>
+												<Combobox.ItemIndicator />
+											</Combobox.Item>
+										{/each}
+									</Combobox.Content>
+								</Combobox.Positioner>
+							</Combobox>
+						{/key}
+					{:else}
+						<input
+							class="ig-input"
+							bind:value={arg.Value}
+							type="text"
+							placeholder={arg.Description}
+						/>
+					{/if}
+					<!-- <input
 			class="ig-input"
 			bind:value={arg.Value}
 			type={arg.Type}
 			placeholder={arg.Description}
 		/> -->
-	</div>
-{/each}
-			{/if}
-			{#if hasAdvancedSettings}
+				</div>
+			{/each}
+		{/if}
+		{#if hasAdvancedSettings}
 			<details class="mt-4 text-xs">
-				<summary class="cursor-pointer font-normal opacity-60 hover:opacity-100">Advanced settings</summary>
+				<summary class="cursor-pointer font-normal opacity-60 hover:opacity-100"
+					>Advanced settings</summary
+				>
 				<label class="label mt-3" for="executionTimeoutSeconds">
-					<span class="label-text text-xs md:text-sm lg:text-base">Execution timeout (seconds)</span>
+					<span class="label-text text-xs md:text-sm lg:text-base">Execution timeout (seconds)</span
+					>
 					<input
 						id="executionTimeoutSeconds"
 						class="input mt-2 text-xs md:text-sm lg:text-base"
@@ -903,13 +1015,21 @@
 						required
 						bind:value={executionTimeoutSeconds}
 					/>
-					<span class="text-xs opacity-70">Maximum time allowed for the complete command. Default: 60 seconds.</span>
+					<span class="text-xs opacity-70"
+						>Maximum time allowed for the complete command. Default: 60 seconds.</span
+					>
 				</label>
 			</details>
-			{/if}
+		{/if}
 	</article>
-	<footer class="flex justify-end gap-4 flex-shrink-0 pt-4">
-		<button type="button" class="btn preset-tonal text-xs md:text-sm lg:text-base" onclick={onCancel}>Cancel</button>
-		<button type="submit" class="btn preset-filled-primary-300-700 text-xs md:text-sm lg:text-base">Execute</button>
+	<footer class="flex flex-shrink-0 justify-end gap-4 pt-4">
+		<button
+			type="button"
+			class="btn preset-tonal text-xs md:text-sm lg:text-base"
+			onclick={onCancel}>Cancel</button
+		>
+		<button type="submit" class="btn preset-filled-primary-300-700 text-xs md:text-sm lg:text-base"
+			>Execute</button
+		>
 	</footer>
 </form>

--- a/frontend/src/lib/modals/ActionParamsModal.svelte
+++ b/frontend/src/lib/modals/ActionParamsModal.svelte
@@ -41,12 +41,6 @@
 		Required?: boolean;
 	}
 
-	interface Constraint {
-		Namespace?: string;
-		Pod?: string;
-		Entitlement?: string;
-	}
-
 	const campaignState = getCampaignState();
 	const ranAPI = getRanAPI();
 
@@ -394,9 +388,6 @@
 		const ttpProcedures = ttp?.procedures;
 		const currentTargetId = targetId;
 		const currentArgContext = argContext;
-
-		// Derive initial namespace from targetId, not from selectedNamespace (which depends on args)
-		const initialNamespace = currentTargetId.startsWith('ns/') ? currentTargetId.split('/')[1] : '';
 
 		untrack(() => {
 			console.group('ActionParamsModal: Initializing args for TTP', currentTtpId);
@@ -914,7 +905,7 @@
 			</label> -->
 		{#if args.length > 0}
 			<span class="h5 text-xs md:text-sm lg:text-base">Params</span>
-			{#each args as arg, index (arg.Name)}
+			{#each args as arg (arg.Name)}
 				<div
 					class="input-group mt-2 grid-cols-[auto_1fr_auto] text-xs md:text-sm lg:text-base"
 					class:opacity-50={arg.Type === 'Namespace' && isAllNamespaces}

--- a/frontend/src/lib/modals/ExploitAppModal.svelte
+++ b/frontend/src/lib/modals/ExploitAppModal.svelte
@@ -7,7 +7,6 @@
 	// Props
 	/** Exposes parent props to this component. */
 	export let parent: SvelteComponent;
-	let exploitRequestParams = {};
 
 	const modalStore = getModalStore();
 
@@ -59,9 +58,9 @@
 			<label class="label" for="method">
 				<span>Method</span>
 				<RadioGroup active="variant-filled-primary" hover="hover:variant-soft-primary">
-					<RadioItem bind:group={exploitParams.method} name="GET" value={'GET'}>GET</RadioItem>
-					<RadioItem bind:group={exploitParams.method} name="POST" value={'POST'}>POST</RadioItem>
-					<RadioItem bind:group={exploitParams.method} name="PUT" value={'PUT'}>PUT</RadioItem>
+					<RadioItem bind:group={exploitParams.method} name="GET" value="GET">GET</RadioItem>
+					<RadioItem bind:group={exploitParams.method} name="POST" value="POST">POST</RadioItem>
+					<RadioItem bind:group={exploitParams.method} name="PUT" value="PUT">PUT</RadioItem>
 				</RadioGroup>
 			</label>
 			<label class="label">

--- a/frontend/src/lib/modals/FileViewerModal.svelte
+++ b/frontend/src/lib/modals/FileViewerModal.svelte
@@ -8,12 +8,13 @@
 	let { path, content, onClose }: FileViewerProps = $props();
 </script>
 
-<div class="space-y-4 max-w-3xl">
+<div class="max-w-3xl space-y-4">
 	<header class="flex items-center justify-between">
-		<h3 class="font-bold text-lg truncate" title={path}>{path}</h3>
+		<h3 class="truncate text-lg font-bold" title={path}>{path}</h3>
 		<button class="btn preset-outlined-surface-500 btn-sm" onclick={onClose}>✕</button>
 	</header>
-	<pre class="max-h-[70vh] overflow-auto rounded-md bg-surface-200-800 p-4 text-sm whitespace-pre-wrap break-words">{content}</pre>
+	<pre
+		class="bg-surface-200-800 max-h-[70vh] overflow-auto rounded-md p-4 text-sm break-words whitespace-pre-wrap">{content}</pre>
 	<footer class="flex justify-end">
 		<button class="btn preset-filled-surface-500" onclick={onClose}>Close</button>
 	</footer>

--- a/frontend/src/lib/modals/PlanPickerModal.svelte
+++ b/frontend/src/lib/modals/PlanPickerModal.svelte
@@ -13,34 +13,35 @@
 
 <div class="space-y-4">
 	<header class="flex items-center justify-between">
-		<h3 class="font-bold text-lg">Load Plan</h3>
+		<h3 class="text-lg font-bold">Load Plan</h3>
 		<button class="btn preset-outlined-surface-500 btn-sm" onclick={onClose}>✕</button>
 	</header>
 
-	<div class="max-h-[60vh] overflow-auto space-y-2">
+	<div class="max-h-[60vh] space-y-2 overflow-auto">
 		{#if loading}
-			<p class="opacity-70 p-4 text-center">Loading plans…</p>
+			<p class="p-4 text-center opacity-70">Loading plans…</p>
 		{:else if plans.length === 0}
-			<p class="opacity-70 p-4 text-center">
+			<p class="p-4 text-center opacity-70">
 				No plans found. Add <code>*.plan.yaml</code> files to the configured plans directory.
 			</p>
 		{:else}
 			{#each plans as plan (plan.filename)}
-				<div
-					class="flex items-center justify-between gap-4 rounded-md bg-surface-200-800 p-3"
-				>
+				<div class="bg-surface-200-800 flex items-center justify-between gap-4 rounded-md p-3">
 					<div class="min-w-0">
-						<p class="font-semibold truncate" title={plan.name}>{plan.name}</p>
+						<p class="truncate font-semibold" title={plan.name}>{plan.name}</p>
 						{#if plan.description}
-							<p class="text-sm opacity-70 truncate" title={plan.description}>
+							<p class="truncate text-sm opacity-70" title={plan.description}>
 								{plan.description}
 							</p>
 						{/if}
-						<p class="text-xs opacity-50 truncate" title={plan.filename}>
+						<p class="truncate text-xs opacity-50" title={plan.filename}>
 							{plan.filename} · {plan.steps} step{plan.steps === 1 ? '' : 's'}
 						</p>
 					</div>
-					<button class="btn preset-filled-primary-500 btn-sm shrink-0" onclick={() => onLoad(plan)}>
+					<button
+						class="btn preset-filled-primary-500 btn-sm shrink-0"
+						onclick={() => onLoad(plan)}
+					>
 						Load
 					</button>
 				</div>

--- a/frontend/src/lib/model.ts
+++ b/frontend/src/lib/model.ts
@@ -1,86 +1,80 @@
-import type { TTP } from "$lib/api/index";
+import type { TTP } from '$lib/api/index';
 
 export enum AccessLevel {
-    UserRead = 1,
-    UserWrite = 2,
-    UserExecute = 3,
-    RootWriteRead = 4,
-    RootWriteWrite = 5,
-    RootWriteExecute = 6
+	UserRead = 1,
+	UserWrite = 2,
+	UserExecute = 3,
+	RootWriteRead = 4,
+	RootWriteWrite = 5,
+	RootWriteExecute = 6
 }
-
 
 export type Param = {
-    Name: string;
-    Type: string;
-    Default: string;
-    Description: string;
-    Required: boolean;
-}
-
+	Name: string;
+	Type: string;
+	Default: string;
+	Description: string;
+	Required: boolean;
+};
 
 export type Node = {
-    id: string,
-    name: string,
-    parent?: string,
-}
+	id: string;
+	name: string;
+	parent?: string;
+};
 
 export type Edge = {
-    source: string,
-    target: string,
-    label: string
-}
-
-
+	source: string;
+	target: string;
+	label: string;
+};
 
 export type EntityId = {
-    name: string
-    namespace: string
-    kind: string
-}
+	name: string;
+	namespace: string;
+	kind: string;
+};
 
 export function parseEntityId(entityId: string): EntityId {
-    // Namespaced resource: "ns/<namespace>/<kind>/<name>"
-    // Cluster-wide resource: "<kind>/<name>"
-    
-    // Check if the string starts with "ns/" (namespaced resource)
-    if (entityId.startsWith('ns/')) {
-        // Split the string by '/'
-        const parts = entityId.split('/');
+	// Namespaced resource: "ns/<namespace>/<kind>/<name>"
+	// Cluster-wide resource: "<kind>/<name>"
 
-        // We expect at least 4 parts: ["ns", "<namespace>", "<kind>", "<name>"]
-        if (parts.length == 2) {
-            return {
-                name: parts[1],
-                namespace: '',
-                kind: 'namespace'
-            }
-        }
-        if (parts.length < 4) {
-            throw new Error('Invalid namespaced entity ID format');
-        }
+	// Check if the string starts with "ns/" (namespaced resource)
+	if (entityId.startsWith('ns/')) {
+		// Split the string by '/'
+		const parts = entityId.split('/');
 
-        // Extract the components
-        const ns = parts[1];
-        const kind = parts[2];
-        const name = parts[3];
+		// We expect at least 4 parts: ["ns", "<namespace>", "<kind>", "<name>"]
+		if (parts.length == 2) {
+			return {
+				name: parts[1],
+				namespace: '',
+				kind: 'namespace'
+			};
+		}
+		if (parts.length < 4) {
+			throw new Error('Invalid namespaced entity ID format');
+		}
 
-        return { name, namespace: ns, kind };
-    } else {
-        // Cluster-wide resource: <kind>/<name>
-        const parts = entityId.split('/');
-        
-        if (parts.length < 2) {
-            throw new Error('Invalid cluster-wide entity ID format');
-        }
-        
-        const kind = parts[0];
-        const name = parts[1];
-        
-        return { name, namespace: '', kind };
-    }
+		// Extract the components
+		const ns = parts[1];
+		const kind = parts[2];
+		const name = parts[3];
+
+		return { name, namespace: ns, kind };
+	} else {
+		// Cluster-wide resource: <kind>/<name>
+		const parts = entityId.split('/');
+
+		if (parts.length < 2) {
+			throw new Error('Invalid cluster-wide entity ID format');
+		}
+
+		const kind = parts[0];
+		const name = parts[1];
+
+		return { name, namespace: '', kind };
+	}
 }
-
-
 
 export type ArmoryType = Map<string, TTP[]>;

--- a/frontend/src/lib/redirectors.test.ts
+++ b/frontend/src/lib/redirectors.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Node } from '$lib/api/index';
-import {
-	allRedirectors,
-	redirectorHop,
-	redirectorOptions,
-	redirectorsOf
-} from './redirectors';
+import { allRedirectors, redirectorHop, redirectorOptions, redirectorsOf } from './redirectors';
 
 function redirector(playId: string, remotePort: number, listenerPort: number, via = 'labctl') {
 	return {
@@ -86,7 +81,9 @@ describe('redirectorsOf', () => {
 
 	it('still labels a redirector whose tool is unknown', () => {
 		const redirectors = redirectorsOf(
-			c2Node([{ id: 'redirector/play1/1337', playId: 'play1', remotePort: 1337, listenerPort: 4444 }])
+			c2Node([
+				{ id: 'redirector/play1/1337', playId: 'play1', remotePort: 1337, listenerPort: 4444 }
+			])
 		);
 
 		expect(redirectors[0].via).toBe('');
@@ -145,9 +142,7 @@ describe('redirectorHop', () => {
 
 describe('redirectorOptions', () => {
 	it('labels by tool and hop, leaving the playground id out', () => {
-		const options = redirectorOptions([
-			c2Node([redirector('zn1kqxk3ykpvxp5x', 9000, 4444)])
-		]);
+		const options = redirectorOptions([c2Node([redirector('zn1kqxk3ykpvxp5x', 9000, 4444)])]);
 
 		expect(options).toEqual([
 			{ label: 'labctl 9000→4444', value: 'redirector/zn1kqxk3ykpvxp5x/9000' }

--- a/frontend/src/lib/redirectors.ts
+++ b/frontend/src/lib/redirectors.ts
@@ -85,9 +85,7 @@ export function allRedirectors(nodes: Node[] | undefined): Redirector[] {
  * case the playground id is appended to those. It is noise everywhere else, so
  * it only appears where it is the thing that tells them apart.
  */
-export function redirectorOptions(
-	nodes: Node[] | undefined
-): { label: string; value: string }[] {
+export function redirectorOptions(nodes: Node[] | undefined): { label: string; value: string }[] {
 	const redirectors = allRedirectors(nodes);
 	const seen = new Map<string, number>();
 	for (const redirector of redirectors) {

--- a/frontend/src/lib/stores/timelineStore.svelte.test.ts
+++ b/frontend/src/lib/stores/timelineStore.svelte.test.ts
@@ -3,8 +3,7 @@ import {
 	TimelineStore,
 	type TtpActionEntry,
 	type EntityEntry,
-	type ActionGroup,
-	type TopEntry
+	type ActionGroup
 } from '$lib/stores/timelineStore.svelte';
 
 function makeTtpEntry(

--- a/frontend/src/lib/stores/timelineStore.svelte.test.ts
+++ b/frontend/src/lib/stores/timelineStore.svelte.test.ts
@@ -1,470 +1,466 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
-    TimelineStore,
-    type TtpActionEntry,
-    type EntityEntry,
-    type ActionGroup,
-    type TopEntry
+	TimelineStore,
+	type TtpActionEntry,
+	type EntityEntry,
+	type ActionGroup,
+	type TopEntry
 } from '$lib/stores/timelineStore.svelte';
 
 function makeTtpEntry(
-    overrides: Partial<Omit<TtpActionEntry, 'kind'>> = {}
+	overrides: Partial<Omit<TtpActionEntry, 'kind'>> = {}
 ): Omit<TtpActionEntry, 'kind'> {
-    return {
-        id: 'cmd-abc',
-        ttpId: 'list-env',
-        ttpName: 'List Environment Variables',
-        targetId: 'pod-1',
-        targetName: 'my-pod',
-        status: 'pending',
-        timestamp: new Date('2026-05-25T10:00:00Z'),
-        ...overrides
-    };
+	return {
+		id: 'cmd-abc',
+		ttpId: 'list-env',
+		ttpName: 'List Environment Variables',
+		targetId: 'pod-1',
+		targetName: 'my-pod',
+		status: 'pending',
+		timestamp: new Date('2026-05-25T10:00:00Z'),
+		...overrides
+	};
 }
 
 function makeExecutedEntry(
-    overrides: Partial<Omit<TtpActionEntry, 'kind'>> = {}
+	overrides: Partial<Omit<TtpActionEntry, 'kind'>> = {}
 ): Omit<TtpActionEntry, 'kind'> {
-    return makeTtpEntry({ status: 'success', ...overrides });
+	return makeTtpEntry({ status: 'success', ...overrides });
 }
 
 function makeEntityEntry(overrides: Partial<EntityEntry> = {}): EntityEntry {
-    return {
-        kind: 'discovery',
-        id: 'ns/default/pod/web-app',
-        entityId: 'ns/default/pod/web-app',
-        entityName: 'web-app',
-        entityKind: 'Pod',
-        timestamp: new Date('2026-05-25T10:01:00Z'),
-        ...overrides
-    };
+	return {
+		kind: 'discovery',
+		id: 'ns/default/pod/web-app',
+		entityId: 'ns/default/pod/web-app',
+		entityName: 'web-app',
+		entityKind: 'Pod',
+		timestamp: new Date('2026-05-25T10:01:00Z'),
+		...overrides
+	};
 }
 
 describe('TimelineStore', () => {
-    let store: TimelineStore;
+	let store: TimelineStore;
 
-    beforeEach(() => {
-        store = new TimelineStore();
-    });
+	beforeEach(() => {
+		store = new TimelineStore();
+	});
 
-    it('starts empty with timeline closed', () => {
-        expect(store.topEntries).toHaveLength(0);
-        expect(store.open).toBe(true);
-        expect(store.pendingCount).toBe(0);
-    });
+	it('starts empty with timeline closed', () => {
+		expect(store.topEntries).toHaveLength(0);
+		expect(store.open).toBe(true);
+		expect(store.pendingCount).toBe(0);
+	});
 
-    // addTtpAction
-    it('addTtpAction creates an ActionGroup prepended to topEntries', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
-        expect(store.topEntries).toHaveLength(1);
-        const entry = store.topEntries[0];
-        expect(entry.kind).toBe('action-group');
-        if (entry.kind === 'action-group') {
-            expect(entry.action.id).toBe('cmd-1');
-            expect(entry.effects).toHaveLength(0);
-            expect(entry.collapsed).toBe(true);
-        }
-    });
+	// addTtpAction
+	it('addTtpAction creates an ActionGroup prepended to topEntries', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
+		expect(store.topEntries).toHaveLength(1);
+		const entry = store.topEntries[0];
+		expect(entry.kind).toBe('action-group');
+		if (entry.kind === 'action-group') {
+			expect(entry.action.id).toBe('cmd-1');
+			expect(entry.effects).toHaveLength(0);
+			expect(entry.collapsed).toBe(true);
+		}
+	});
 
-    it('addTtpAction prepends newest first', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-2' }));
-        expect(store.topEntries[0].kind).toBe('action-group');
-        if (store.topEntries[0].kind === 'action-group') {
-            expect(store.topEntries[0].action.id).toBe('cmd-2');
-        }
-    });
+	it('addTtpAction prepends newest first', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-2' }));
+		expect(store.topEntries[0].kind).toBe('action-group');
+		if (store.topEntries[0].kind === 'action-group') {
+			expect(store.topEntries[0].action.id).toBe('cmd-2');
+		}
+	});
 
-    // addEntityEvent - grouping
-    it('addEntityEvent with matching cmdId appends to group effects', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
-        store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-abc' }));
-        expect(store.topEntries).toHaveLength(1); // still one top-level entry
-        const entry = store.topEntries[0];
-        if (entry.kind === 'action-group') {
-            expect(entry.effects).toHaveLength(1);
-            expect(entry.effects[0].entityName).toBe('web-app');
-        }
-    });
+	// addEntityEvent - grouping
+	it('addEntityEvent with matching cmdId appends to group effects', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
+		store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-abc' }));
+		expect(store.topEntries).toHaveLength(1); // still one top-level entry
+		const entry = store.topEntries[0];
+		if (entry.kind === 'action-group') {
+			expect(entry.effects).toHaveLength(1);
+			expect(entry.effects[0].entityName).toBe('web-app');
+		}
+	});
 
-    it('addEntityEvent without cmdId prepends as standalone', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
-        store.addEntityEvent(makeEntityEntry({ cmdId: undefined }));
-        expect(store.topEntries).toHaveLength(2);
-        expect(store.topEntries[0].kind).toBe('discovery');
-    });
+	it('addEntityEvent without cmdId prepends as standalone', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
+		store.addEntityEvent(makeEntityEntry({ cmdId: undefined }));
+		expect(store.topEntries).toHaveLength(2);
+		expect(store.topEntries[0].kind).toBe('discovery');
+	});
 
-    it('addEntityEvent with unmatched cmdId prepends as standalone', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
-        store.addEntityEvent(makeEntityEntry({ id: 'x', entityId: 'x', cmdId: 'cmd-unknown' }));
-        expect(store.topEntries).toHaveLength(2);
-        expect(store.topEntries[0].kind).toBe('discovery');
-    });
+	it('addEntityEvent with unmatched cmdId prepends as standalone', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
+		store.addEntityEvent(makeEntityEntry({ id: 'x', entityId: 'x', cmdId: 'cmd-unknown' }));
+		expect(store.topEntries).toHaveLength(2);
+		expect(store.topEntries[0].kind).toBe('discovery');
+	});
 
-    // deduplication
-    it('addEntityEvent deduplicates standalone entries by id', () => {
-        store.addEntityEvent(makeEntityEntry({ id: 'pod-a', entityId: 'pod-a', cmdId: undefined }));
-        store.addEntityEvent(makeEntityEntry({ id: 'pod-a', entityId: 'pod-a', cmdId: undefined }));
-        expect(store.topEntries).toHaveLength(1);
-    });
+	// deduplication
+	it('addEntityEvent deduplicates standalone entries by id', () => {
+		store.addEntityEvent(makeEntityEntry({ id: 'pod-a', entityId: 'pod-a', cmdId: undefined }));
+		store.addEntityEvent(makeEntityEntry({ id: 'pod-a', entityId: 'pod-a', cmdId: undefined }));
+		expect(store.topEntries).toHaveLength(1);
+	});
 
-    it('addEntityEvent deduplicates group effects by id', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
-        store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-abc' }));
-        store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-abc' })); // same id
-        const entry = store.topEntries[0];
-        if (entry.kind === 'action-group') {
-            expect(entry.effects).toHaveLength(1);
-        }
-    });
+	it('addEntityEvent deduplicates group effects by id', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
+		store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-abc' }));
+		store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-abc' })); // same id
+		const entry = store.topEntries[0];
+		if (entry.kind === 'action-group') {
+			expect(entry.effects).toHaveLength(1);
+		}
+	});
 
-    // addEntityEvent — outcomes
-    it('folds an entity the action created into that action instead of a standalone row', () => {
-        // The reported noise: creating a listener showed "Create Listener" and
-        // then a separate "Discovered Listener" right next to it.
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-listen', ttpName: 'Create Listener' }));
-        store.addEntityEvent(
-            makeEntityEntry({
-                kind: 'discovery',
-                outcome: 'created',
-                id: 'listener/tcp/1337',
-                entityId: 'listener/tcp/1337',
-                entityName: 'tcp/1337',
-                entityKind: 'Listener',
-                cmdId: 'cmd-listen'
-            })
-        );
+	// addEntityEvent - outcomes
+	it('folds an entity the action created into that action instead of a standalone row', () => {
+		// The reported noise: creating a listener showed "Create Listener" and
+		// then a separate "Discovered Listener" right next to it.
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-listen', ttpName: 'Create Listener' }));
+		store.addEntityEvent(
+			makeEntityEntry({
+				kind: 'discovery',
+				outcome: 'created',
+				id: 'listener/tcp/1337',
+				entityId: 'listener/tcp/1337',
+				entityName: 'tcp/1337',
+				entityKind: 'Listener',
+				cmdId: 'cmd-listen'
+			})
+		);
 
-        expect(store.topEntries).toHaveLength(1);
-        const group = store.topEntries[0] as ActionGroup;
-        expect(group.kind).toBe('action-group');
-        expect(group.effects).toHaveLength(1);
-        expect(group.effects[0].outcome).toBe('created');
-    });
+		expect(store.topEntries).toHaveLength(1);
+		const group = store.topEntries[0] as ActionGroup;
+		expect(group.kind).toBe('action-group');
+		expect(group.effects).toHaveLength(1);
+		expect(group.effects[0].outcome).toBe('created');
+	});
 
-    it('keeps a created entity visible as a standalone row when its action is unknown', () => {
-        // Losing the fact entirely would be worse than showing it; it is just
-        // never labelled a discovery.
-        store.addEntityEvent(
-            makeEntityEntry({
-                outcome: 'created',
-                id: 'listener/tcp/1337',
-                entityId: 'listener/tcp/1337',
-                entityKind: 'Listener',
-                cmdId: 'cmd-that-never-registered'
-            })
-        );
-        expect(store.topEntries).toHaveLength(1);
-        expect(store.topEntries[0].kind).toBe('discovery');
-    });
+	it('keeps a created entity visible as a standalone row when its action is unknown', () => {
+		// Losing the fact entirely would be worse than showing it; it is just
+		// never labelled a discovery.
+		store.addEntityEvent(
+			makeEntityEntry({
+				outcome: 'created',
+				id: 'listener/tcp/1337',
+				entityId: 'listener/tcp/1337',
+				entityKind: 'Listener',
+				cmdId: 'cmd-that-never-registered'
+			})
+		);
+		expect(store.topEntries).toHaveLength(1);
+		expect(store.topEntries[0].kind).toBe('discovery');
+	});
 
-    it('drops an update to an already-known entity that has no action to sit under', () => {
-        store.addEntityEvent(
-            makeEntityEntry({ outcome: 'updated', cmdId: 'session/node-a-4444' })
-        );
-        expect(store.topEntries).toHaveLength(0);
-    });
+	it('drops an update to an already-known entity that has no action to sit under', () => {
+		store.addEntityEvent(makeEntityEntry({ outcome: 'updated', cmdId: 'session/node-a-4444' }));
+		expect(store.topEntries).toHaveLength(0);
+	});
 
-    it('keeps an update inside its action group so the expanded view stays complete', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
-        store.addEntityEvent(makeEntityEntry({ outcome: 'updated', cmdId: 'cmd-abc' }));
+	it('keeps an update inside its action group so the expanded view stays complete', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
+		store.addEntityEvent(makeEntityEntry({ outcome: 'updated', cmdId: 'cmd-abc' }));
 
-        const group = store.topEntries[0] as ActionGroup;
-        expect(group.effects).toHaveLength(1);
-        expect(group.effects[0].outcome).toBe('updated');
-    });
+		const group = store.topEntries[0] as ActionGroup;
+		expect(group.effects).toHaveLength(1);
+		expect(group.effects[0].outcome).toBe('updated');
+	});
 
-    it('shows a shell caught on an already-known host, despite the update outcome', () => {
-        // A reverse shell arrives under its backend id, which never matches an
-        // action group, and updates a host the campaign already had. Suppressing
-        // it as a mere update would silently drop the single most significant
-        // event in a campaign.
-        store.addEntityEvent(
-            makeEntityEntry({
-                kind: 'access-gained',
-                outcome: 'updated',
-                id: 'node/worker-1',
-                entityId: 'node/worker-1',
-                entityName: 'worker-1',
-                entityKind: 'K8sNode',
-                cmdId: 'session/worker-1-4444'
-            })
-        );
+	it('shows a shell caught on an already-known host, despite the update outcome', () => {
+		// A reverse shell arrives under its backend id, which never matches an
+		// action group, and updates a host the campaign already had. Suppressing
+		// it as a mere update would silently drop the single most significant
+		// event in a campaign.
+		store.addEntityEvent(
+			makeEntityEntry({
+				kind: 'access-gained',
+				outcome: 'updated',
+				id: 'node/worker-1',
+				entityId: 'node/worker-1',
+				entityName: 'worker-1',
+				entityKind: 'K8sNode',
+				cmdId: 'session/worker-1-4444'
+			})
+		);
 
-        expect(store.topEntries).toHaveLength(1);
-        expect(store.topEntries[0].kind).toBe('access-gained');
-    });
+		expect(store.topEntries).toHaveLength(1);
+		expect(store.topEntries[0].kind).toBe('access-gained');
+	});
 
-    it('shows a found credential on a known entity for the same reason', () => {
-        store.addEntityEvent(
-            makeEntityEntry({
-                kind: 'credential',
-                outcome: 'updated',
-                id: 'secret/default/api-key',
-                entityId: 'secret/default/api-key',
-                entityKind: 'Secret',
-                cmdId: 'cmd-that-never-registered'
-            })
-        );
-        expect(store.topEntries).toHaveLength(1);
-    });
+	it('shows a found credential on a known entity for the same reason', () => {
+		store.addEntityEvent(
+			makeEntityEntry({
+				kind: 'credential',
+				outcome: 'updated',
+				id: 'secret/default/api-key',
+				entityId: 'secret/default/api-key',
+				entityKind: 'Secret',
+				cmdId: 'cmd-that-never-registered'
+			})
+		);
+		expect(store.topEntries).toHaveLength(1);
+	});
 
-    it('does not consume the dedup slot for an update it dropped', () => {
-        // A later, genuine observation of the same entity must still get through.
-        store.addEntityEvent(
-            makeEntityEntry({ outcome: 'updated', cmdId: 'cmd-that-never-registered' })
-        );
-        store.addEntityEvent(makeEntityEntry({ outcome: 'observed', cmdId: undefined }));
-        expect(store.topEntries).toHaveLength(1);
-        expect((store.topEntries[0] as EntityEntry).outcome).toBe('observed');
-    });
+	it('does not consume the dedup slot for an update it dropped', () => {
+		// A later, genuine observation of the same entity must still get through.
+		store.addEntityEvent(
+			makeEntityEntry({ outcome: 'updated', cmdId: 'cmd-that-never-registered' })
+		);
+		store.addEntityEvent(makeEntityEntry({ outcome: 'observed', cmdId: undefined }));
+		expect(store.topEntries).toHaveLength(1);
+		expect((store.topEntries[0] as EntityEntry).outcome).toBe('observed');
+	});
 
-    it('treats an entry with no outcome as observed', () => {
-        store.addEntityEvent(makeEntityEntry({ cmdId: undefined }));
-        expect(store.topEntries).toHaveLength(1);
-    });
+	it('treats an entry with no outcome as observed', () => {
+		store.addEntityEvent(makeEntityEntry({ cmdId: undefined }));
+		expect(store.topEntries).toHaveLength(1);
+	});
 
-    it('addEntityEvent does not suppress entity when a group has the same id as the entity', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'ns/default/pod/web-app' }));
-        store.addEntityEvent(
-            makeEntityEntry({
-                id: 'ns/default/pod/web-app',
-                entityId: 'ns/default/pod/web-app',
-                cmdId: undefined
-            })
-        );
-        expect(store.topEntries).toHaveLength(2);
-        expect(store.topEntries[0].kind).toBe('discovery');
-    });
+	it('addEntityEvent does not suppress entity when a group has the same id as the entity', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'ns/default/pod/web-app' }));
+		store.addEntityEvent(
+			makeEntityEntry({
+				id: 'ns/default/pod/web-app',
+				entityId: 'ns/default/pod/web-app',
+				cmdId: undefined
+			})
+		);
+		expect(store.topEntries).toHaveLength(2);
+		expect(store.topEntries[0].kind).toBe('discovery');
+	});
 
-    // pendingCount
-    it('pendingCount counts only pending action groups', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-1', status: 'pending' }));
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-2', status: 'pending' }));
-        store.addEntityEvent(makeEntityEntry({ cmdId: undefined }));
-        expect(store.pendingCount).toBe(2);
-        store.recordExecutedTtp(makeExecutedEntry({ id: 'cmd-1', status: 'success' }));
-        expect(store.pendingCount).toBe(1);
-    });
+	// pendingCount
+	it('pendingCount counts only pending action groups', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-1', status: 'pending' }));
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-2', status: 'pending' }));
+		store.addEntityEvent(makeEntityEntry({ cmdId: undefined }));
+		expect(store.pendingCount).toBe(2);
+		store.recordExecutedTtp(makeExecutedEntry({ id: 'cmd-1', status: 'success' }));
+		expect(store.pendingCount).toBe(1);
+	});
 
-    // recordExecutedTtp
-    it('recordExecutedTtp marks matching pending group as success', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc', status: 'pending' }));
-        store.recordExecutedTtp(makeExecutedEntry({ id: 'cmd-abc', status: 'success' }));
-        expect(store.topEntries).toHaveLength(1);
-        const entry = store.topEntries[0];
-        if (entry.kind === 'action-group') {
-            expect(entry.action.status).toBe('success');
-            expect(entry.action.failReason).toBeUndefined();
-        }
-    });
+	// recordExecutedTtp
+	it('recordExecutedTtp marks matching pending group as success', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc', status: 'pending' }));
+		store.recordExecutedTtp(makeExecutedEntry({ id: 'cmd-abc', status: 'success' }));
+		expect(store.topEntries).toHaveLength(1);
+		const entry = store.topEntries[0];
+		if (entry.kind === 'action-group') {
+			expect(entry.action.status).toBe('success');
+			expect(entry.action.failReason).toBeUndefined();
+		}
+	});
 
-    it('recordExecutedTtp marks matching pending group as failed with reason', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc', status: 'pending' }));
-        store.recordExecutedTtp(
-            makeExecutedEntry({ id: 'cmd-abc', status: 'failed', failReason: 'permission denied' })
-        );
-        const entry = store.topEntries[0];
-        if (entry.kind === 'action-group') {
-            expect(entry.action.status).toBe('failed');
-            expect(entry.action.failReason).toBe('permission denied');
-        }
-    });
+	it('recordExecutedTtp marks matching pending group as failed with reason', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc', status: 'pending' }));
+		store.recordExecutedTtp(
+			makeExecutedEntry({ id: 'cmd-abc', status: 'failed', failReason: 'permission denied' })
+		);
+		const entry = store.topEntries[0];
+		if (entry.kind === 'action-group') {
+			expect(entry.action.status).toBe('failed');
+			expect(entry.action.failReason).toBe('permission denied');
+		}
+	});
 
-    it('recordExecutedTtp on already-resolved entry is a no-op', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc', status: 'success' }));
-        store.recordExecutedTtp(
-            makeExecutedEntry({ id: 'cmd-abc', status: 'failed', failReason: 'should not change' })
-        );
-        const entry = store.topEntries[0];
-        if (entry.kind === 'action-group') {
-            expect(entry.action.status).toBe('success');
-        }
-    });
+	it('recordExecutedTtp on already-resolved entry is a no-op', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc', status: 'success' }));
+		store.recordExecutedTtp(
+			makeExecutedEntry({ id: 'cmd-abc', status: 'failed', failReason: 'should not change' })
+		);
+		const entry = store.topEntries[0];
+		if (entry.kind === 'action-group') {
+			expect(entry.action.status).toBe('success');
+		}
+	});
 
-    // recordExecutedTtp creating entries for non-UI actions (MCP / autonomous plans)
-    it('recordExecutedTtp creates a resolved entry when no pending entry exists', () => {
-        store.recordExecutedTtp(
-            makeExecutedEntry({ id: 'cmd-mcp', ttpName: 'List Pods', status: 'success' })
-        );
-        expect(store.topEntries).toHaveLength(1);
-        const entry = store.topEntries[0];
-        expect(entry.kind).toBe('action-group');
-        if (entry.kind === 'action-group') {
-            expect(entry.action.id).toBe('cmd-mcp');
-            expect(entry.action.ttpName).toBe('List Pods');
-            expect(entry.action.status).toBe('success');
-        }
-    });
+	// recordExecutedTtp creating entries for non-UI actions (MCP / autonomous plans)
+	it('recordExecutedTtp creates a resolved entry when no pending entry exists', () => {
+		store.recordExecutedTtp(
+			makeExecutedEntry({ id: 'cmd-mcp', ttpName: 'List Pods', status: 'success' })
+		);
+		expect(store.topEntries).toHaveLength(1);
+		const entry = store.topEntries[0];
+		expect(entry.kind).toBe('action-group');
+		if (entry.kind === 'action-group') {
+			expect(entry.action.id).toBe('cmd-mcp');
+			expect(entry.action.ttpName).toBe('List Pods');
+			expect(entry.action.status).toBe('success');
+		}
+	});
 
-    it('recordExecutedTtp-created entry groups subsequent effects by cmdId', () => {
-        store.recordExecutedTtp(makeExecutedEntry({ id: 'cmd-mcp', status: 'success' }));
-        store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-mcp' }));
-        expect(store.topEntries).toHaveLength(1);
-        const entry = store.topEntries[0];
-        if (entry.kind === 'action-group') {
-            expect(entry.effects).toHaveLength(1);
-            expect(entry.effects[0].entityName).toBe('web-app');
-        }
-    });
+	it('recordExecutedTtp-created entry groups subsequent effects by cmdId', () => {
+		store.recordExecutedTtp(makeExecutedEntry({ id: 'cmd-mcp', status: 'success' }));
+		store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-mcp' }));
+		expect(store.topEntries).toHaveLength(1);
+		const entry = store.topEntries[0];
+		if (entry.kind === 'action-group') {
+			expect(entry.effects).toHaveLength(1);
+			expect(entry.effects[0].entityName).toBe('web-app');
+		}
+	});
 
-    it('recordExecutedTtp before addTtpAction (SSE beats HTTP) keeps resolved status and enriches names', () => {
-        // SSE arrives first with the target id but no friendly target name.
-        store.recordExecutedTtp(
-            makeExecutedEntry({
-                id: 'cmd-abc',
-                targetName: 'pod-1',
-                status: 'failed',
-                failReason: 'shell write failed: broken pipe'
-            })
-        );
-        // HTTP response follows with the names the UI knows.
-        store.addTtpAction(
-            makeTtpEntry({ id: 'cmd-abc', targetName: 'my-pod', status: 'pending' })
-        );
-        expect(store.topEntries).toHaveLength(1);
-        const entry = store.topEntries[0];
-        if (entry.kind === 'action-group') {
-            expect(entry.action.status).toBe('failed');
-            expect(entry.action.failReason).toBe('shell write failed: broken pipe');
-            expect(entry.action.targetName).toBe('my-pod');
-        }
-    });
+	it('recordExecutedTtp before addTtpAction (SSE beats HTTP) keeps resolved status and enriches names', () => {
+		// SSE arrives first with the target id but no friendly target name.
+		store.recordExecutedTtp(
+			makeExecutedEntry({
+				id: 'cmd-abc',
+				targetName: 'pod-1',
+				status: 'failed',
+				failReason: 'shell write failed: broken pipe'
+			})
+		);
+		// HTTP response follows with the names the UI knows.
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc', targetName: 'my-pod', status: 'pending' }));
+		expect(store.topEntries).toHaveLength(1);
+		const entry = store.topEntries[0];
+		if (entry.kind === 'action-group') {
+			expect(entry.action.status).toBe('failed');
+			expect(entry.action.failReason).toBe('shell write failed: broken pipe');
+			expect(entry.action.targetName).toBe('my-pod');
+		}
+	});
 
-    // toggleGroup
-    it('toggleGroup flips collapsed from true to false', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
-        store.toggleGroup('cmd-abc');
-        const entry = store.topEntries[0];
-        if (entry.kind === 'action-group') {
-            expect(entry.collapsed).toBe(false);
-        }
-    });
+	// toggleGroup
+	it('toggleGroup flips collapsed from true to false', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
+		store.toggleGroup('cmd-abc');
+		const entry = store.topEntries[0];
+		if (entry.kind === 'action-group') {
+			expect(entry.collapsed).toBe(false);
+		}
+	});
 
-    it('toggleGroup flips collapsed from false to true', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
-        store.toggleGroup('cmd-abc'); // false
-        store.toggleGroup('cmd-abc'); // true
-        const entry = store.topEntries[0];
-        if (entry.kind === 'action-group') {
-            expect(entry.collapsed).toBe(true);
-        }
-    });
+	it('toggleGroup flips collapsed from false to true', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
+		store.toggleGroup('cmd-abc'); // false
+		store.toggleGroup('cmd-abc'); // true
+		const entry = store.topEntries[0];
+		if (entry.kind === 'action-group') {
+			expect(entry.collapsed).toBe(true);
+		}
+	});
 
-    it('toggleGroup with unknown id is a no-op', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
-        expect(() => store.toggleGroup('cmd-unknown')).not.toThrow();
-    });
+	it('toggleGroup with unknown id is a no-op', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-abc' }));
+		expect(() => store.toggleGroup('cmd-unknown')).not.toThrow();
+	});
 
-    it('backfill restores discovered entities as expandable action effects', () => {
-        store.backfill([
-            {
-                id: 'cmd-get-pods',
-                ttpId: 'get-pods',
-                ttpName: 'GetPods',
-                targetId: 'cluster-1',
-                targetName: 'cluster-1',
-                success: true,
-                timestampMs: 1,
-                effects: [
-                    {
-                        kind: 'discovery',
-                        id: 'pod/default/web',
-                        entityId: 'pod/default/web',
-                        entityName: 'web',
-                        entityKind: 'Pod'
-                    }
-                ]
-            }
-        ]);
+	it('backfill restores discovered entities as expandable action effects', () => {
+		store.backfill([
+			{
+				id: 'cmd-get-pods',
+				ttpId: 'get-pods',
+				ttpName: 'GetPods',
+				targetId: 'cluster-1',
+				targetName: 'cluster-1',
+				success: true,
+				timestampMs: 1,
+				effects: [
+					{
+						kind: 'discovery',
+						id: 'pod/default/web',
+						entityId: 'pod/default/web',
+						entityName: 'web',
+						entityKind: 'Pod'
+					}
+				]
+			}
+		]);
 
-        const group = store.topEntries[0] as ActionGroup;
-        expect(group.effects).toHaveLength(1);
-        expect(group.collapsed).toBe(true);
-        store.toggleGroup('cmd-get-pods');
-        expect(group.collapsed).toBe(false);
-    });
+		const group = store.topEntries[0] as ActionGroup;
+		expect(group.effects).toHaveLength(1);
+		expect(group.collapsed).toBe(true);
+		store.toggleGroup('cmd-get-pods');
+		expect(group.collapsed).toBe(false);
+	});
 
-    // startup kubeconfig backfill
-    it('backfillBootstrap creates an oldest successful group with discovery effects', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-live' }));
-        store.backfillBootstrap([
-            {
-                id: 'bootstrap:kubeconfig:developer',
-                name: 'Read kubeconfig',
-                detail: 'developer (context: demo)',
-                effects: [
-                    {
-                        entityId: 'k8s/credential/developer',
-                        entityName: 'developer',
-                        entityKind: 'K8sCredential',
-                        category: 'credential'
-                    },
-                    {
-                        entityId: 'k8s/cluster/demo',
-                        entityName: 'demo',
-                        entityKind: 'Cluster',
-                        category: 'discovery'
-                    },
-                    {
-                        entityId: 'ns/default',
-                        entityName: 'default',
-                        entityKind: 'Namespace',
-                        category: 'discovery'
-                    }
-                ]
-            }
-        ]);
+	// startup kubeconfig backfill
+	it('backfillBootstrap creates an oldest successful group with discovery effects', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-live' }));
+		store.backfillBootstrap([
+			{
+				id: 'bootstrap:kubeconfig:developer',
+				name: 'Read kubeconfig',
+				detail: 'developer (context: demo)',
+				effects: [
+					{
+						entityId: 'k8s/credential/developer',
+						entityName: 'developer',
+						entityKind: 'K8sCredential',
+						category: 'credential'
+					},
+					{
+						entityId: 'k8s/cluster/demo',
+						entityName: 'demo',
+						entityKind: 'Cluster',
+						category: 'discovery'
+					},
+					{
+						entityId: 'ns/default',
+						entityName: 'default',
+						entityKind: 'Namespace',
+						category: 'discovery'
+					}
+				]
+			}
+		]);
 
-        expect(store.topEntries).toHaveLength(2);
-        const startup = store.topEntries[1];
-        expect(startup.kind).toBe('action-group');
-        if (startup.kind === 'action-group') {
-            expect(startup.action.startup).toBe(true);
-            expect(startup.action.timestamp).toBeInstanceOf(Date);
-            expect(startup.effects.map((effect) => effect.entityKind)).toEqual([
-                'K8sCredential',
-                'Cluster',
-                'Namespace'
-            ]);
-        }
-    });
+		expect(store.topEntries).toHaveLength(2);
+		const startup = store.topEntries[1];
+		expect(startup.kind).toBe('action-group');
+		if (startup.kind === 'action-group') {
+			expect(startup.action.startup).toBe(true);
+			expect(startup.action.timestamp).toBeInstanceOf(Date);
+			expect(startup.effects.map((effect) => effect.entityKind)).toEqual([
+				'K8sCredential',
+				'Cluster',
+				'Namespace'
+			]);
+		}
+	});
 
-    it('backfillBootstrap is idempotent and can repopulate after clear', () => {
-        const operations = [
-            {
-                id: 'bootstrap:kubeconfig:developer',
-                name: 'Read kubeconfig',
-                detail: 'developer',
-                effects: []
-            }
-        ];
-        store.backfillBootstrap(operations);
-        store.backfillBootstrap(operations);
-        expect(store.topEntries).toHaveLength(1);
-        store.clear();
-        store.backfillBootstrap(operations);
-        expect(store.topEntries).toHaveLength(1);
-    });
+	it('backfillBootstrap is idempotent and can repopulate after clear', () => {
+		const operations = [
+			{
+				id: 'bootstrap:kubeconfig:developer',
+				name: 'Read kubeconfig',
+				detail: 'developer',
+				effects: []
+			}
+		];
+		store.backfillBootstrap(operations);
+		store.backfillBootstrap(operations);
+		expect(store.topEntries).toHaveLength(1);
+		store.clear();
+		store.backfillBootstrap(operations);
+		expect(store.topEntries).toHaveLength(1);
+	});
 
-    // clear
-    it('clear removes all entries', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
-        store.addEntityEvent(makeEntityEntry({ cmdId: undefined }));
-        store.clear();
-        expect(store.topEntries).toHaveLength(0);
-        // index is also cleared: new entity with old cmdId goes to standalone
-        store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-1' }));
-        expect(store.topEntries).toHaveLength(1);
-        expect(store.topEntries[0].kind).toBe('discovery');
-    });
+	// clear
+	it('clear removes all entries', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
+		store.addEntityEvent(makeEntityEntry({ cmdId: undefined }));
+		store.clear();
+		expect(store.topEntries).toHaveLength(0);
+		// index is also cleared: new entity with old cmdId goes to standalone
+		store.addEntityEvent(makeEntityEntry({ cmdId: 'cmd-1' }));
+		expect(store.topEntries).toHaveLength(1);
+		expect(store.topEntries[0].kind).toBe('discovery');
+	});
 
-    // mixed ordering
-    it('mixed entries interleave by insertion order, newest first', () => {
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
-        store.addEntityEvent(makeEntityEntry({ id: 'pod-a', entityId: 'pod-a', cmdId: undefined }));
-        store.addTtpAction(makeTtpEntry({ id: 'cmd-2' }));
-        const ids = store.topEntries.map((e) => (e.kind === 'action-group' ? e.action.id : e.id));
-        expect(ids).toEqual(['cmd-2', 'pod-a', 'cmd-1']);
-    });
+	// mixed ordering
+	it('mixed entries interleave by insertion order, newest first', () => {
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-1' }));
+		store.addEntityEvent(makeEntityEntry({ id: 'pod-a', entityId: 'pod-a', cmdId: undefined }));
+		store.addTtpAction(makeTtpEntry({ id: 'cmd-2' }));
+		const ids = store.topEntries.map((e) => (e.kind === 'action-group' ? e.action.id : e.id));
+		expect(ids).toEqual(['cmd-2', 'pod-a', 'cmd-1']);
+	});
 });

--- a/frontend/src/lib/stores/timelineStore.svelte.ts
+++ b/frontend/src/lib/stores/timelineStore.svelte.ts
@@ -1,19 +1,19 @@
 import type { BootstrapOperation } from '$lib/api';
 
 export type TtpActionEntry = {
-    kind: 'ttp-action';
-    id: string;
-    ttpId: string;
-    ttpName: string;
-    targetId: string;
-    targetName: string;
-    execSystemId?: string;
-    execSystemName?: string;
-    status: 'pending' | 'success' | 'failed';
-    failReason?: string;
-    timestamp?: Date;
-    startup?: boolean;
-    detail?: string;
+	kind: 'ttp-action';
+	id: string;
+	ttpId: string;
+	ttpName: string;
+	targetId: string;
+	targetName: string;
+	execSystemId?: string;
+	execSystemName?: string;
+	status: 'pending' | 'success' | 'failed';
+	failReason?: string;
+	timestamp?: Date;
+	startup?: boolean;
+	detail?: string;
 };
 
 /**
@@ -26,254 +26,254 @@ export type TtpActionEntry = {
 export type FactOutcome = 'observed' | 'created' | 'updated';
 
 export type EntityEntry = {
-    kind: 'discovery' | 'credential' | 'access-gained';
-    /** Defaults to `observed` so pre-outcome records keep their old meaning. */
-    outcome?: FactOutcome;
-    id: string;
-    entityId: string;
-    entityName: string;
-    entityKind: string;
-    cmdId?: string;
-    timestamp?: Date;
+	kind: 'discovery' | 'credential' | 'access-gained';
+	/** Defaults to `observed` so pre-outcome records keep their old meaning. */
+	outcome?: FactOutcome;
+	id: string;
+	entityId: string;
+	entityName: string;
+	entityKind: string;
+	cmdId?: string;
+	timestamp?: Date;
 };
 
 export type ActionGroup = {
-    kind: 'action-group';
-    action: TtpActionEntry;
-    effects: EntityEntry[];
-    collapsed: boolean;
-    score?: number;
+	kind: 'action-group';
+	action: TtpActionEntry;
+	effects: EntityEntry[];
+	collapsed: boolean;
+	score?: number;
 };
 
 export type TopEntry = ActionGroup | EntityEntry;
 
 /** A historical execution distilled to what the timeline needs to replay it. */
 export type BackfillRecord = {
-    id: string;
-    ttpId: string;
-    ttpName: string;
-    targetId: string;
-    targetName: string;
-    execSystemId?: string;
-    execSystemName?: string;
-    success: boolean;
-    failReason?: string;
-    timestampMs: number;
-    effects?: Array<Omit<EntityEntry, 'cmdId' | 'timestamp'>>;
+	id: string;
+	ttpId: string;
+	ttpName: string;
+	targetId: string;
+	targetName: string;
+	execSystemId?: string;
+	execSystemName?: string;
+	success: boolean;
+	failReason?: string;
+	timestampMs: number;
+	effects?: Array<Omit<EntityEntry, 'cmdId' | 'timestamp'>>;
 };
 
 /** An in-flight (dispatched, not yet completed) action to seed as pending. */
 export type PendingRecord = Omit<BackfillRecord, 'success' | 'failReason'>;
 
 export class TimelineStore {
-    topEntries = $state<TopEntry[]>([]);
-    open = $state(true);
+	topEntries = $state<TopEntry[]>([]);
+	open = $state(true);
 
-    private index = new Map<string, ActionGroup>();
-    private seenEntityIds = new Set<string>();
+	private index = new Map<string, ActionGroup>();
+	private seenEntityIds = new Set<string>();
 
-    pendingCount = $derived(
-        this.topEntries.filter(
-            (e): e is ActionGroup => e.kind === 'action-group' && e.action.status === 'pending'
-        ).length
-    );
+	pendingCount = $derived(
+		this.topEntries.filter(
+			(e): e is ActionGroup => e.kind === 'action-group' && e.action.status === 'pending'
+		).length
+	);
 
-    /** Prepend a fresh action group and return the reactive proxy stored in the index. */
-    private createGroup(entry: Omit<TtpActionEntry, 'kind'>): ActionGroup {
-        const action: TtpActionEntry = { kind: 'ttp-action', ...entry };
-        const group: ActionGroup = { kind: 'action-group', action, effects: [], collapsed: true };
-        this.topEntries = [group, ...this.topEntries];
-        const proxy = this.topEntries[0] as ActionGroup;
-        this.index.set(entry.id, proxy);
-        return proxy;
-    }
+	/** Prepend a fresh action group and return the reactive proxy stored in the index. */
+	private createGroup(entry: Omit<TtpActionEntry, 'kind'>): ActionGroup {
+		const action: TtpActionEntry = { kind: 'ttp-action', ...entry };
+		const group: ActionGroup = { kind: 'action-group', action, effects: [], collapsed: true };
+		this.topEntries = [group, ...this.topEntries];
+		const proxy = this.topEntries[0] as ActionGroup;
+		this.index.set(entry.id, proxy);
+		return proxy;
+	}
 
-    addTtpAction(entry: Omit<TtpActionEntry, 'kind'>): void {
-        // The ttp-executed SSE may have already created (and resolved) this entry
-        // if it beat the HTTP response. Enrich it with the names the UI knows
-        // rather than creating a duplicate, and leave the resolved status intact.
-        const existing = this.index.get(entry.id);
-        if (existing) {
-            existing.action.ttpId = entry.ttpId;
-            existing.action.ttpName = entry.ttpName;
-            existing.action.targetId = entry.targetId;
-            existing.action.targetName = entry.targetName;
-            if (entry.execSystemId) {
-                existing.action.execSystemId = entry.execSystemId;
-                existing.action.execSystemName = entry.execSystemName;
-            }
-            return;
-        }
-        this.createGroup(entry);
-    }
+	addTtpAction(entry: Omit<TtpActionEntry, 'kind'>): void {
+		// The ttp-executed SSE may have already created (and resolved) this entry
+		// if it beat the HTTP response. Enrich it with the names the UI knows
+		// rather than creating a duplicate, and leave the resolved status intact.
+		const existing = this.index.get(entry.id);
+		if (existing) {
+			existing.action.ttpId = entry.ttpId;
+			existing.action.ttpName = entry.ttpName;
+			existing.action.targetId = entry.targetId;
+			existing.action.targetName = entry.targetName;
+			if (entry.execSystemId) {
+				existing.action.execSystemId = entry.execSystemId;
+				existing.action.execSystemName = entry.execSystemName;
+			}
+			return;
+		}
+		this.createGroup(entry);
+	}
 
-    addEntityEvent(entry: EntityEntry): void {
-        // Global dedup: each entity id appears at most once across all groups and standalone rows.
-        // This matches the previous flat-list dedup behaviour. Reset on clear().
-        if (this.seenEntityIds.has(entry.id)) return;
+	addEntityEvent(entry: EntityEntry): void {
+		// Global dedup: each entity id appears at most once across all groups and standalone rows.
+		// This matches the previous flat-list dedup behaviour. Reset on clear().
+		if (this.seenEntityIds.has(entry.id)) return;
 
-        const outcome = entry.outcome ?? 'observed';
-        const group = entry.cmdId ? this.index.get(entry.cmdId) : undefined;
+		const outcome = entry.outcome ?? 'observed';
+		const group = entry.cmdId ? this.index.get(entry.cmdId) : undefined;
 
-        // An update to something already on screen is not news *about the
-        // entity* — but the category can carry news of its own. Catching a shell
-        // on a host the campaign already knew updates nothing and still matters,
-        // so suppression is scoped to plain discoveries; without that clause the
-        // most significant event in a campaign renders as nothing at all.
-        const isNewsInItself = entry.kind === 'access-gained' || entry.kind === 'credential';
-        if (outcome === 'updated' && !group && !isNewsInItself) return;
+		// An update to something already on screen is not news *about the
+		// entity* - but the category can carry news of its own. Catching a shell
+		// on a host the campaign already knew updates nothing and still matters,
+		// so suppression is scoped to plain discoveries; without that clause the
+		// most significant event in a campaign renders as nothing at all.
+		const isNewsInItself = entry.kind === 'access-gained' || entry.kind === 'credential';
+		if (outcome === 'updated' && !group && !isNewsInItself) return;
 
-        this.seenEntityIds.add(entry.id);
+		this.seenEntityIds.add(entry.id);
 
-        if (group) {
-            group.effects.push(entry);
-            return;
-        }
+		if (group) {
+			group.effects.push(entry);
+			return;
+		}
 
-        // No group to fold into: still worth a row (a created listener whose
-        // action never registered, or a host that called back on its own), and
-        // `entityPrefix` labels it by outcome rather than calling it a discovery.
-        this.topEntries = [entry, ...this.topEntries];
-    }
+		// No group to fold into: still worth a row (a created listener whose
+		// action never registered, or a host that called back on its own), and
+		// `entityPrefix` labels it by outcome rather than calling it a discovery.
+		this.topEntries = [entry, ...this.topEntries];
+	}
 
-    /**
-     * Record a completed TTP execution (driven by the `ttp-executed` SSE).
-     *
-     * Resolves the matching pending entry when the action was initiated from
-     * this UI. When no entry exists - e.g. the action was fired via the MCP
-     * server or an autonomous plan - it creates a new, already-resolved entry
-     * so MCP-driven actions show up in the timeline, not just the flow page.
-     */
-    recordExecutedTtp(entry: Omit<TtpActionEntry, 'kind'>): void {
-        const existing = this.index.get(entry.id);
-        if (existing) {
-            if (existing.action.status === 'pending') {
-                existing.action.status = entry.status;
-                if (entry.status === 'failed') existing.action.failReason = entry.failReason;
-            }
-            return;
-        }
-        this.createGroup(entry);
-    }
+	/**
+	 * Record a completed TTP execution (driven by the `ttp-executed` SSE).
+	 *
+	 * Resolves the matching pending entry when the action was initiated from
+	 * this UI. When no entry exists - e.g. the action was fired via the MCP
+	 * server or an autonomous plan - it creates a new, already-resolved entry
+	 * so MCP-driven actions show up in the timeline, not just the flow page.
+	 */
+	recordExecutedTtp(entry: Omit<TtpActionEntry, 'kind'>): void {
+		const existing = this.index.get(entry.id);
+		if (existing) {
+			if (existing.action.status === 'pending') {
+				existing.action.status = entry.status;
+				if (entry.status === 'failed') existing.action.failReason = entry.failReason;
+			}
+			return;
+		}
+		this.createGroup(entry);
+	}
 
-    /**
-     * Seed the timeline with the campaign's existing execution history.
-     *
-     * The store is otherwise live-only: it just listens to SSE events that
-     * arrive after the UI connects, so a session attached to an already-running
-     * campaign would start blank. This replays the persisted records - newest
-     * last so the prepend in `recordExecutedTtp` leaves them newest-first - and
-     * is idempotent via the per-id index, so it's safe to call alongside any
-     * live `ttp-executed` events that race in.
-     */
-    backfill(records: BackfillRecord[]): void {
-        const ordered = [...records].sort((a, b) => a.timestampMs - b.timestampMs);
-        for (const r of ordered) {
-            this.recordExecutedTtp({
-                id: r.id,
-                ttpId: r.ttpId,
-                ttpName: r.ttpName,
-                targetId: r.targetId,
-                targetName: r.targetName,
-                execSystemId: r.execSystemId,
-                execSystemName: r.execSystemName,
-                status: r.success ? 'success' : 'failed',
-                failReason: r.success ? undefined : r.failReason,
-                timestamp: new Date(r.timestampMs)
-            });
-            for (const effect of r.effects ?? []) {
-                this.addEntityEvent({
-                    ...effect,
-                    cmdId: r.id,
-                    timestamp: new Date(r.timestampMs)
-                });
-            }
-        }
-    }
+	/**
+	 * Seed the timeline with the campaign's existing execution history.
+	 *
+	 * The store is otherwise live-only: it just listens to SSE events that
+	 * arrive after the UI connects, so a session attached to an already-running
+	 * campaign would start blank. This replays the persisted records - newest
+	 * last so the prepend in `recordExecutedTtp` leaves them newest-first - and
+	 * is idempotent via the per-id index, so it's safe to call alongside any
+	 * live `ttp-executed` events that race in.
+	 */
+	backfill(records: BackfillRecord[]): void {
+		const ordered = [...records].sort((a, b) => a.timestampMs - b.timestampMs);
+		for (const r of ordered) {
+			this.recordExecutedTtp({
+				id: r.id,
+				ttpId: r.ttpId,
+				ttpName: r.ttpName,
+				targetId: r.targetId,
+				targetName: r.targetName,
+				execSystemId: r.execSystemId,
+				execSystemName: r.execSystemName,
+				status: r.success ? 'success' : 'failed',
+				failReason: r.success ? undefined : r.failReason,
+				timestamp: new Date(r.timestampMs)
+			});
+			for (const effect of r.effects ?? []) {
+				this.addEntityEvent({
+					...effect,
+					cmdId: r.id,
+					timestamp: new Date(r.timestampMs)
+				});
+			}
+		}
+	}
 
-    /**
-     * Seed in-flight actions as pending entries (driven by `/api/flow`'s
-     * `Ongoing` steps on load). Routed through `addTtpAction` so it's idempotent
-     * against a live `ttp-dispatched` for the same id, and so the eventual
-     * `ttp-executed` resolves the entry in place. Oldest-first so the prepend
-     * leaves the most recently dispatched on top.
-     */
-    backfillPending(records: PendingRecord[]): void {
-        const ordered = [...records].sort((a, b) => a.timestampMs - b.timestampMs);
-        for (const r of ordered) {
-            this.addTtpAction({
-                id: r.id,
-                ttpId: r.ttpId,
-                ttpName: r.ttpName,
-                targetId: r.targetId,
-                targetName: r.targetName,
-                execSystemId: r.execSystemId,
-                execSystemName: r.execSystemName,
-                status: 'pending',
-                timestamp: new Date(r.timestampMs)
-            });
-        }
-    }
+	/**
+	 * Seed in-flight actions as pending entries (driven by `/api/flow`'s
+	 * `Ongoing` steps on load). Routed through `addTtpAction` so it's idempotent
+	 * against a live `ttp-dispatched` for the same id, and so the eventual
+	 * `ttp-executed` resolves the entry in place. Oldest-first so the prepend
+	 * leaves the most recently dispatched on top.
+	 */
+	backfillPending(records: PendingRecord[]): void {
+		const ordered = [...records].sort((a, b) => a.timestampMs - b.timestampMs);
+		for (const r of ordered) {
+			this.addTtpAction({
+				id: r.id,
+				ttpId: r.ttpId,
+				ttpName: r.ttpName,
+				targetId: r.targetId,
+				targetName: r.targetName,
+				execSystemId: r.execSystemId,
+				execSystemName: r.execSystemName,
+				status: 'pending',
+				timestamp: new Date(r.timestampMs)
+			});
+		}
+	}
 
-    /**
-     * Add durable kubeconfig loads that happened before the frontend connected.
-     * Startup groups live at the oldest end of the newest-first store and use
-     * stable backend IDs, so repeated campaign-state refreshes are idempotent.
-     */
-    backfillBootstrap(operations: BootstrapOperation[]): void {
-        const timestamp = new Date();
-        for (const operation of [...operations].sort((a, b) => b.id.localeCompare(a.id))) {
-            if (this.index.has(operation.id)) continue;
+	/**
+	 * Add durable kubeconfig loads that happened before the frontend connected.
+	 * Startup groups live at the oldest end of the newest-first store and use
+	 * stable backend IDs, so repeated campaign-state refreshes are idempotent.
+	 */
+	backfillBootstrap(operations: BootstrapOperation[]): void {
+		const timestamp = new Date();
+		for (const operation of [...operations].sort((a, b) => b.id.localeCompare(a.id))) {
+			if (this.index.has(operation.id)) continue;
 
-            const group: ActionGroup = {
-                kind: 'action-group',
-                action: {
-                    kind: 'ttp-action',
-                    id: operation.id,
-                    ttpId: '',
-                    ttpName: operation.name,
-                    targetId: '',
-                    targetName: '',
-                    status: 'success',
-                    startup: true,
-                    detail: operation.detail,
-                    timestamp
-                },
-                effects: [],
-                collapsed: true
-            };
-            this.topEntries = [...this.topEntries, group];
-            const proxy = this.topEntries[this.topEntries.length - 1] as ActionGroup;
-            this.index.set(operation.id, proxy);
+			const group: ActionGroup = {
+				kind: 'action-group',
+				action: {
+					kind: 'ttp-action',
+					id: operation.id,
+					ttpId: '',
+					ttpName: operation.name,
+					targetId: '',
+					targetName: '',
+					status: 'success',
+					startup: true,
+					detail: operation.detail,
+					timestamp
+				},
+				effects: [],
+				collapsed: true
+			};
+			this.topEntries = [...this.topEntries, group];
+			const proxy = this.topEntries[this.topEntries.length - 1] as ActionGroup;
+			this.index.set(operation.id, proxy);
 
-            for (const effect of operation.effects) {
-                if (this.seenEntityIds.has(effect.entityId)) continue;
-                this.seenEntityIds.add(effect.entityId);
-                proxy.effects.push({
-                    kind: effect.category === 'credential' ? 'credential' : 'discovery',
-                    id: effect.entityId,
-                    entityId: effect.entityId,
-                    entityName: effect.entityName,
-                    entityKind: effect.entityKind
-                });
-            }
-        }
-    }
+			for (const effect of operation.effects) {
+				if (this.seenEntityIds.has(effect.entityId)) continue;
+				this.seenEntityIds.add(effect.entityId);
+				proxy.effects.push({
+					kind: effect.category === 'credential' ? 'credential' : 'discovery',
+					id: effect.entityId,
+					entityId: effect.entityId,
+					entityName: effect.entityName,
+					entityKind: effect.entityKind
+				});
+			}
+		}
+	}
 
-    toggleGroup(cmdId: string): void {
-        for (const entry of this.topEntries) {
-            if (entry.kind === 'action-group' && entry.action.id === cmdId) {
-                entry.collapsed = !entry.collapsed;
-                return;
-            }
-        }
-    }
+	toggleGroup(cmdId: string): void {
+		for (const entry of this.topEntries) {
+			if (entry.kind === 'action-group' && entry.action.id === cmdId) {
+				entry.collapsed = !entry.collapsed;
+				return;
+			}
+		}
+	}
 
-    clear(): void {
-        this.topEntries = [];
-        this.index.clear();
-        this.seenEntityIds.clear();
-    }
+	clear(): void {
+		this.topEntries = [];
+		this.index.clear();
+		this.seenEntityIds.clear();
+	}
 }
 
 export const timeline = new TimelineStore();

--- a/frontend/src/lib/tactic_icons.ts
+++ b/frontend/src/lib/tactic_icons.ts
@@ -1,16 +1,15 @@
-
 export const iconMap: Record<string, string> = {
-    'Resource Development': 'healthicons:entry-outline',
-    'Initial Access': 'material-symbols:door-open-outline',
-    Discovery: 'material-symbols:schema-outline',
-    Execution: 'material-symbols:settings-slow-motion',
-    Persistence: 'game-icons:life-jacket',
-    'Privilege Escalation': 'mdi:account-arrow-up',
-    'Defense Evasion': 'game-icons:hood',
-    'Credential Access': 'mdi:key-chain-variant',
-    'Command And Control': 'material-symbols:satellite-alt',
-    Collection: 'game-icons:receive-money',
-    'Lateral Movement': 'material-symbols:timeline',
-    Impact: 'game-icons:falling-bomb',
-    Other: 'game-icons:dig-dug'
+	'Resource Development': 'healthicons:entry-outline',
+	'Initial Access': 'material-symbols:door-open-outline',
+	Discovery: 'material-symbols:schema-outline',
+	Execution: 'material-symbols:settings-slow-motion',
+	Persistence: 'game-icons:life-jacket',
+	'Privilege Escalation': 'mdi:account-arrow-up',
+	'Defense Evasion': 'game-icons:hood',
+	'Credential Access': 'mdi:key-chain-variant',
+	'Command And Control': 'material-symbols:satellite-alt',
+	Collection: 'game-icons:receive-money',
+	'Lateral Movement': 'material-symbols:timeline',
+	Impact: 'game-icons:falling-bomb',
+	Other: 'game-icons:dig-dug'
 };

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,157 +1,168 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-    import { AppBar, Toast, Switch } from '@skeletonlabs/skeleton-svelte';
-    import {setContext} from 'svelte';
-    import { page } from '$app/state';
-    import IconMap from '~icons/game-icons/treasure-map';
-    import IconSteps from '~icons/game-icons/footsteps';
-    import IconSun from '~icons/material-symbols/light-mode';
-    import IconMoon from '~icons/material-symbols/dark-mode';
-    import { browser } from '$app/environment';
-    import { toaster } from '$lib/components/toaster';
-    import Icon from '@iconify/svelte';
-    import '../app.css';
-    import { setCampaignState } from '$lib/components/CampaignState.svelte';
+	import { onMount } from 'svelte';
+	import { AppBar, Toast, Switch } from '@skeletonlabs/skeleton-svelte';
+	import { setContext } from 'svelte';
+	import { page } from '$app/state';
+	import IconMap from '~icons/game-icons/treasure-map';
+	import IconSteps from '~icons/game-icons/footsteps';
+	import IconSun from '~icons/material-symbols/light-mode';
+	import IconMoon from '~icons/material-symbols/dark-mode';
+	import { browser } from '$app/environment';
+	import { toaster } from '$lib/components/toaster';
+	import Icon from '@iconify/svelte';
+	import '../app.css';
+	import { setCampaignState } from '$lib/components/CampaignState.svelte';
 	import AppMenu from '$lib/components/app_menu.svelte';
-    import { timeline } from '$lib/stores/timelineStore.svelte';
-    let { children } = $props();
+	import { timeline } from '$lib/stores/timelineStore.svelte';
+	let { children } = $props();
 
-    setCampaignState();
+	setCampaignState();
 
-    let isDark: boolean = $state(false)
+	let isDark: boolean = $state(false);
 
-    function toggle(details: { checked: boolean }) {
-        isDark = details.checked;
-        if (browser) {
-            localStorage.setItem('theme', isDark ? 'dark' : 'light');
-            updateBodyTheme();
-        }
-    }
+	function toggle(details: { checked: boolean }) {
+		isDark = details.checked;
+		if (browser) {
+			localStorage.setItem('theme', isDark ? 'dark' : 'light');
+			updateBodyTheme();
+		}
+	}
 
-    function updateBodyTheme() {
-        if (browser) {
-            document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
-            document.documentElement.classList.toggle('dark', isDark);
-        }
-    }
+	function updateBodyTheme() {
+		if (browser) {
+			document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
+			document.documentElement.classList.toggle('dark', isDark);
+		}
+	}
 
-    setContext('theme', { get isDark() { return isDark }, toggle });
+	setContext('theme', {
+		get isDark() {
+			return isDark;
+		},
+		toggle
+	});
 
-    let mediaQuery: MediaQueryList | null = $state(null);
+	let mediaQuery: MediaQueryList | null = $state(null);
 	let mediaQueryHandler: ((event: MediaQueryListEvent) => void) | null = null;
-    onMount(() => {
-        if (browser) {
-            // Priority: localStorage > system preference
-            const stored = localStorage.getItem('theme');
+	onMount(() => {
+		if (browser) {
+			// Priority: localStorage > system preference
+			const stored = localStorage.getItem('theme');
 
-            if (stored) {
-                isDark = stored === 'dark';
-            } else {
-                mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
-                isDark = mediaQuery.matches;
+			if (stored) {
+				isDark = stored === 'dark';
+			} else {
+				mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+				isDark = mediaQuery.matches;
 
-                mediaQueryHandler = (event: MediaQueryListEvent) => {
-                    // Only update from system preference if user hasn't set explicit preference
-                    if (!localStorage.getItem('theme')) {
-                        isDark = event.matches;
-                        updateBodyTheme();
-                    }
-                };
-                mediaQuery.addEventListener("change", mediaQueryHandler);
-            }
+				mediaQueryHandler = (event: MediaQueryListEvent) => {
+					// Only update from system preference if user hasn't set explicit preference
+					if (!localStorage.getItem('theme')) {
+						isDark = event.matches;
+						updateBodyTheme();
+					}
+				};
+				mediaQuery.addEventListener('change', mediaQueryHandler);
+			}
 
-            updateBodyTheme();
+			updateBodyTheme();
 
-            return () => {
+			return () => {
 				if (mediaQuery && mediaQueryHandler) {
-					mediaQuery.removeEventListener("change", mediaQueryHandler);
+					mediaQuery.removeEventListener('change', mediaQueryHandler);
 				}
-            };
-        }
-    });
-
+			};
+		}
+	});
 </script>
 
-<AppBar class="top-0 p-0 border-b border-surface-200-800 h-[calc(var(--header-height))] flex ">
-    <AppBar.Toolbar class="grid-cols-[auto_auto]">
-        <AppBar.Lead>
-            <!-- <ArrowLeft size={24} /> -->
-             <AppMenu></AppMenu>
-        </AppBar.Lead>
-        <AppBar.Trail>
-            <nav class="btn-group preset-outlined-surface-200-800 flex-row p-0 shrink-0">
-                <a class="btn preset-filled-primary hover:preset-tonal whitespace-nowrap" class:selected={page.url.pathname === '/' || page.url.pathname === ''} href="/">
-                    <IconMap class="inline-block text-xl" />
-                    Graph
-                </a>
-                <a class="btn hover:preset-tonal whitespace-nowrap" class:selected={page.url.pathname === '/flow'} href="/flow">
-                    <IconSteps class="inline-block text-xl" />
-                    Flow
-                </a>
-            </nav>
-            <button
-                class="btn btn-sm relative p-1"
-                type="button"
-                onclick={() => (timeline.open = !timeline.open)}
-                title="Operation timeline"
-                aria-label="Toggle operation timeline"
-                aria-pressed={timeline.open}
-            >
-                <Icon icon="mdi:history" class="size-5" />
-                {#if timeline.pendingCount > 0 && !timeline.open}
-                    <span
-                        class="absolute -top-1 -right-1 bg-warning-500 text-warning-contrast-500 text-[10px] rounded-full w-4 h-4 flex items-center justify-center font-bold"
-                    >
-                        {timeline.pendingCount}
-                    </span>
-                {/if}
-            </button>
-        <Switch checked={isDark} onCheckedChange={toggle} class="mx-2">
-            <Switch.Control>
-                <Switch.Thumb>
-                    <Switch.Context>
-                        {#snippet children(switch_)}
-                            {#if switch_().checked}
-                                <IconMoon class="inline-block size-3" />
-                            {:else}
-                                <IconSun class="inline-block size-3" />
-                            {/if}
-                        {/snippet}
-                    </Switch.Context>
-                </Switch.Thumb>
-            </Switch.Control>
-            <!-- <Switch.Label>
+<AppBar class="border-surface-200-800 top-0 flex h-[calc(var(--header-height))] border-b p-0 ">
+	<AppBar.Toolbar class="grid-cols-[auto_auto]">
+		<AppBar.Lead>
+			<!-- <ArrowLeft size={24} /> -->
+			<AppMenu></AppMenu>
+		</AppBar.Lead>
+		<AppBar.Trail>
+			<nav class="btn-group preset-outlined-surface-200-800 shrink-0 flex-row p-0">
+				<a
+					class="btn preset-filled-primary hover:preset-tonal whitespace-nowrap"
+					class:selected={page.url.pathname === '/' || page.url.pathname === ''}
+					href="/"
+				>
+					<IconMap class="inline-block text-xl" />
+					Graph
+				</a>
+				<a
+					class="btn hover:preset-tonal whitespace-nowrap"
+					class:selected={page.url.pathname === '/flow'}
+					href="/flow"
+				>
+					<IconSteps class="inline-block text-xl" />
+					Flow
+				</a>
+			</nav>
+			<button
+				class="btn btn-sm relative p-1"
+				type="button"
+				onclick={() => (timeline.open = !timeline.open)}
+				title="Operation timeline"
+				aria-label="Toggle operation timeline"
+				aria-pressed={timeline.open}
+			>
+				<Icon icon="mdi:history" class="size-5" />
+				{#if timeline.pendingCount > 0 && !timeline.open}
+					<span
+						class="bg-warning-500 text-warning-contrast-500 absolute -top-1 -right-1 flex h-4 w-4 items-center justify-center rounded-full text-[10px] font-bold"
+					>
+						{timeline.pendingCount}
+					</span>
+				{/if}
+			</button>
+			<Switch checked={isDark} onCheckedChange={toggle} class="mx-2">
+				<Switch.Control>
+					<Switch.Thumb>
+						<Switch.Context>
+							{#snippet children(switch_)}
+								{#if switch_().checked}
+									<IconMoon class="inline-block size-3" />
+								{:else}
+									<IconSun class="inline-block size-3" />
+								{/if}
+							{/snippet}
+						</Switch.Context>
+					</Switch.Thumb>
+				</Switch.Control>
+				<!-- <Switch.Label>
             </Switch.Label> -->
-            <Switch.HiddenInput />
-        </Switch>
-        </AppBar.Trail>
-    </AppBar.Toolbar>
+				<Switch.HiddenInput />
+			</Switch>
+		</AppBar.Trail>
+	</AppBar.Toolbar>
 </AppBar>
 
 <Toast.Group {toaster}>
-    {#snippet children(toast)}
-        <Toast {toast}>
-            <Toast.Message>
-                <Toast.Title class="flex items-center gap-2">
-                    {#if toast.meta?.spinner}
-                        <Icon icon="svg-spinners:90-ring-with-bg" class="inline-block size-4" />
-                    {/if}
-                    {toast.title}
-                </Toast.Title>
-                <Toast.Description>{toast.description}</Toast.Description>
-            </Toast.Message>
-            <Toast.CloseTrigger />
-        </Toast>
-    {/snippet}
+	{#snippet children(toast)}
+		<Toast {toast}>
+			<Toast.Message>
+				<Toast.Title class="flex items-center gap-2">
+					{#if toast.meta?.spinner}
+						<Icon icon="svg-spinners:90-ring-with-bg" class="inline-block size-4" />
+					{/if}
+					{toast.title}
+				</Toast.Title>
+				<Toast.Description>{toast.description}</Toast.Description>
+			</Toast.Message>
+			<Toast.CloseTrigger />
+		</Toast>
+	{/snippet}
 </Toast.Group>
 <main class="">
-    {@render children()}
+	{@render children()}
 </main>
 
 <style>
-    
 	.btn.selected {
-        background-color: var(--color-surface-200-800);
-        color: var(--color-surface-contrast-200-800);
+		background-color: var(--color-surface-200-800);
+		color: var(--color-surface-contrast-200-800);
 	}
 </style>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
 	import { AppBar, Toast, Switch } from '@skeletonlabs/skeleton-svelte';
 	import { setContext } from 'svelte';
 	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
 	import IconMap from '~icons/game-icons/treasure-map';
 	import IconSteps from '~icons/game-icons/footsteps';
 	import IconSun from '~icons/material-symbols/light-mode';
@@ -86,8 +87,8 @@
 			<nav class="btn-group preset-outlined-surface-200-800 shrink-0 flex-row p-0">
 				<a
 					class="btn preset-filled-primary hover:preset-tonal whitespace-nowrap"
-					class:selected={page.url.pathname === '/' || page.url.pathname === ''}
-					href="/"
+					class:selected={page.url.pathname === '/'}
+					href={resolve('/')}
 				>
 					<IconMap class="inline-block text-xl" />
 					Graph
@@ -95,7 +96,7 @@
 				<a
 					class="btn hover:preset-tonal whitespace-nowrap"
 					class:selected={page.url.pathname === '/flow'}
-					href="/flow"
+					href={resolve('/flow')}
 				>
 					<IconSteps class="inline-block text-xl" />
 					Flow

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,2 +1,2 @@
-export const prerender = true
-export const ssr = false
+export const prerender = true;
+export const ssr = false;

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -87,16 +87,16 @@
 		try {
 			const savedWidth = sessionStorage.getItem(ARMORY_WIDTH_KEY);
 			const savedCollapsed = sessionStorage.getItem(ARMORY_COLLAPSED_KEY);
-			
+
 			const { min, max } = getResponsiveConstraints();
 			const defaultWidth = getResponsiveDefaultWidth();
-			
+
 			if (savedWidth) {
 				armoryWidth = Math.max(min, Math.min(max, parseInt(savedWidth)));
 			} else {
 				armoryWidth = defaultWidth;
 			}
-			
+
 			if (savedCollapsed) armoryCollapsed = savedCollapsed === 'true';
 		} catch (e) {
 			console.warn('Failed to load armory preferences:', e);
@@ -118,11 +118,17 @@
 		try {
 			const savedWidth = sessionStorage.getItem(ENTITYINFO_WIDTH_KEY);
 			const savedHeight = sessionStorage.getItem(ENTITYINFO_HEIGHT_KEY);
-			
+
 			if (savedWidth && savedHeight) {
 				// Only load and apply saved dimensions if both exist (indicating user manually resized)
-				entityInfoWidth = Math.max(MIN_ENTITYINFO_WIDTH, Math.min(MAX_ENTITYINFO_WIDTH, parseInt(savedWidth)));
-				entityInfoHeight = Math.max(MIN_ENTITYINFO_HEIGHT, Math.min(MAX_ENTITYINFO_HEIGHT, parseInt(savedHeight)));
+				entityInfoWidth = Math.max(
+					MIN_ENTITYINFO_WIDTH,
+					Math.min(MAX_ENTITYINFO_WIDTH, parseInt(savedWidth))
+				);
+				entityInfoHeight = Math.max(
+					MIN_ENTITYINFO_HEIGHT,
+					Math.min(MAX_ENTITYINFO_HEIGHT, parseInt(savedHeight))
+				);
 				hasManuallyResizedEntityInfo = true;
 			}
 		} catch (e) {
@@ -166,12 +172,12 @@
 
 	function handleMouseMove(e: MouseEvent) {
 		if (!isResizing) return;
-		
+
 		// Cancel any pending animation frame
 		if (rafId !== null) {
 			cancelAnimationFrame(rafId);
 		}
-		
+
 		// Use requestAnimationFrame for smooth updates
 		rafId = requestAnimationFrame(() => {
 			const { min, max } = getResponsiveConstraints();
@@ -217,21 +223,27 @@
 
 	function handleMouseMoveEntityInfo(e: MouseEvent) {
 		if (!isResizingEntityInfo) return;
-		
+
 		if (entityInfoRafId !== null) {
 			cancelAnimationFrame(entityInfoRafId);
 		}
-		
+
 		entityInfoRafId = requestAnimationFrame(() => {
 			// EntityInfo is anchored at top-right with: top-2 (8px) + navbar (60px) = 68px from top, right-2 (8px) from right
 			// Calculate width from mouse X to right edge (minus the 8px offset)
 			const rightEdge = window.innerWidth - 8;
-			const newWidth = Math.max(MIN_ENTITYINFO_WIDTH, Math.min(MAX_ENTITYINFO_WIDTH, rightEdge - e.clientX));
-			
+			const newWidth = Math.max(
+				MIN_ENTITYINFO_WIDTH,
+				Math.min(MAX_ENTITYINFO_WIDTH, rightEdge - e.clientX)
+			);
+
 			// Calculate height from top anchor (68px) to mouse Y
 			const topOffset = 68; // navbar (60px) + top-2 (8px)
-			const newHeight = Math.max(MIN_ENTITYINFO_HEIGHT, Math.min(MAX_ENTITYINFO_HEIGHT, e.clientY - topOffset));
-			
+			const newHeight = Math.max(
+				MIN_ENTITYINFO_HEIGHT,
+				Math.min(MAX_ENTITYINFO_HEIGHT, e.clientY - topOffset)
+			);
+
 			entityInfoWidth = newWidth;
 			entityInfoHeight = newHeight;
 			entityInfoRafId = null;
@@ -271,7 +283,7 @@
 		selectedObject = undefined;
 		selectedAttackStep = null;
 		actionDetailsRequestId++;
-	})
+	});
 
 	// Reset entity info to content-fit when a new node is selected
 	$effect(() => {
@@ -287,7 +299,9 @@
 	}
 
 	async function sendAction(ttp: TTP, args: Record<string, any> = {}) {
-		const selectedKind = campaignState.graph.nodes.find((node) => node.id === selectedObjectId)?.kind;
+		const selectedKind = campaignState.graph.nodes.find(
+			(node) => node.id === selectedObjectId
+		)?.kind;
 		if (selectedKind && WORKLOAD_KINDS.has(selectedKind)) {
 			const pods = childPods(selectedObjectId);
 			const applicability = await Promise.all(
@@ -394,7 +408,7 @@
 			window.addEventListener('mousemove', handleMouseMove);
 			window.addEventListener('mouseup', stopResize);
 			window.addEventListener('resize', handleWindowResize);
-			
+
 			// EntityInfo resize listeners
 			window.addEventListener('mousemove', handleMouseMoveEntityInfo);
 			window.addEventListener('mouseup', stopResizeEntityInfo);
@@ -433,11 +447,14 @@
 			});
 
 			if (data.Success && data.TTP?.id === 'read-file' && data.Args?.PATH) {
-				ranAPI.GetFileContent(data.Args.PATH).then((file) => {
-					fileViewerPath = file.path ?? data.Args.PATH;
-					fileViewerContent = file.content ?? '';
-					showFileViewer = true;
-				}).catch(() => {});
+				ranAPI
+					.GetFileContent(data.Args.PATH)
+					.then((file) => {
+						fileViewerPath = file.path ?? data.Args.PATH;
+						fileViewerContent = file.content ?? '';
+						showFileViewer = true;
+					})
+					.catch(() => {});
 			}
 		});
 
@@ -486,7 +503,8 @@
 		// to an already-running campaign isn't blank: completed actions from the
 		// execution log, then any in-flight (Ongoing) steps as pending on top. The
 		// id-index dedup makes this safe alongside the live handlers above.
-		ranAPI.GetExecutionRecords()
+		ranAPI
+			.GetExecutionRecords()
 			.then((records) => {
 				timeline.backfill(
 					records.map((r) => {
@@ -521,7 +539,8 @@
 			})
 			.catch((err) => console.error('Timeline backfill failed', err))
 			.finally(() => {
-				ranAPI.GetFlow()
+				ranAPI
+					.GetFlow()
 					.then((flow) => {
 						timeline.backfillPending(
 							flow.steps
@@ -553,21 +572,36 @@
 			window.removeEventListener('mousemove', handleMouseMove);
 			window.removeEventListener('mouseup', stopResize);
 			window.removeEventListener('resize', handleWindowResize);
-			
+
 			// EntityInfo resize listeners
 			window.removeEventListener('mousemove', handleMouseMoveEntityInfo);
 			window.removeEventListener('mouseup', stopResizeEntityInfo);
 		}
 	});
 
-	async function onExecuteTTP(ttpId: string, execSystemId: string, authIdentityId: string, procedureId: string, args: Record<string, string>, executionTimeoutSeconds: number) {
+	async function onExecuteTTP(
+		ttpId: string,
+		execSystemId: string,
+		authIdentityId: string,
+		procedureId: string,
+		args: Record<string, string>,
+		executionTimeoutSeconds: number
+	) {
 		const ttp = campaignState.getTtpById(ttpId);
 		const targetName = campaignState.getEntityById(actionTargetId)?.name ?? actionTargetId;
 
 		closeModal();
 
 		try {
-			const result = await ExecuteAction({ actionId: ttpId, execSystemId, authIdentityId: authIdentityId || undefined, targetId: actionTargetId, procedureId, args, executionTimeoutSeconds });
+			const result = await ExecuteAction({
+				actionId: ttpId,
+				execSystemId,
+				authIdentityId: authIdentityId || undefined,
+				targetId: actionTargetId,
+				procedureId,
+				args,
+				executionTimeoutSeconds
+			});
 			const cmdId = (result as any)?.cmdId ?? crypto.randomUUID();
 			const differsFromTarget = execSystemId && execSystemId !== actionTargetId;
 			timeline.addTtpAction({
@@ -596,7 +630,7 @@
 			description = e;
 		}
 
-		console.error(e)
+		console.error(e);
 
 		toaster.create({
 			title: 'Error',
@@ -640,13 +674,15 @@
 	{#if campaignState.isReady()}
 		<!-- Armory panel -->
 		<div
-			class="bg-surface-100-900 flex-shrink-0 {isResizing ? '' : 'transition-[width] duration-300 ease-in-out'}"
+			class="bg-surface-100-900 flex-shrink-0 {isResizing
+				? ''
+				: 'transition-[width] duration-300 ease-in-out'}"
 			style="width: {armoryCollapsed ? '0px' : `${armoryWidth}px`}; overflow: hidden;"
 		>
 			<Armory
 				class="h-full min-h-0 w-full"
 				action={sendAction}
-				runRecommendation={runRecommendation}
+				{runRecommendation}
 				targetId={selectedObjectId}
 				target={selectedObject}
 				bind:focusSearch={focusArmorySearch}
@@ -655,9 +691,9 @@
 
 		<!-- Resize handle -->
 		{#if !armoryCollapsed}
-			<div class="relative w-px shrink-0 bg-surface-200-800">
+			<div class="bg-surface-200-800 relative w-px shrink-0">
 				<div
-					class="absolute -left-1 top-0 z-10 h-full w-2 cursor-col-resize group"
+					class="group absolute top-0 -left-1 z-10 h-full w-2 cursor-col-resize"
 					role="slider"
 					aria-orientation="horizontal"
 					aria-label="Resize armory panel"
@@ -668,14 +704,16 @@
 					onmousedown={startResize}
 					onkeydown={onArmoryResizeKeydown}
 				>
-					<div class="absolute inset-y-0 left-1/2 w-0.5 -translate-x-1/2 bg-transparent group-hover:bg-primary-500 transition-colors"></div>
+					<div
+						class="group-hover:bg-primary-500 absolute inset-y-0 left-1/2 w-0.5 -translate-x-1/2 bg-transparent transition-colors"
+					></div>
 				</div>
 			</div>
 		{/if}
 
 		<!-- Collapse/Expand button -->
 		<button
-			class="absolute left-0 z-50 bg-surface-200-800 hover:bg-surface-300-700 border border-surface-400-600 rounded-r-md px-0.5 py-2 opacity-30 hover:opacity-100 transition-all duration-200"
+			class="bg-surface-200-800 hover:bg-surface-300-700 border-surface-400-600 absolute left-0 z-50 rounded-r-md border px-0.5 py-2 opacity-30 transition-all duration-200 hover:opacity-100"
 			style="left: {armoryCollapsed ? '0' : `${armoryWidth}px`}; top: 0.5rem;"
 			onclick={toggleArmoryCollapse}
 			title={armoryCollapsed ? 'Expand armory' : 'Collapse armory'}
@@ -687,54 +725,67 @@
 			/>
 		</button>
 
-<!-- Graph area with EntityInfo overlay and Action Log drawer -->
-	<div class="flex-1 min-w-0 flex flex-col min-h-0">
-		<div class="flex-1 min-h-0 relative">
-			<Graph bind:selectedObjectId={selectedObjectId} bind:selectedObject class="h-full" />
+		<!-- Graph area with EntityInfo overlay and Action Log drawer -->
+		<div class="flex min-h-0 min-w-0 flex-1 flex-col">
+			<div class="relative min-h-0 flex-1">
+				<Graph bind:selectedObjectId bind:selectedObject class="h-full" />
 
-			{#if selectedObjectId !== ''}
-				<svelte:boundary onerror={handleError}>
-					<div
-						bind:this={entityInfoContainer}
-						class="absolute top-2 right-2 flex flex-col z-50"
-						class:max-w-[800px]={!hasManuallyResizedEntityInfo}
-						class:max-h-[calc(100vh-80px)]={!hasManuallyResizedEntityInfo}
-						style={hasManuallyResizedEntityInfo ? `width: ${entityInfoWidth}px; height: ${entityInfoHeight}px;` : 'width: fit-content; height: fit-content;'}
-					>
-						<EntityInfo class={hasManuallyResizedEntityInfo ? "overflow-auto flex-1" : "overflow-auto"} objectId={selectedObjectId} {sendAction} />
-						<!-- Resize handle at bottom-left corner -->
-						<button
-						class="absolute bottom-0 left-0 w-4 h-4 cursor-nwse-resize opacity-30 hover:opacity-100 transition-opacity bg-gradient-to-bl from-transparent from-50% to-current to-50% rounded-bl-lg"
-							onmousedown={startResizeEntityInfo}
-							aria-label="Resize entity info panel"
-						></button>
-					</div>
-				</svelte:boundary>
+				{#if selectedObjectId !== ''}
+					<svelte:boundary onerror={handleError}>
+						<div
+							bind:this={entityInfoContainer}
+							class="absolute top-2 right-2 z-50 flex flex-col"
+							class:max-w-[800px]={!hasManuallyResizedEntityInfo}
+							class:max-h-[calc(100vh-80px)]={!hasManuallyResizedEntityInfo}
+							style={hasManuallyResizedEntityInfo
+								? `width: ${entityInfoWidth}px; height: ${entityInfoHeight}px;`
+								: 'width: fit-content; height: fit-content;'}
+						>
+							<EntityInfo
+								class={hasManuallyResizedEntityInfo ? 'flex-1 overflow-auto' : 'overflow-auto'}
+								objectId={selectedObjectId}
+								{sendAction}
+							/>
+							<!-- Resize handle at bottom-left corner -->
+							<button
+								class="absolute bottom-0 left-0 h-4 w-4 cursor-nwse-resize rounded-bl-lg bg-gradient-to-bl from-transparent from-50% to-current to-50% opacity-30 transition-opacity hover:opacity-100"
+								onmousedown={startResizeEntityInfo}
+								aria-label="Resize entity info panel"
+							></button>
+						</div>
+					</svelte:boundary>
+				{/if}
+			</div>
+
+			{#if timeline.open}
+				<OperationTimeline
+					entries={timeline.topEntries}
+					onfocusentity={(id) => {
+						selectedObjectId = id;
+					}}
+					ontogglegroup={(cmdId) => timeline.toggleGroup(cmdId)}
+					onviewaction={viewTimelineAction}
+				/>
 			{/if}
 		</div>
 
-		{#if timeline.open}
-			<OperationTimeline
-				entries={timeline.topEntries}
-				onfocusentity={(id) => { selectedObjectId = id; }}
-				ontogglegroup={(cmdId) => timeline.toggleGroup(cmdId)}
-				onviewaction={viewTimelineAction}
-			/>
-		{/if}
-	</div>
-
 		<Dialog open={podChooserOpen} onOpenChange={(e) => (podChooserOpen = e.open)}>
 			<Portal>
-				<Dialog.Backdrop class="fixed inset-0 z-[100] bg-surface-50-950/50" />
-				<Dialog.Positioner class="fixed inset-0 z-[100] flex justify-center items-center">
-					<Dialog.Content class="card min-w-80 max-w-lg bg-surface-100-900 p-4 space-y-3 shadow-xl border border-surface-600">
+				<Dialog.Backdrop class="bg-surface-50-950/50 fixed inset-0 z-[100]" />
+				<Dialog.Positioner class="fixed inset-0 z-[100] flex items-center justify-center">
+					<Dialog.Content
+						class="card bg-surface-100-900 border-surface-600 max-w-lg min-w-80 space-y-3 border p-4 shadow-xl"
+					>
 						<Dialog.Title class="font-semibold">Choose a pod</Dialog.Title>
-						<Dialog.Description class="text-sm text-surface-500">
+						<Dialog.Description class="text-surface-500 text-sm">
 							{selectedTTP?.name} is applicable to {eligibleActionPods.length} pods in this workload.
 						</Dialog.Description>
-						<div class="flex flex-col gap-2 max-h-80 overflow-auto">
+						<div class="flex max-h-80 flex-col gap-2 overflow-auto">
 							{#each eligibleActionPods as pod}
-								<button class="btn preset-outlined-surface-200-800 justify-start" onclick={() => chooseActionPod(pod.id)}>
+								<button
+									class="btn preset-outlined-surface-200-800 justify-start"
+									onclick={() => chooseActionPod(pod.id)}
+								>
 									<Icon icon="mdi:kubernetes" class="size-4" />
 									<span class="truncate">{pod.name}</span>
 								</button>
@@ -747,9 +798,11 @@
 
 		<Dialog open={showParamModal} onOpenChange={(e) => (showParamModal = e.open)}>
 			<Portal>
-				<Dialog.Backdrop class="fixed inset-0 z-[100] bg-surface-50-950/50" />
-				<Dialog.Positioner class="fixed inset-0 z-[100] flex justify-center items-center ">
-					<Dialog.Content class="card min-w-modal bg-surface-100-900 p-4 space-y-2 shadow-xl max-h-[90vh] flex flex-col border border-surface-600 ">
+				<Dialog.Backdrop class="bg-surface-50-950/50 fixed inset-0 z-[100]" />
+				<Dialog.Positioner class="fixed inset-0 z-[100] flex items-center justify-center ">
+					<Dialog.Content
+						class="card min-w-modal bg-surface-100-900 border-surface-600 flex max-h-[90vh] flex-col space-y-2 border p-4 shadow-xl "
+					>
 						{#if selectedTTP}
 							<ActionParamsModal
 								targetId={actionTargetId}
@@ -764,14 +817,11 @@
 			</Portal>
 		</Dialog>
 
-		<Dialog
-			open={showFileViewer}
-			onOpenChange={(e) => (showFileViewer = e.open)}
-		>
+		<Dialog open={showFileViewer} onOpenChange={(e) => (showFileViewer = e.open)}>
 			<Portal>
-				<Dialog.Backdrop class="fixed inset-0 z-50 bg-surface-50-950/50"/>
-				<Dialog.Positioner class="fixed inset-0 z-50 flex justify-center items-center">
-					<Dialog.Content class="card bg-surface-100-900 p-4 space-y-2 shadow-xl max-w-3xl w-full">
+				<Dialog.Backdrop class="bg-surface-50-950/50 fixed inset-0 z-50" />
+				<Dialog.Positioner class="fixed inset-0 z-50 flex items-center justify-center">
+					<Dialog.Content class="card bg-surface-100-900 w-full max-w-3xl space-y-2 p-4 shadow-xl">
 						<FileViewerModal
 							path={fileViewerPath}
 							content={fileViewerContent}
@@ -784,12 +834,15 @@
 
 		<AttackStepDrawer step={selectedAttackStep} onclose={closeAttackStepDrawer} />
 	{:else}
-		<div class="flex items-center justify-center w-full h-full">
+		<div class="flex h-full w-full items-center justify-center">
 			<div class="text-center">
-				<Icon icon="game-icons:fishing-net" rotate={90} class="fill-token h-64 w-64 -scale-x-100 mx-auto" />
-				<div class="mt-4 text-surface-600-400">Loading campaign...</div>
+				<Icon
+					icon="game-icons:fishing-net"
+					rotate={90}
+					class="fill-token mx-auto h-64 w-64 -scale-x-100"
+				/>
+				<div class="text-surface-600-400 mt-4">Loading campaign...</div>
 			</div>
 		</div>
 	{/if}
-
 </div>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -3,7 +3,7 @@
 	import type { AttackStep, Node, TTP, ScoredCandidate } from '$lib/api/index';
 	import Icon from '@iconify/svelte';
 	import Graph from './components/graph.svelte';
-	import { Dialog, Popover, Portal } from '@skeletonlabs/skeleton-svelte';
+	import { Dialog, Portal } from '@skeletonlabs/skeleton-svelte';
 	import ActionParamsModal from '$lib/modals/ActionParamsModal.svelte';
 	import FileViewerModal from '$lib/modals/FileViewerModal.svelte';
 	import { onMount, onDestroy } from 'svelte';
@@ -25,7 +25,7 @@
 	let selectedObject: Node | undefined = $state();
 	let ttpArgContext: Record<string, any> = $state({});
 	let showParamModal: boolean = $state(false);
-	let activeGlobalConditions: Object = {};
+	let activeGlobalConditions: object = {};
 	let selectedTTP: TTP | undefined = $state();
 	let actionTargetId: string = $state('');
 	let podChooserOpen = $state(false);

--- a/frontend/src/routes/components/GraphLayoutPlayground.svelte
+++ b/frontend/src/routes/components/GraphLayoutPlayground.svelte
@@ -13,25 +13,36 @@
 	let panelOpen = $state(false);
 	let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
-	type Slider = { key: keyof LayoutParams; label: string; min: number; max: number; step: number; unit: string };
-	type Dropdown<T extends string> = { key: keyof LayoutParams; label: string; options: { value: T; label: string }[] };
+	type Slider = {
+		key: keyof LayoutParams;
+		label: string;
+		min: number;
+		max: number;
+		step: number;
+		unit: string;
+	};
+	type Dropdown<T extends string> = {
+		key: keyof LayoutParams;
+		label: string;
+		options: { value: T; label: string }[];
+	};
 
 	const spacingSliders: Slider[] = [
-		{ key: 'layerSpacing',      label: 'Layer spacing',      min: 0, max: 400, step: 5,   unit: 'px' },
-		{ key: 'nodeSpacing',       label: 'Node spacing',        min: 0, max: 150, step: 5,   unit: 'px' },
-		{ key: 'edgeNodeSpacing',   label: 'Edge-node spacing',   min: 0, max: 150, step: 5,   unit: 'px' },
-		{ key: 'aspectRatio',       label: 'Aspect ratio',        min: 0, max: 5,   step: 0.1, unit: '' },
-		{ key: 'usesStraightness',  label: '"uses" straightness', min: 0, max: 10,  step: 1,   unit: '' },
+		{ key: 'layerSpacing', label: 'Layer spacing', min: 0, max: 400, step: 5, unit: 'px' },
+		{ key: 'nodeSpacing', label: 'Node spacing', min: 0, max: 150, step: 5, unit: 'px' },
+		{ key: 'edgeNodeSpacing', label: 'Edge-node spacing', min: 0, max: 150, step: 5, unit: 'px' },
+		{ key: 'aspectRatio', label: 'Aspect ratio', min: 0, max: 5, step: 0.1, unit: '' },
+		{ key: 'usesStraightness', label: '"uses" straightness', min: 0, max: 10, step: 1, unit: '' }
 	];
 
 	const compoundSliders: Slider[] = [
-		{ key: 'compoundEdgeLength', label: 'Edge length',   min: 0, max: 200, step: 5,  unit: 'px' },
-		{ key: 'compoundPadding',    label: 'Padding',       min: 0, max: 60,  step: 5,  unit: 'px' },
-		{ key: 'stressIterations',   label: 'Iterations',    min: 0, max: 1000, step: 10, unit: '' },
+		{ key: 'compoundEdgeLength', label: 'Edge length', min: 0, max: 200, step: 5, unit: 'px' },
+		{ key: 'compoundPadding', label: 'Padding', min: 0, max: 60, step: 5, unit: 'px' },
+		{ key: 'stressIterations', label: 'Iterations', min: 0, max: 1000, step: 10, unit: '' }
 	];
 
 	const animSliders: Slider[] = [
-		{ key: 'animationDuration', label: 'Duration', min: 0, max: 2000, step: 50, unit: 'ms' },
+		{ key: 'animationDuration', label: 'Duration', min: 0, max: 2000, step: 50, unit: 'ms' }
 	];
 
 	const layeringDropdown: Dropdown<LayeringStrategy> = {
@@ -39,21 +50,21 @@
 		label: 'Layering',
 		options: [
 			{ value: 'NETWORK_SIMPLEX', label: 'Network simplex' },
-			{ value: 'LONGEST_PATH',    label: 'Longest path' },
-			{ value: 'INTERACTIVE',     label: 'Interactive' },
-			{ value: 'MIN_WIDTH',       label: 'Min width' },
-		],
+			{ value: 'LONGEST_PATH', label: 'Longest path' },
+			{ value: 'INTERACTIVE', label: 'Interactive' },
+			{ value: 'MIN_WIDTH', label: 'Min width' }
+		]
 	};
 
 	const placementDropdown: Dropdown<NodePlacementStrategy> = {
 		key: 'nodePlacementStrategy',
 		label: 'Node placement',
 		options: [
-			{ value: 'BRANDES_KOEPF',    label: 'Brandes-Koepf' },
-			{ value: 'NETWORK_SIMPLEX',  label: 'Network simplex' },
-			{ value: 'LINEAR_SEGMENTS',  label: 'Linear segments' },
-			{ value: 'SIMPLE',           label: 'Simple' },
-		],
+			{ value: 'BRANDES_KOEPF', label: 'Brandes-Koepf' },
+			{ value: 'NETWORK_SIMPLEX', label: 'Network simplex' },
+			{ value: 'LINEAR_SEGMENTS', label: 'Linear segments' },
+			{ value: 'SIMPLE', label: 'Simple' }
+		]
 	};
 
 	function onChange() {
@@ -71,19 +82,19 @@
 	<div class="fixed inset-0 z-40" role="presentation" onclick={() => (panelOpen = false)}></div>
 {/if}
 
-<div class="absolute bottom-1 right-12 z-50 text-surface-700-300">
+<div class="text-surface-700-300 absolute right-12 bottom-1 z-50">
 	<button
 		class="chip preset-outlined-surface-100-900 border-surface-400-600"
 		onclick={() => (panelOpen = !panelOpen)}
 		title="Layout playground"
 		aria-label="Toggle layout playground"
 	>
-		<Icon icon="mdi:tune-variant" class="inline-block text-surface-400-600" />
+		<Icon icon="mdi:tune-variant" class="text-surface-400-600 inline-block" />
 	</button>
 
 	{#if panelOpen}
 		<div
-			class="absolute bottom-full right-0 mb-1 w-72 bg-surface-50-950 border border-surface-300-700 rounded-lg shadow-xl z-50 font-mono overflow-y-auto max-h-[80vh]"
+			class="bg-surface-50-950 border-surface-300-700 absolute right-0 bottom-full z-50 mb-1 max-h-[80vh] w-72 overflow-y-auto rounded-lg border font-mono shadow-xl"
 			role="dialog"
 			aria-label="Layout playground"
 			tabindex="-1"
@@ -91,27 +102,32 @@
 			onkeydown={(e) => e.stopPropagation()}
 		>
 			<!-- Header -->
-			<div class="flex items-center justify-between px-4 pt-4 pb-2 sticky top-0 bg-surface-50-950 border-b border-surface-200-800">
-				<h3 class="text-xs font-semibold text-primary-500 tracking-widest uppercase">Layout playground</h3>
+			<div
+				class="bg-surface-50-950 border-surface-200-800 sticky top-0 flex items-center justify-between border-b px-4 pt-4 pb-2"
+			>
+				<h3 class="text-primary-500 text-xs font-semibold tracking-widest uppercase">
+					Layout playground
+				</h3>
 				<button
-					class="text-xs text-surface-400-600 hover:text-surface-700-300 transition-colors cursor-pointer"
-					onclick={reset}
-				>reset</button>
+					class="text-surface-400-600 hover:text-surface-700-300 cursor-pointer text-xs transition-colors"
+					onclick={reset}>reset</button
+				>
 			</div>
 
-			<div class="p-4 space-y-5">
-
+			<div class="space-y-5 p-4">
 				<!-- Strategies -->
 				<section>
-					<p class="text-[10px] text-surface-400-600 uppercase tracking-widest mb-2">Strategies</p>
+					<p class="text-surface-400-600 mb-2 text-[10px] tracking-widest uppercase">Strategies</p>
 					{#each [layeringDropdown, placementDropdown] as d}
 						<div class="mb-2">
-							<label for="layout-{String(d.key)}" class="text-xs text-surface-500-400 block mb-1">{d.label}</label>
+							<label for="layout-{String(d.key)}" class="text-surface-500-400 mb-1 block text-xs"
+								>{d.label}</label
+							>
 							<select
 								id="layout-{String(d.key)}"
 								bind:value={params[d.key]}
 								onchange={onChange}
-								class="w-full text-xs bg-surface-100-900 border border-surface-300-700 rounded px-2 py-1 text-surface-700-300 cursor-pointer"
+								class="bg-surface-100-900 border-surface-300-700 text-surface-700-300 w-full cursor-pointer rounded border px-2 py-1 text-xs"
 							>
 								{#each d.options as opt}
 									<option value={opt.value}>{opt.label}</option>
@@ -123,12 +139,14 @@
 
 				<!-- Global spacing -->
 				<section>
-					<p class="text-[10px] text-surface-400-600 uppercase tracking-widest mb-2">Global spacing</p>
+					<p class="text-surface-400-600 mb-2 text-[10px] tracking-widest uppercase">
+						Global spacing
+					</p>
 					{#each spacingSliders as s}
 						<div class="mb-3">
-							<div class="flex justify-between items-baseline mb-1">
-								<label for="layout-{s.key}" class="text-xs text-surface-500-400">{s.label}</label>
-								<span class="text-xs text-primary-400 tabular-nums">{params[s.key]}{s.unit}</span>
+							<div class="mb-1 flex items-baseline justify-between">
+								<label for="layout-{s.key}" class="text-surface-500-400 text-xs">{s.label}</label>
+								<span class="text-primary-400 text-xs tabular-nums">{params[s.key]}{s.unit}</span>
 							</div>
 							<input
 								id="layout-{s.key}"
@@ -138,9 +156,9 @@
 								step={s.step}
 								bind:value={params[s.key]}
 								oninput={onChange}
-								class="w-full h-1 appearance-none bg-surface-300-700 rounded-full cursor-pointer accent-primary-500"
+								class="bg-surface-300-700 accent-primary-500 h-1 w-full cursor-pointer appearance-none rounded-full"
 							/>
-							<div class="flex justify-between text-[10px] text-surface-400-600 mt-0.5">
+							<div class="text-surface-400-600 mt-0.5 flex justify-between text-[10px]">
 								<span>{s.min}</span><span>{s.max}</span>
 							</div>
 						</div>
@@ -149,12 +167,14 @@
 
 				<!-- Compound / cluster -->
 				<section>
-					<p class="text-[10px] text-surface-400-600 uppercase tracking-widest mb-2">Cluster (stress)</p>
+					<p class="text-surface-400-600 mb-2 text-[10px] tracking-widest uppercase">
+						Cluster (stress)
+					</p>
 					{#each compoundSliders as s}
 						<div class="mb-3">
-							<div class="flex justify-between items-baseline mb-1">
-								<label for="layout-{s.key}" class="text-xs text-surface-500-400">{s.label}</label>
-								<span class="text-xs text-primary-400 tabular-nums">{params[s.key]}{s.unit}</span>
+							<div class="mb-1 flex items-baseline justify-between">
+								<label for="layout-{s.key}" class="text-surface-500-400 text-xs">{s.label}</label>
+								<span class="text-primary-400 text-xs tabular-nums">{params[s.key]}{s.unit}</span>
 							</div>
 							<input
 								id="layout-{s.key}"
@@ -164,9 +184,9 @@
 								step={s.step}
 								bind:value={params[s.key]}
 								oninput={onChange}
-								class="w-full h-1 appearance-none bg-surface-300-700 rounded-full cursor-pointer accent-primary-500"
+								class="bg-surface-300-700 accent-primary-500 h-1 w-full cursor-pointer appearance-none rounded-full"
 							/>
-							<div class="flex justify-between text-[10px] text-surface-400-600 mt-0.5">
+							<div class="text-surface-400-600 mt-0.5 flex justify-between text-[10px]">
 								<span>{s.min}</span><span>{s.max}</span>
 							</div>
 						</div>
@@ -175,12 +195,12 @@
 
 				<!-- Animation -->
 				<section>
-					<p class="text-[10px] text-surface-400-600 uppercase tracking-widest mb-2">Animation</p>
+					<p class="text-surface-400-600 mb-2 text-[10px] tracking-widest uppercase">Animation</p>
 					{#each animSliders as s}
 						<div class="mb-3">
-							<div class="flex justify-between items-baseline mb-1">
-								<label for="layout-{s.key}" class="text-xs text-surface-500-400">{s.label}</label>
-								<span class="text-xs text-primary-400 tabular-nums">{params[s.key]}{s.unit}</span>
+							<div class="mb-1 flex items-baseline justify-between">
+								<label for="layout-{s.key}" class="text-surface-500-400 text-xs">{s.label}</label>
+								<span class="text-primary-400 text-xs tabular-nums">{params[s.key]}{s.unit}</span>
 							</div>
 							<input
 								id="layout-{s.key}"
@@ -190,15 +210,14 @@
 								step={s.step}
 								bind:value={params[s.key]}
 								oninput={onChange}
-								class="w-full h-1 appearance-none bg-surface-300-700 rounded-full cursor-pointer accent-primary-500"
+								class="bg-surface-300-700 accent-primary-500 h-1 w-full cursor-pointer appearance-none rounded-full"
 							/>
-							<div class="flex justify-between text-[10px] text-surface-400-600 mt-0.5">
+							<div class="text-surface-400-600 mt-0.5 flex justify-between text-[10px]">
 								<span>{s.min}</span><span>{s.max}</span>
 							</div>
 						</div>
 					{/each}
 				</section>
-
 			</div>
 		</div>
 	{/if}

--- a/frontend/src/routes/components/action_card.svelte
+++ b/frontend/src/routes/components/action_card.svelte
@@ -127,9 +127,7 @@
 	let activeVeto = $derived(
 		breakdown?.find((c) => c.kind === 'utility' && c.veto && c.curved <= 0)
 	);
-	let beliefBlocker = $derived(
-		breakdown?.find((c) => c.kind === 'belief' && c.curved <= 0)
-	);
+	let beliefBlocker = $derived(breakdown?.find((c) => c.kind === 'belief' && c.curved <= 0));
 	let scoreBlocker = $derived(activeVeto ?? beliefBlocker);
 	let blockerLabel = $derived(
 		activeVeto
@@ -143,14 +141,14 @@
 <div
 	class={[
 		cardStyle +
-			' flex items-center hover:bg-surface-400-600 text-xs md:text-sm lg:text-base border-surface-50-950',
+			' hover:bg-surface-400-600 border-surface-50-950 flex items-center text-xs md:text-sm lg:text-base',
 		className
 	]}
 	style="overflow: visible;"
 >
 	<button
 		onclick={() => onclick(ttp)}
-		class="flex items-center gap-2 flex-1 min-w-0 p-0 pl-4 py-2 text-left bg-transparent"
+		class="flex min-w-0 flex-1 items-center gap-2 bg-transparent p-0 py-2 pl-4 text-left"
 		role="menuitem"
 		tabindex="0"
 		disabled={!enabled}
@@ -168,20 +166,28 @@
 					: 'bg-warning-100-900 text-warning-700-300'}"
 				aria-label={`${prerequisitesFulfilled ? 'Prerequisites fulfilled' : 'Prerequisites not fulfilled'}: ${requirementDetails.length} ${requirementDetails.length === 1 ? 'requirement' : 'requirements'}`}
 			>
-				<Icon icon={prerequisitesFulfilled ? 'mdi:check-circle-outline' : 'mdi:alert-circle-outline'} width="14" />
+				<Icon
+					icon={prerequisitesFulfilled ? 'mdi:check-circle-outline' : 'mdi:alert-circle-outline'}
+					width="14"
+				/>
 				<span class="tabular-nums">{requirementDetails.length}</span>
 			</Tooltip.Trigger>
 			<Tooltip.Positioner>
-				<Tooltip.Content class="z-[90] w-72 rounded border border-surface-300-700 bg-surface-100-900 p-2 shadow-xl">
+				<Tooltip.Content
+					class="border-surface-300-700 bg-surface-100-900 z-[90] w-72 rounded border p-2 shadow-xl"
+				>
 					<div class="mb-1.5 flex items-center gap-1.5 text-xs font-semibold">
-						<Icon icon={prerequisitesFulfilled ? 'mdi:check-circle' : 'mdi:alert-circle'} width="14" />
+						<Icon
+							icon={prerequisitesFulfilled ? 'mdi:check-circle' : 'mdi:alert-circle'}
+							width="14"
+						/>
 						{prerequisitesFulfilled ? 'Prerequisites fulfilled' : 'Prerequisites not fulfilled'}
 					</div>
 					<div class="space-y-1.5">
 						{#each requirementDetails as requirement}
 							<div class="flex gap-1.5 text-xs">
-								<span class="shrink-0 font-medium text-surface-700-300">{requirement.label}:</span>
-								<span class="min-w-0 break-words text-surface-500">{requirement.value}</span>
+								<span class="text-surface-700-300 shrink-0 font-medium">{requirement.label}:</span>
+								<span class="text-surface-500 min-w-0 break-words">{requirement.value}</span>
 							</div>
 						{/each}
 					</div>
@@ -195,31 +201,29 @@
 			{#if scoreBlocker}
 				<Icon icon="mdi:alert-circle" width="14" class="text-error-500" aria-label={blockerLabel} />
 			{/if}
-			<span class="h-1.5 w-10 rounded bg-surface-300-700 overflow-hidden">
+			<span class="bg-surface-300-700 h-1.5 w-10 overflow-hidden rounded">
 				<span class="block h-full {utilityClass(utility)}" style="width: {pct}%"></span>
 			</span>
-			<span class="text-[10px] tabular-nums w-6 text-right">{pct}</span>
+			<span class="w-6 text-right text-[10px] tabular-nums">{pct}</span>
 		{/snippet}
 
 		{#if breakdown && breakdown.length}
-			<Tooltip
-				openDelay={120}
-				closeDelay={80}
-				positioning={{ placement: 'right', gutter: 8 }}
-			>
+			<Tooltip openDelay={120} closeDelay={80} positioning={{ placement: 'right', gutter: 8 }}>
 				<Tooltip.Trigger
-					class="flex items-center gap-1 pr-2 pl-1 flex-shrink-0 cursor-help text-surface-500 hover:text-primary-500"
-					aria-label={scoreBlocker ? `Utility ${pct} - ${blockerLabel}` : `Utility ${pct} - hover for breakdown`}
+					class="text-surface-500 hover:text-primary-500 flex flex-shrink-0 cursor-help items-center gap-1 pr-2 pl-1"
+					aria-label={scoreBlocker
+						? `Utility ${pct} - ${blockerLabel}`
+						: `Utility ${pct} - hover for breakdown`}
 					title={blockerLabel || 'Hover for utility breakdown'}
 				>
 					{@render chip()}
 				</Tooltip.Trigger>
 				<Tooltip.Positioner>
 					<Tooltip.Content
-						class="z-[90] w-64 bg-surface-100-900 border border-surface-300-700 rounded shadow-xl p-2"
+						class="bg-surface-100-900 border-surface-300-700 z-[90] w-64 rounded border p-2 shadow-xl"
 					>
-						<div class="flex items-center justify-between mb-1.5">
-							<span class="text-[10px] uppercase tracking-wide text-surface-500">Utility</span>
+						<div class="mb-1.5 flex items-center justify-between">
+							<span class="text-surface-500 text-[10px] tracking-wide uppercase">Utility</span>
 							<span class="text-xs font-semibold">{pct}</span>
 						</div>
 						<ConsiderationBreakdown {breakdown} />
@@ -227,7 +231,10 @@
 				</Tooltip.Positioner>
 			</Tooltip>
 		{:else}
-			<span class="flex items-center gap-1 pr-2 pl-1 flex-shrink-0 text-surface-500" title="Utility {pct}">
+			<span
+				class="text-surface-500 flex flex-shrink-0 items-center gap-1 pr-2 pl-1"
+				title="Utility {pct}"
+			>
 				{@render chip()}
 			</span>
 		{/if}

--- a/frontend/src/routes/components/armory.svelte
+++ b/frontend/src/routes/components/armory.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import type { ArmoryType } from '$lib/model';
-	import { onDestroy } from 'svelte';
 	import Icon from '@iconify/svelte';
 	import { iconMap } from '$lib/tactic_icons';
 
@@ -38,7 +37,7 @@
 	let searchInputElement: HTMLInputElement | undefined = $state();
 
 	// $: selectedConditions = { ...globalConditions, ...(selectedNode ?? {}) };
-	let armory: ArmoryType = $state(new Map());
+	const armory: ArmoryType = $derived(campaign.armory);
 	let showAllTTPs: boolean = $state(false);
 	let applicableTTPs: ArmoryType = $state(new Map());
 	let searchTerm: string = $state('');
@@ -59,10 +58,6 @@
 		campaign.api.GetScoringProfile().then((profile) => {
 			scoringEnabled = profile?.enabled ?? false;
 		});
-	});
-
-	$effect(() => {
-		armory = campaign.armory;
 	});
 
 	// Score the applicable actions for the selected target. The armory already
@@ -120,13 +115,9 @@
 		// Session connect/loss events replace the campaign graph, so track it in
 		// addition to the selected node's directly exposed applicability fields.
 		void campaign.graph;
-		const nodeState = target
-			? {
-					compromised: target.compromised,
-					accessLevel: target.accessLevel,
-					entity: target.entity
-				}
-			: null;
+		void target?.compromised;
+		void target?.accessLevel;
+		void target?.entity;
 
 		if (!targetId) {
 			applicableTTPs = new Map();

--- a/frontend/src/routes/components/armory.svelte
+++ b/frontend/src/routes/components/armory.svelte
@@ -24,7 +24,14 @@
 		focusSearch?: () => void;
 	};
 
-	let { class: className = '', targetId, target, action: sendAction, runRecommendation, focusSearch = $bindable(() => {}) }: ArmoryProps = $props();
+	let {
+		class: className = '',
+		targetId,
+		target,
+		action: sendAction,
+		runRecommendation,
+		focusSearch = $bindable(() => {})
+	}: ArmoryProps = $props();
 
 	let activeTab: string = $state('actions');
 
@@ -44,7 +51,8 @@
 	const liftedPodCount = $derived.by(() => {
 		const kind = campaign.graph.nodes.find((node) => node.id === targetId)?.kind;
 		if (!kind || !WORKLOAD_KINDS.has(kind)) return 0;
-		return campaign.graph.nodes.filter((node) => node.kind === 'Pod' && node.parent === targetId).length;
+		return campaign.graph.nodes.filter((node) => node.kind === 'Pod' && node.parent === targetId)
+			.length;
 	});
 
 	$effect(() => {
@@ -53,7 +61,9 @@
 		});
 	});
 
-	$effect(() => { armory = campaign.armory; });
+	$effect(() => {
+		armory = campaign.armory;
+	});
 
 	// Score the applicable actions for the selected target. The armory already
 	// prefilters to applicable TTPs, so we only score those - utility per action
@@ -95,24 +105,29 @@
 		if (!normalizedSearch) return Array.from(source.entries());
 
 		return Array.from(source.entries())
-			.map(([tactic, ttps]) => [
-				tactic,
-				ttps.filter((ttp: TTP) => ttp.name.toLowerCase().includes(normalizedSearch))
-			] as [string, TTP[]])
+			.map(
+				([tactic, ttps]) =>
+					[
+						tactic,
+						ttps.filter((ttp: TTP) => ttp.name.toLowerCase().includes(normalizedSearch))
+					] as [string, TTP[]]
+			)
 			.filter(([, ttps]) => ttps.length > 0);
 	});
- 
+
 	// Fetch applicable TTPs whenever the target node changes or its state updates
 	$effect(() => {
 		// Session connect/loss events replace the campaign graph, so track it in
 		// addition to the selected node's directly exposed applicability fields.
 		void campaign.graph;
-		const nodeState = target ? {
-			compromised: target.compromised,
-			accessLevel: target.accessLevel,
-			entity: target.entity
-		} : null;
-		
+		const nodeState = target
+			? {
+					compromised: target.compromised,
+					accessLevel: target.accessLevel,
+					entity: target.entity
+				}
+			: null;
+
 		if (!targetId) {
 			applicableTTPs = new Map();
 			return;
@@ -123,18 +138,22 @@
 		const requestedTargetId = targetId;
 		applicableTTPs = new Map();
 		const targetKind = campaign.graph.nodes.find((node) => node.id === requestedTargetId)?.kind;
-		const podIds = targetKind && WORKLOAD_KINDS.has(targetKind)
-			? campaign.graph.nodes
-				.filter((node) => node.kind === 'Pod' && node.parent === requestedTargetId)
-				.map((node) => node.id)
-			: [];
-		const applicableRequest = podIds.length > 0
-			? Promise.all(podIds.map((podId) => campaign.api.GetApplicableTTPs(podId))).then((results) => {
-				const byId = new Map<string, TTP>();
-				results.flat().forEach((ttp) => byId.set(ttp.id, ttp));
-				return [...byId.values()];
-			})
-			: campaign.api.GetApplicableTTPs(requestedTargetId);
+		const podIds =
+			targetKind && WORKLOAD_KINDS.has(targetKind)
+				? campaign.graph.nodes
+						.filter((node) => node.kind === 'Pod' && node.parent === requestedTargetId)
+						.map((node) => node.id)
+				: [];
+		const applicableRequest =
+			podIds.length > 0
+				? Promise.all(podIds.map((podId) => campaign.api.GetApplicableTTPs(podId))).then(
+						(results) => {
+							const byId = new Map<string, TTP>();
+							results.flat().forEach((ttp) => byId.set(ttp.id, ttp));
+							return [...byId.values()];
+						}
+					)
+				: campaign.api.GetApplicableTTPs(requestedTargetId);
 
 		applicableRequest
 			.then((result: TTP[]) => {
@@ -158,7 +177,6 @@
 			searchInputElement?.focus();
 		};
 	});
-
 
 	function handleClearWithEscape(event: KeyboardEvent) {
 		if (event.key == 'Escape') {
@@ -200,22 +218,36 @@
 	}
 
 	function onActionSelected(ttp: TTP) {
-		searchTerm = ''; // reset the filter again to show all TTPs 
+		searchTerm = ''; // reset the filter again to show all TTPs
 		sendAction(ttp);
 	}
 </script>
 
 <div class="bg-surface-100-900 inset-y-0 right-0 flex flex-col {className}">
-	<Tabs value={activeTab} onValueChange={(e) => (activeTab = e.value)} class="flex-1 min-h-0 flex flex-col">
-		<Tabs.List class="grid h-10 w-full flex-none {scoringEnabled ? 'grid-cols-2' : 'grid-cols-1'} items-stretch gap-0 overflow-hidden border-b border-surface-300-700 p-0">
+	<Tabs
+		value={activeTab}
+		onValueChange={(e) => (activeTab = e.value)}
+		class="flex min-h-0 flex-1 flex-col"
+	>
+		<Tabs.List
+			class="grid h-10 w-full flex-none {scoringEnabled
+				? 'grid-cols-2'
+				: 'grid-cols-1'} border-surface-300-700 items-stretch gap-0 overflow-hidden border-b p-0"
+		>
 			<Tabs.Trigger
 				value="actions"
-				class="m-0 flex h-full min-h-0 w-full self-stretch items-center justify-center rounded-none p-0 text-center transition-colors {activeTab === 'actions' ? 'bg-surface-200-800 text-primary-700-300 shadow-[inset_0_-2px_0_var(--color-primary-500)] font-semibold' : 'text-surface-500 hover:bg-surface-200-800/60'}"
-			>Actions</Tabs.Trigger>
+				class="m-0 flex h-full min-h-0 w-full items-center justify-center self-stretch rounded-none p-0 text-center transition-colors {activeTab ===
+				'actions'
+					? 'bg-surface-200-800 text-primary-700-300 font-semibold shadow-[inset_0_-2px_0_var(--color-primary-500)]'
+					: 'text-surface-500 hover:bg-surface-200-800/60'}">Actions</Tabs.Trigger
+			>
 			{#if scoringEnabled}
 				<Tabs.Trigger
 					value="recommendations"
-					class="m-0 flex h-full min-h-0 w-full self-stretch items-center justify-center rounded-none p-0 text-center transition-colors {activeTab === 'recommendations' ? 'bg-surface-200-800 text-primary-700-300 shadow-[inset_0_-2px_0_var(--color-primary-500)] font-semibold' : 'text-surface-500 hover:bg-surface-200-800/60'}"
+					class="m-0 flex h-full min-h-0 w-full items-center justify-center self-stretch rounded-none p-0 text-center transition-colors {activeTab ===
+					'recommendations'
+						? 'bg-surface-200-800 text-primary-700-300 font-semibold shadow-[inset_0_-2px_0_var(--color-primary-500)]'
+						: 'text-surface-500 hover:bg-surface-200-800/60'}"
 				>
 					<span class="flex items-center justify-center gap-1">
 						<Icon icon="mdi:lightbulb-on-outline" width="16" class="text-warning-500" />
@@ -226,26 +258,30 @@
 		</Tabs.List>
 
 		<!-- Actions: all applicable TTPs grouped by tactic, scored per target -->
-		<Tabs.Content value="actions" class="flex-1 min-h-0 flex flex-col !p-0 !m-0">
+		<Tabs.Content value="actions" class="!m-0 flex min-h-0 flex-1 flex-col !p-0">
 			{#if liftedPodCount > 0}
-				<div class="flex items-center gap-1.5 px-2 py-1.5 border-b border-surface-200-800 text-xs text-surface-500">
+				<div
+					class="border-surface-200-800 text-surface-500 flex items-center gap-1.5 border-b px-2 py-1.5 text-xs"
+				>
 					<Icon icon="mdi:layers-outline" width="14" />
-					<span>Showing actions from {liftedPodCount} pod{liftedPodCount === 1 ? '' : 's'} in this workload</span>
+					<span
+						>Showing actions from {liftedPodCount} pod{liftedPodCount === 1 ? '' : 's'} in this workload</span
+					>
 				</div>
 			{/if}
 			<!-- Toolbar: search + scope toggle on one compact row -->
-			<div class="flex-shrink-0 flex items-center gap-2 px-2 py-2 border-b border-surface-200-800">
+			<div class="border-surface-200-800 flex flex-shrink-0 items-center gap-2 border-b px-2 py-2">
 				<input
 					id="search-box"
 					type="search"
 					placeholder="Search… (a)"
-					class="input rounded-container-token flex-1 min-w-0 !py-1 text-sm"
+					class="input rounded-container-token min-w-0 flex-1 !py-1 text-sm"
 					bind:this={searchInputElement}
 					bind:value={searchTerm}
 					onkeydown={handleClearWithEscape}
 				/>
 				<div
-					class="flex shrink-0 rounded-md overflow-hidden border border-surface-300-700 text-xs"
+					class="border-surface-300-700 flex shrink-0 overflow-hidden rounded-md border text-xs"
 					role="group"
 					aria-label="Action scope"
 				>
@@ -260,7 +296,7 @@
 						Applicable
 					</button>
 					<button
-						class="px-2 py-1 border-l border-surface-300-700 transition-colors {showAllTTPs
+						class="border-surface-300-700 border-l px-2 py-1 transition-colors {showAllTTPs
 							? 'bg-primary-500 text-primary-contrast-500'
 							: 'text-surface-500 hover:bg-surface-200-800'}"
 						aria-pressed={showAllTTPs}
@@ -272,32 +308,43 @@
 				</div>
 			</div>
 
-			<div class="flex-1 overflow-y-auto min-h-0">
+			<div class="min-h-0 flex-1 overflow-y-auto">
 				{#if shownTTPs.length === 0}
 					<div class="flex h-full items-center justify-center text-center text-gray-500">
-						No TTPs available. <br>
+						No TTPs available. <br />
 						Please select an entity in the graph.
 					</div>
 				{:else}
-					<Accordion value={openTactic} onValueChange={(e) => (openTactic = e.value)} collapsible class="!gap-0 !space-y-0 bg-surface-200-800">
+					<Accordion
+						value={openTactic}
+						onValueChange={(e) => (openTactic = e.value)}
+						collapsible
+						class="bg-surface-200-800 !gap-0 !space-y-0"
+					>
 						{#each Array.from(shownTTPs) as [tactic, ttps]}
 							<Accordion.Item
 								value={tactic}
-								class="text-surface-contrast-200-800 !p-0 mb-0 !gap-0"
+								class="text-surface-contrast-200-800 mb-0 !gap-0 !p-0"
 								disabled={ttps?.length === 0}
 							>
-								<Accordion.ItemTrigger class="flex justify-between items-center bg-surface-200-800 hover:bg-surface-300-700 hover:text-primary-800-200 text-m lg:text-l border-t border-surface-300-700 p-3 !m-0">
+								<Accordion.ItemTrigger
+									class="bg-surface-200-800 hover:bg-surface-300-700 hover:text-primary-800-200 text-m lg:text-l border-surface-300-700 !m-0 flex items-center justify-between border-t p-3"
+								>
 									<Icon icon={iconMap[tactic]} width="26" class="flex-shrink-0"></Icon>
-									<div class="flex w-full items-center ml-2">
+									<div class="ml-2 flex w-full items-center">
 										<span class="flex-1">{tactic}</span>
-										<span class="ml-2 px-2 py-0.5 rounded text-xs bg-surface-200-800 text-surface-contrast-200-800">
+										<span
+											class="bg-surface-200-800 text-surface-contrast-200-800 ml-2 rounded px-2 py-0.5 text-xs"
+										>
 											{applicableTTPs.get(tactic)?.length ?? 0}
 										</span>
 									</div>
 								</Accordion.ItemTrigger>
-								<Accordion.ItemContent class="!p-0 !m-0 !gap-0 bg-surface-100-900">
+								<Accordion.ItemContent class="bg-surface-100-900 !m-0 !gap-0 !p-0">
 									{#each byUtility(ttps) as ttp}
-										<div class="ml-3 border-t-1 border-surface-400-600 bg-surface-200-800 hover:text-primary-800-200">
+										<div
+											class="border-surface-400-600 bg-surface-200-800 hover:text-primary-800-200 ml-3 border-t-1"
+										>
 											<ActionCard
 												{ttp}
 												prerequisitesFulfilled={isTTPApplicable(ttp)}
@@ -319,7 +366,7 @@
 
 		<!-- Recommendations: utility-scored next steps across all targets -->
 		{#if scoringEnabled}
-			<Tabs.Content value="recommendations" class="flex-1 min-h-0 flex flex-col !p-0 !m-0">
+			<Tabs.Content value="recommendations" class="!m-0 flex min-h-0 flex-1 flex-col !p-0">
 				<Recommendations run={runRecommendation}>
 					{#snippet actions()}
 						<ScoringTuner />

--- a/frontend/src/routes/components/c2_badges.svelte.test.ts
+++ b/frontend/src/routes/components/c2_badges.svelte.test.ts
@@ -197,9 +197,7 @@ describe('C2Badges', () => {
 		// The tooltip names the tool, because that is what says which kind of
 		// redirector this is; the playground id alone carries nothing.
 		expect(
-			screen.getByTitle(
-				'labctl 1337→4444 - via labctl on playground zn1kqxk3ykpvxp5x'
-			)
+			screen.getByTitle('labctl 1337→4444 - via labctl on playground zn1kqxk3ykpvxp5x')
 		).toBeInTheDocument();
 	});
 

--- a/frontend/src/routes/components/c2_badges.test.ts
+++ b/frontend/src/routes/components/c2_badges.test.ts
@@ -136,11 +136,7 @@ describe('c2Badges', () => {
 
 	it('names the adapters in a collapsed listener tooltip', () => {
 		const groups = c2Badges(
-			[
-				c2Node([listener('tcp', 1), listener('tcp', 2)], 'c2/ran', [
-					redirector('play1', 1337, 2)
-				])
-			],
+			[c2Node([listener('tcp', 1), listener('tcp', 2)], 'c2/ran', [redirector('play1', 1337, 2)])],
 			1
 		);
 
@@ -151,12 +147,7 @@ describe('c2Badges', () => {
 
 	it('names orphans by tool and hop in the overflow tooltip', () => {
 		const groups = c2Badges(
-			[
-				c2Node([], 'c2/ran', [
-					redirector('play1', 9000, 4444),
-					redirector('play2', 9001, 4444)
-				])
-			],
+			[c2Node([], 'c2/ran', [redirector('play1', 9000, 4444), redirector('play2', 9001, 4444)])],
 			1
 		);
 

--- a/frontend/src/routes/components/consideration_breakdown.svelte
+++ b/frontend/src/routes/components/consideration_breakdown.svelte
@@ -34,25 +34,38 @@
 		if (c.veto) return `× ${c.curved.toFixed(3)} gate`;
 		return `${c.weight.toFixed(1)} × ${c.curved.toFixed(3)} weighted value`;
 	}
-
 </script>
 
 <div class="space-y-1 {className}">
 	{#each breakdown as c (c.name)}
 		{@const help = helpFor(c.name)}
-		<details class="group rounded px-1 -mx-1 {isActiveVeto(c) || isBeliefBlocker(c) ? 'bg-error-500/10' : ''}">
-			<summary class="flex items-center gap-2 cursor-pointer list-none" title={`${c.name} - ${statusTitle(c)}`}>
-				<span class="text-xs text-surface-500 w-28 truncate">{c.name}</span>
-				<div class="h-1 flex-1 rounded bg-surface-300-700 overflow-hidden">
+		<details
+			class="group -mx-1 rounded px-1 {isActiveVeto(c) || isBeliefBlocker(c)
+				? 'bg-error-500/10'
+				: ''}"
+		>
+			<summary
+				class="flex cursor-pointer list-none items-center gap-2"
+				title={`${c.name} - ${statusTitle(c)}`}
+			>
+				<span class="text-surface-500 w-28 truncate text-xs">{c.name}</span>
+				<div class="bg-surface-300-700 h-1 flex-1 overflow-hidden rounded">
 					<div
-						class="h-full {c.veto || isBeliefBlocker(c) ? 'bg-error-500' : c.kind === 'belief' ? 'bg-warning-500' : 'bg-primary-500'}"
+						class="h-full {c.veto || isBeliefBlocker(c)
+							? 'bg-error-500'
+							: c.kind === 'belief'
+								? 'bg-warning-500'
+								: 'bg-primary-500'}"
 						style="width: {Math.round(c.curved * 100)}%"
 					></div>
 				</div>
-				<span class="text-xs text-surface-500 w-7 text-right">{c.curved.toFixed(2)}</span>
+				<span class="text-surface-500 w-7 text-right text-xs">{c.curved.toFixed(2)}</span>
 			</summary>
-			<div class="ml-2 mt-1 mb-2 border-l border-surface-300-700 pl-2 text-[11px] leading-snug text-surface-600-400 space-y-1">
-				{#if help}<p>{help.summary}</p><code class="block text-surface-900-100">{help.formula}</code>{/if}
+			<div
+				class="border-surface-300-700 text-surface-600-400 mt-1 mb-2 ml-2 space-y-1 border-l pl-2 text-[11px] leading-snug"
+			>
+				{#if help}<p>{help.summary}</p>
+					<code class="text-surface-900-100 block">{help.formula}</code>{/if}
 				<p class="font-mono">raw {c.raw.toFixed(3)} → curve {c.curved.toFixed(3)}</p>
 				<p>{contribution(c)} · {statusTitle(c)}</p>
 			</div>

--- a/frontend/src/routes/components/elk_layout.ts
+++ b/frontend/src/routes/components/elk_layout.ts
@@ -3,18 +3,18 @@ import { INFORMATIONAL_EDGES } from './edge_categories';
 
 /** Rejects positions with non-finite coordinates or extreme values. */
 export function isValidPosition(pos: unknown): pos is { x: number; y: number } {
-  if (!pos || typeof pos !== 'object') return false;
-  const { x, y } = pos as { x: number; y: number };
-  return (
-    typeof x === 'number' &&
-    typeof y === 'number' &&
-    isFinite(x) &&
-    isFinite(y) &&
-    !isNaN(x) &&
-    !isNaN(y) &&
-    Math.abs(x) < 1e6 &&
-    Math.abs(y) < 1e6
-  );
+	if (!pos || typeof pos !== 'object') return false;
+	const { x, y } = pos as { x: number; y: number };
+	return (
+		typeof x === 'number' &&
+		typeof y === 'number' &&
+		isFinite(x) &&
+		isFinite(y) &&
+		!isNaN(x) &&
+		!isNaN(y) &&
+		Math.abs(x) < 1e6 &&
+		Math.abs(y) < 1e6
+	);
 }
 
 /**
@@ -28,92 +28,96 @@ export const NODE_LAYER: Record<string, number> = {
 	Namespace: 3,
 	// Attack origin
 	C2: 0,
-  // External machines / adversary infrastructure
-  Adversary: 1,
-  System: 1,
-  // C2 channels. Listeners and redirectors are absent on purpose: both render as
-  // badges on their C2 rather than as nodes, so they never reach the layout.
-  Session: 2,
-  // Cluster entry points
-  Ingress: 3,
-  Service: 3,
-  AppService: 4,
-  // Workloads
-  Pod: 4,
-  Container: 4,
-  MicroService: 4,
-  AbstractWorkload: 4,
-  Deployment: 4,
-  ReplicaSet: 4,
-  StatefulSet: 4,
-  DaemonSet: 4,
-  Job: 4,
-  CronJob: 4,
-  // RBAC / k8s resources (tend to be used BY workloads, so one step right)
-  ServiceAccount: 5,
-  K8sCredential: 5,
-  Role: 5,
-  ClusterRole: 5,
-  RoleBinding: 5,
-  ClusterRoleBinding: 5,
-  User: 5,
-  Group: 5,
-  ConfigMap: 5,
-  Secret: 5,
-  Volume: 5,
-  // Control plane
-  KubeApiServer: 6,
-  ControlPlane: 6,
-  // Infrastructure nodes (also pushed south via priority)
-  Node: 7,
-  ClusterNode: 7,
-  // Cloud resources
-  GCPBucket: 8,
-  GCPServiceAccount: 8,
-  GCPServiceAccountToken: 8,
-  MetadataServer: 8,
-  GCPMetadataServer: 8,
+	// External machines / adversary infrastructure
+	Adversary: 1,
+	System: 1,
+	// C2 channels. Listeners and redirectors are absent on purpose: both render as
+	// badges on their C2 rather than as nodes, so they never reach the layout.
+	Session: 2,
+	// Cluster entry points
+	Ingress: 3,
+	Service: 3,
+	AppService: 4,
+	// Workloads
+	Pod: 4,
+	Container: 4,
+	MicroService: 4,
+	AbstractWorkload: 4,
+	Deployment: 4,
+	ReplicaSet: 4,
+	StatefulSet: 4,
+	DaemonSet: 4,
+	Job: 4,
+	CronJob: 4,
+	// RBAC / k8s resources (tend to be used BY workloads, so one step right)
+	ServiceAccount: 5,
+	K8sCredential: 5,
+	Role: 5,
+	ClusterRole: 5,
+	RoleBinding: 5,
+	ClusterRoleBinding: 5,
+	User: 5,
+	Group: 5,
+	ConfigMap: 5,
+	Secret: 5,
+	Volume: 5,
+	// Control plane
+	KubeApiServer: 6,
+	ControlPlane: 6,
+	// Infrastructure nodes (also pushed south via priority)
+	Node: 7,
+	ClusterNode: 7,
+	// Cloud resources
+	GCPBucket: 8,
+	GCPServiceAccount: 8,
+	GCPServiceAccountToken: 8,
+	MetadataServer: 8,
+	GCPMetadataServer: 8
 };
 
 export type LayeringStrategy = 'NETWORK_SIMPLEX' | 'LONGEST_PATH' | 'INTERACTIVE' | 'MIN_WIDTH';
-export type NodePlacementStrategy = 'BRANDES_KOEPF' | 'NETWORK_SIMPLEX' | 'LINEAR_SEGMENTS' | 'SIMPLE';
+export type NodePlacementStrategy =
+	| 'BRANDES_KOEPF'
+	| 'NETWORK_SIMPLEX'
+	| 'LINEAR_SEGMENTS'
+	| 'SIMPLE';
 
 export type LayoutParams = {
-  // Spacing
-  layerSpacing: number;       // horizontal gap between attack-chain layers
-  nodeSpacing: number;        // vertical gap between nodes in the same layer
-  edgeNodeSpacing: number;    // gap between edges and nodes across layer boundaries
-  aspectRatio: number;        // target width/height ratio for the overall layout
-  // Compound (namespace) sub-layout
-  compoundEdgeLength: number; // stress target edge length within namespace compounds
-  compoundPadding: number;    // padding inside namespace compound nodes
-  stressIterations: number;   // max iterations of stress algorithm inside compounds
-  // Edge behaviour
-  usesStraightness: number;   // 0-10: how hard ELK tries to align "uses" edge endpoints vertically
-  // Animation
-  animationDuration: number;  // ms; 0 = instant
-  // Strategies
-  layeringStrategy: LayeringStrategy;
-  nodePlacementStrategy: NodePlacementStrategy;
+	// Spacing
+	layerSpacing: number; // horizontal gap between attack-chain layers
+	nodeSpacing: number; // vertical gap between nodes in the same layer
+	edgeNodeSpacing: number; // gap between edges and nodes across layer boundaries
+	aspectRatio: number; // target width/height ratio for the overall layout
+	// Compound (namespace) sub-layout
+	compoundEdgeLength: number; // stress target edge length within namespace compounds
+	compoundPadding: number; // padding inside namespace compound nodes
+	stressIterations: number; // max iterations of stress algorithm inside compounds
+	// Edge behaviour
+	usesStraightness: number; // 0-10: how hard ELK tries to align "uses" edge endpoints vertically
+	// Animation
+	animationDuration: number; // ms; 0 = instant
+	// Strategies
+	layeringStrategy: LayeringStrategy;
+	nodePlacementStrategy: NodePlacementStrategy;
 };
 
 export const DEFAULT_LAYOUT_PARAMS: LayoutParams = {
-  layerSpacing: 130,
-  nodeSpacing: 40,
-  edgeNodeSpacing: 20,
-  aspectRatio: 1.6,
+	layerSpacing: 130,
+	nodeSpacing: 40,
+	edgeNodeSpacing: 20,
+	aspectRatio: 1.6,
 	compoundEdgeLength: 32,
 	compoundPadding: 8,
-  stressIterations: 300,
-  usesStraightness: 3,
-  animationDuration: 250,
-  layeringStrategy: 'NETWORK_SIMPLEX',
-  nodePlacementStrategy: 'BRANDES_KOEPF',
+	stressIterations: 300,
+	usesStraightness: 3,
+	animationDuration: 250,
+	layeringStrategy: 'NETWORK_SIMPLEX',
+	nodePlacementStrategy: 'BRANDES_KOEPF'
 };
 
 /** Serialise a position for the elk.position layout option. */
 function elkPos(x: number, y: number): string {
-  return `(${Math.round(x)},${Math.round(y)})`;
+	return `(${Math.round(x)},${Math.round(y)})`;
 }
 
 /**
@@ -124,81 +128,81 @@ function elkPos(x: number, y: number): string {
  * @param params - Tunable spacing parameters (defaults to DEFAULT_LAYOUT_PARAMS).
  */
 export function createElkLayout(
-  positions: Record<string, { x: number; y: number }> = {},
-  params: LayoutParams = DEFAULT_LAYOUT_PARAMS
+	positions: Record<string, { x: number; y: number }> = {},
+	params: LayoutParams = DEFAULT_LAYOUT_PARAMS
 ): cytoscape.LayoutOptions & Record<string, unknown> {
-  const p = params.compoundPadding;
-  const compoundPad = `[top=${p},left=${p},bottom=${p},right=${p}]`;
+	const p = params.compoundPadding;
+	const compoundPad = `[top=${p},left=${p},bottom=${p},right=${p}]`;
 
-  return {
-    name: 'elk',
-    nodeDimensionsIncludeLabels: true,
-    fit: false,
-    padding: 60,
-    animate: params.animationDuration > 0,
-    animationDuration: params.animationDuration,
+	return {
+		name: 'elk',
+		nodeDimensionsIncludeLabels: true,
+		fit: false,
+		padding: 60,
+		animate: params.animationDuration > 0,
+		animationDuration: params.animationDuration,
 
-    elk: {
-		'elk.algorithm': 'layered',
-		'elk.direction': 'RIGHT',
-		// Process child-to-external edges (for example local kubeconfig → cluster)
-		// in the same run so compound parents receive meaningful ordering.
-		'org.eclipse.elk.hierarchyHandling': 'INCLUDE_CHILDREN',
-      'elk.aspectRatio': String(params.aspectRatio),
-      'elk.layered.spacing.nodeNodeBetweenLayers': String(params.layerSpacing),
-      'elk.spacing.nodeNode': String(params.nodeSpacing),
-      'elk.layered.spacing.edgeNodeBetweenLayers': String(params.edgeNodeSpacing),
-      'elk.edgeRouting': 'SPLINES',
-      'elk.interactiveLayout': 'true',
-      'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
-      'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
-      'elk.layered.layering.strategy': params.layeringStrategy,
-      'elk.layered.nodePlacement.strategy': params.nodePlacementStrategy,
-      'elk.padding': '[top=20,left=20,bottom=20,right=20]',
-    },
+		elk: {
+			'elk.algorithm': 'layered',
+			'elk.direction': 'RIGHT',
+			// Process child-to-external edges (for example local kubeconfig → cluster)
+			// in the same run so compound parents receive meaningful ordering.
+			'org.eclipse.elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+			'elk.aspectRatio': String(params.aspectRatio),
+			'elk.layered.spacing.nodeNodeBetweenLayers': String(params.layerSpacing),
+			'elk.spacing.nodeNode': String(params.nodeSpacing),
+			'elk.layered.spacing.edgeNodeBetweenLayers': String(params.edgeNodeSpacing),
+			'elk.edgeRouting': 'SPLINES',
+			'elk.interactiveLayout': 'true',
+			'elk.layered.considerModelOrder.strategy': 'NODES_AND_EDGES',
+			'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
+			'elk.layered.layering.strategy': params.layeringStrategy,
+			'elk.layered.nodePlacement.strategy': params.nodePlacementStrategy,
+			'elk.padding': '[top=20,left=20,bottom=20,right=20]'
+		},
 
-    nodeLayoutOptions: (node: cytoscape.NodeSingular) => {
-      const opts: Record<string, string> = {};
+		nodeLayoutOptions: (node: cytoscape.NodeSingular) => {
+			const opts: Record<string, string> = {};
 
-		const pos = positions[node.id()];
-		if (pos) {
-			opts['elk.position'] = elkPos(pos.x, pos.y);
+			const pos = positions[node.id()];
+			if (pos) {
+				opts['elk.position'] = elkPos(pos.x, pos.y);
+			}
+
+			// A compound participates in its parent's layered layout as one node, so
+			// it needs its own layer hint even though its children use a local layout.
+			const kind: string = node.data('kind') ?? '';
+			const layer = NODE_LAYER[kind];
+			if (layer !== undefined) {
+				opts['elk.layered.layering.layer'] = String(layer);
+			}
+			if (kind === 'OperatorHost') {
+				opts['org.eclipse.elk.layered.layering.layerConstraint'] = 'FIRST';
+			}
+
+			if (node.isParent()) {
+				// A single layered hierarchy is required for edges that cross compound
+				// boundaries. Mixing stress sub-layouts with INCLUDE_CHILDREN makes ELK
+				// treat child and external endpoints as belonging to different runs.
+				opts['elk.algorithm'] = 'layered';
+				opts['elk.direction'] = 'RIGHT';
+				opts['elk.spacing.nodeNode'] = '18';
+				opts['elk.layered.spacing.nodeNodeBetweenLayers'] = String(params.compoundEdgeLength);
+				opts['elk.padding'] = compoundPad;
+			}
+
+			return opts;
+		},
+
+		edgeLayoutOptions: (edge: cytoscape.EdgeSingular) => {
+			const name: string = edge.data('name');
+			if (name === 'uses') {
+				return { 'elk.layered.priority.straightness': String(params.usesStraightness) };
+			}
+			if (INFORMATIONAL_EDGES.has(name)) {
+				return undefined;
+			}
+			return {};
 		}
-
-		// A compound participates in its parent's layered layout as one node, so
-		// it needs its own layer hint even though its children use a local layout.
-		const kind: string = node.data('kind') ?? '';
-		const layer = NODE_LAYER[kind];
-		if (layer !== undefined) {
-			opts['elk.layered.layering.layer'] = String(layer);
-		}
-		if (kind === 'OperatorHost') {
-			opts['org.eclipse.elk.layered.layering.layerConstraint'] = 'FIRST';
-		}
-
-		if (node.isParent()) {
-			// A single layered hierarchy is required for edges that cross compound
-			// boundaries. Mixing stress sub-layouts with INCLUDE_CHILDREN makes ELK
-			// treat child and external endpoints as belonging to different runs.
-			opts['elk.algorithm'] = 'layered';
-			opts['elk.direction'] = 'RIGHT';
-			opts['elk.spacing.nodeNode'] = '18';
-			opts['elk.layered.spacing.nodeNodeBetweenLayers'] = String(params.compoundEdgeLength);
-			opts['elk.padding'] = compoundPad;
-		}
-
-      return opts;
-    },
-
-    edgeLayoutOptions: (edge: cytoscape.EdgeSingular) => {
-      const name: string = edge.data('name');
-      if (name === 'uses') {
-        return { 'elk.layered.priority.straightness': String(params.usesStraightness) };
-      }
-      if (INFORMATIONAL_EDGES.has(name)) {
-        return undefined;
-      }
-      return {};
-    },
-  };
+	};
 }

--- a/frontend/src/routes/components/entitlement_info.svelte
+++ b/frontend/src/routes/components/entitlement_info.svelte
@@ -74,9 +74,10 @@
 	function matchingAssessments(permission: RBACPermission): KubetierPermission[] {
 		if (!catalog) return [];
 		const resource = permissionResource(permission);
-		const nonResourceUrl = !resource && (permission.resourceName?.startsWith('/') || permission.resourceName === '*')
-			? permission.resourceName
-			: null;
+		const nonResourceUrl =
+			!resource && (permission.resourceName?.startsWith('/') || permission.resourceName === '*')
+				? permission.resourceName
+				: null;
 		const scopeKind = permission.scopeKind ?? 'unknown';
 		return catalog.permissions.filter((assessment) => {
 			const universalWildcard = permission.verb === '*' && resource === '*';
@@ -93,18 +94,21 @@
 				: nonResourceUrl !== null || normalizedGroup(permission) === '*'
 					? true
 					: assessment.apiGroup === normalizedGroup(permission);
-			const scopeMatches = universalWildcard || (scopeKind === 'unknown'
-				? true
-				: scopeKind === 'cluster'
-					? assessment.scope === 'cluster'
-					: assessment.scope === 'namespaced');
+			const scopeMatches =
+				universalWildcard ||
+				(scopeKind === 'unknown'
+					? true
+					: scopeKind === 'cluster'
+						? assessment.scope === 'cluster'
+						: assessment.scope === 'namespaced');
 			return verbMatches && resourceMatches && groupMatches && scopeMatches;
 		});
 	}
 
 	function tiersFor(permission: RBACPermission): KubetierTier[] {
-		return [...new Set(matchingAssessments(permission).map((entry) => entry.tier))]
-			.sort((a, b) => tierRank[a] - tierRank[b]);
+		return [...new Set(matchingAssessments(permission).map((entry) => entry.tier))].sort(
+			(a, b) => tierRank[a] - tierRank[b]
+		);
 	}
 
 	function scopeLabel(permission: RBACPermission): string {
@@ -120,15 +124,19 @@
 	}
 
 	function isUniversalResourcePermission(permission: RBACPermission): boolean {
-		return permission.verb === '*'
-			&& permissionResource(permission) === '*'
-			&& normalizedGroup(permission) === '*';
+		return (
+			permission.verb === '*' &&
+			permissionResource(permission) === '*' &&
+			normalizedGroup(permission) === '*'
+		);
 	}
 
 	function isUniversalNonResourcePermission(permission: RBACPermission): boolean {
-		return permission.verb === '*'
-			&& permissionResource(permission) === ''
-			&& permission.resourceName === '*';
+		return (
+			permission.verb === '*' &&
+			permissionResource(permission) === '' &&
+			permission.resourceName === '*'
+		);
 	}
 
 	function permissionIdentity(permission: RBACPermission): string {
@@ -150,14 +158,18 @@
 		const filteredEntitlements = hasUniversalResourcePermission
 			? entitlements.filter((permission) => !isUniversalNonResourcePermission(permission))
 			: entitlements;
-		const visibleEntitlements = [...new Map(
-			filteredEntitlements.map((permission) => [permissionIdentity(permission), permission])
-		).values()];
+		const visibleEntitlements = [
+			...new Map(
+				filteredEntitlements.map((permission) => [permissionIdentity(permission), permission])
+			).values()
+		];
 		return [...visibleEntitlements].sort((a, b) => {
 			const aTier = tiersFor(a)[0];
 			const bTier = tiersFor(b)[0];
 			const rank = (aTier ? tierRank[aTier] : 99) - (bTier ? tierRank[bTier] : 99);
-			return rank || `${a.verb} ${displayResource(a)}`.localeCompare(`${b.verb} ${displayResource(b)}`);
+			return (
+				rank || `${a.verb} ${displayResource(a)}`.localeCompare(`${b.verb} ${displayResource(b)}`)
+			);
 		});
 	}
 
@@ -178,11 +190,15 @@
 		return [...links.values()];
 	}
 
-	function assessmentLabel(assessment: KubetierPermission, assessments: KubetierPermission[]): string {
+	function assessmentLabel(
+		assessment: KubetierPermission,
+		assessments: KubetierPermission[]
+	): string {
 		const base = `${assessment.verb} ${assessment.resource}`;
-		const hasScopeVariants = assessments.filter((entry) =>
-			entry.verb === assessment.verb && entry.resource === assessment.resource
-		).length > 1;
+		const hasScopeVariants =
+			assessments.filter(
+				(entry) => entry.verb === assessment.verb && entry.resource === assessment.resource
+			).length > 1;
 		return hasScopeVariants ? `${base} (${assessment.scope})` : base;
 	}
 
@@ -196,10 +212,16 @@
 		return [...new Set(matches.flatMap((assessment) => assessment.description ?? []))];
 	}
 
-	function uniqueEscalationPaths(matches: KubetierPermission[]): KubetierPermission['escalationPaths'] {
-		return [...new Map(
-			matches.flatMap((assessment) => assessment.escalationPaths).map((path) => [path.sourceUrl, path])
-		).values()];
+	function uniqueEscalationPaths(
+		matches: KubetierPermission[]
+	): KubetierPermission['escalationPaths'] {
+		return [
+			...new Map(
+				matches
+					.flatMap((assessment) => assessment.escalationPaths)
+					.map((path) => [path.sourceUrl, path])
+			).values()
+		];
 	}
 
 	function escalationCount(matches: KubetierPermission[]): number {
@@ -239,12 +261,14 @@
 	}
 
 	function actualRuleSet(): Set<string> {
-		return new Set(entitlements.map((permission) => {
-			const resource = permissionResource(permission);
-			const target = resource || `url:${permission.resourceName ?? ''}`;
-			const resourceName = resource ? permission.resourceName ?? '' : '';
-			return `${normalizedGroup(permission)}|${target}|${permission.verb}|${resourceName}`;
-		}));
+		return new Set(
+			entitlements.map((permission) => {
+				const resource = permissionResource(permission);
+				const target = resource || `url:${permission.resourceName ?? ''}`;
+				const resourceName = resource ? (permission.resourceName ?? '') : '';
+				return `${normalizedGroup(permission)}|${target}|${permission.verb}|${resourceName}`;
+			})
+		);
 	}
 
 	function referenceRuleSet(role: KubetierRole): Set<string> {
@@ -270,23 +294,35 @@
 </script>
 
 {#if builtInRole}
-	<div class="mb-3 rounded border border-surface-300 p-2 dark:border-surface-700">
+	<div class="border-surface-300 dark:border-surface-700 mb-3 rounded border p-2">
 		<div class="flex flex-wrap items-center gap-2">
-			<span class={`rounded border px-1.5 py-0.5 font-mono font-bold ${tierClass(builtInRole.tier)}`}>
+			<span
+				class={`rounded border px-1.5 py-0.5 font-mono font-bold ${tierClass(builtInRole.tier)}`}
+			>
 				{builtInRole.tier}
 			</span>
-			<a class="font-semibold underline" href={builtInRole.sourceUrl} target="_blank" rel="noreferrer">
+			<a
+				class="font-semibold underline"
+				href={builtInRole.sourceUrl}
+				target="_blank"
+				rel="noreferrer"
+			>
 				KubeTier built-in Role assessment ↗
 			</a>
 		</div>
 		{#if roleMatches(builtInRole)}
-			<p class="mt-1 text-green-700 dark:text-green-300">Discovered rules match the imported reference.</p>
+			<p class="mt-1 text-green-700 dark:text-green-300">
+				Discovered rules match the imported reference.
+			</p>
 		{:else}
 			<p class="mt-1 font-semibold text-amber-700 dark:text-amber-300">
-				Definition differs from the imported Kubernetes {catalog?.validatedKubernetesVersion ?? ''} reference; this is a nominal tier only.
+				Definition differs from the imported Kubernetes {catalog?.validatedKubernetesVersion ?? ''} reference;
+				this is a nominal tier only.
 			</p>
 		{/if}
-		{#if builtInRole.description}<p class="mt-1 text-surface-600 dark:text-surface-300">{builtInRole.description}</p>{/if}
+		{#if builtInRole.description}<p class="text-surface-600 dark:text-surface-300 mt-1">
+				{builtInRole.description}
+			</p>{/if}
 	</div>
 {/if}
 
@@ -295,11 +331,12 @@
 		{@const tiers = tiersFor(permission)}
 		<div class="flex items-center gap-1">
 			<span class={`font-mono ${permissionTierClass(tiers[0])}`}>
-				{permission.verb} {displayResource(permission)}
+				{permission.verb}
+				{displayResource(permission)}
 			</span>
 			<button
 				type="button"
-				class="inline-flex cursor-help items-center text-surface-400 hover:text-surface-700 focus:outline-none dark:hover:text-surface-200"
+				class="text-surface-400 hover:text-surface-700 dark:hover:text-surface-200 inline-flex cursor-help items-center focus:outline-none"
 				aria-label={`Details for ${permission.verb} ${displayResource(permission)}`}
 				onmouseenter={(event) => showTooltip(event, permission)}
 				onmouseleave={scheduleTooltipHide}
@@ -323,7 +360,7 @@
 		role="dialog"
 		aria-label="Capability details"
 		tabindex="-1"
-		class="fixed z-50 max-h-[70vh] w-[min(28rem,calc(100vw-1rem))] overflow-auto rounded-md border border-surface-300 bg-surface-50 p-3 text-sm font-normal text-surface-700 shadow-xl dark:border-surface-600 dark:bg-surface-900 dark:text-surface-200"
+		class="border-surface-300 bg-surface-50 text-surface-700 dark:border-surface-600 dark:bg-surface-900 dark:text-surface-200 fixed z-50 max-h-[70vh] w-[min(28rem,calc(100vw-1rem))] overflow-auto rounded-md border p-3 text-sm font-normal shadow-xl"
 		style:left={`${activeTooltip.left}px`}
 		style:top={activeTooltip.top === undefined ? undefined : `${activeTooltip.top}px`}
 		style:bottom={activeTooltip.bottom === undefined ? undefined : `${activeTooltip.bottom}px`}
@@ -333,7 +370,8 @@
 		onfocusout={scheduleTooltipHide}
 	>
 		<div class="font-mono font-semibold">
-			{activeTooltip.permission.verb} {displayResource(activeTooltip.permission)}
+			{activeTooltip.permission.verb}
+			{displayResource(activeTooltip.permission)}
 		</div>
 		<dl class="mt-2 grid grid-cols-[auto_1fr] gap-x-2 gap-y-1 text-xs">
 			<dt class="text-surface-500">Scope</dt>
@@ -350,7 +388,7 @@
 			<dd><code>{activeTooltip.permission.apiGroup || '(core)'}</code></dd>
 		</dl>
 		{#if matches.length === 0}
-			<p class="mt-2 text-xs text-surface-500">No matching KubeTier assessment.</p>
+			<p class="text-surface-500 mt-2 text-xs">No matching KubeTier assessment.</p>
 		{:else}
 			<div class="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-xs">
 				{#each assessments as assessment}
@@ -359,8 +397,13 @@
 						href={assessmentUrl(assessment)}
 						target="_blank"
 						rel="noreferrer"
-						aria-label={assessments.length === 1 ? 'KubeTier assessment' : `KubeTier: ${assessmentLabel(assessment, assessments)}`}
-					>{assessments.length === 1 ? 'KubeTier assessment' : `KubeTier: ${assessmentLabel(assessment, assessments)}`} ↗</a>
+						aria-label={assessments.length === 1
+							? 'KubeTier assessment'
+							: `KubeTier: ${assessmentLabel(assessment, assessments)}`}
+						>{assessments.length === 1
+							? 'KubeTier assessment'
+							: `KubeTier: ${assessmentLabel(assessment, assessments)}`} ↗</a
+					>
 				{/each}
 				{#each documentationLinks as documentationLink}
 					<a
@@ -368,9 +411,13 @@
 						href={documentationLink.url}
 						target="_blank"
 						rel="noreferrer"
-						aria-label={documentationLinks.length === 1 ? 'Kubernetes documentation' : `Kubernetes docs: ${assessmentLabel(documentationLink.assessment, assessments)}`}
+						aria-label={documentationLinks.length === 1
+							? 'Kubernetes documentation'
+							: `Kubernetes docs: ${assessmentLabel(documentationLink.assessment, assessments)}`}
 					>
-						{documentationLinks.length === 1 ? 'Kubernetes documentation' : `Kubernetes docs: ${assessmentLabel(documentationLink.assessment, assessments)}`} ↗
+						{documentationLinks.length === 1
+							? 'Kubernetes documentation'
+							: `Kubernetes docs: ${assessmentLabel(documentationLink.assessment, assessments)}`} ↗
 					</a>
 				{/each}
 			</div>
@@ -379,13 +426,20 @@
 				<ul class="mt-2 list-disc pl-4">
 					{#each escalationPaths as path}
 						<li>
-							<a class="underline" href={path.sourceUrl} target="_blank" rel="noreferrer">{path.name} ↗</a>
-							{#if path.steps.length > 0}<ol class="list-decimal pl-4">{#each path.steps as step}<li>{step}</li>{/each}</ol>{/if}
+							<a class="underline" href={path.sourceUrl} target="_blank" rel="noreferrer"
+								>{path.name} ↗</a
+							>
+							{#if path.steps.length > 0}<ol class="list-decimal pl-4">
+									{#each path.steps as step}<li>{step}</li>{/each}
+								</ol>{/if}
 						</li>
 					{/each}
 				</ul>
 			{:else if documentedEscalations > 0}
-				<p class="mt-2 text-xs text-surface-500">{#if matches.length > 1}Up to {/if}{documentedEscalations} documented escalation path(s).</p>
+				<p class="text-surface-500 mt-2 text-xs">
+					{#if matches.length > 1}Up to
+					{/if}{documentedEscalations} documented escalation path(s).
+				</p>
 			{/if}
 		{/if}
 	</div>

--- a/frontend/src/routes/components/entitlement_info.svelte
+++ b/frontend/src/routes/components/entitlement_info.svelte
@@ -1,4 +1,11 @@
 <script lang="ts">
+	/* eslint-disable svelte/no-navigation-without-resolve --
+	   Every href in this component is an external documentation URL carried in
+	   the assessment data (sourceUrl, documentationLink.url). resolve() is for
+	   app routes and would corrupt them. The rule cannot see that from a
+	   dynamic href, and the anchors span several lines, so the suppression has
+	   to sit at file scope: keep it that way only while there is no internal
+	   link in here. */
 	import Icon from '@iconify/svelte';
 	import type {
 		KubetierCatalog,

--- a/frontend/src/routes/components/entitlement_info.svelte.test.ts
+++ b/frontend/src/routes/components/entitlement_info.svelte.test.ts
@@ -58,7 +58,8 @@ const catalog: KubetierCatalog = {
 			tier: 'T0',
 			escalationCount: 0,
 			sourceUrl: 'https://kubetier.com/wildcard-all',
-			kubernetesDocUrl: 'https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles',
+			kubernetesDocUrl:
+				'https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles',
 			escalationPaths: []
 		},
 		{
@@ -150,8 +151,18 @@ describe('KubeTier entitlement presentation', () => {
 		render(EntitlementInfo, {
 			props: {
 				entitlements: [
-					permission({ verb: 'get', resourceType: 'configmaps', scopeKind: 'namespace', scope: 'default' }),
-					permission({ verb: 'get', resourceType: 'pods', scopeKind: 'namespace', scope: 'default' })
+					permission({
+						verb: 'get',
+						resourceType: 'configmaps',
+						scopeKind: 'namespace',
+						scope: 'default'
+					}),
+					permission({
+						verb: 'get',
+						resourceType: 'pods',
+						scopeKind: 'namespace',
+						scope: 'default'
+					})
 				],
 				catalog
 			}
@@ -165,25 +176,40 @@ describe('KubeTier entitlement presentation', () => {
 		render(EntitlementInfo, { props: { entitlements: [permission()], catalog } });
 		await fireEvent.mouseEnter(screen.getByLabelText('Details for list secrets'));
 
-		expect(screen.getAllByRole('link', { name: 'KubeTier: list secrets (cluster)' })).toHaveLength(1);
-		expect(screen.getAllByRole('link', { name: 'KubeTier: list secrets (namespaced)' })).toHaveLength(1);
-		expect(screen.getAllByRole('link', { name: 'Kubernetes docs: list secrets (cluster)' })).toHaveLength(1);
-		expect(screen.getAllByRole('link', { name: 'Kubernetes docs: list secrets (namespaced)' })).toHaveLength(1);
+		expect(screen.getAllByRole('link', { name: 'KubeTier: list secrets (cluster)' })).toHaveLength(
+			1
+		);
+		expect(
+			screen.getAllByRole('link', { name: 'KubeTier: list secrets (namespaced)' })
+		).toHaveLength(1);
+		expect(
+			screen.getAllByRole('link', { name: 'Kubernetes docs: list secrets (cluster)' })
+		).toHaveLength(1);
+		expect(
+			screen.getAllByRole('link', { name: 'Kubernetes docs: list secrets (namespaced)' })
+		).toHaveLength(1);
 		expect(screen.queryByText(/Assessment by KubeTier/)).not.toBeInTheDocument();
-		expect(screen.getByRole('link', { name: 'KubeTier: list secrets (cluster)' })).not.toHaveClass('font-semibold');
+		expect(screen.getByRole('link', { name: 'KubeTier: list secrets (cluster)' })).not.toHaveClass(
+			'font-semibold'
+		);
 	});
 
 	it('maps an SSRR wildcard capability exclusively to the dedicated KubeTier entry', async () => {
 		render(EntitlementInfo, {
 			props: {
-				entitlements: [permission({ verb: '*', resourceType: '*', apiGroup: '*', scopeKind: 'unknown' })],
+				entitlements: [
+					permission({ verb: '*', resourceType: '*', apiGroup: '*', scopeKind: 'unknown' })
+				],
 				catalog
 			}
 		});
 		await fireEvent.mouseEnter(screen.getByLabelText('Details for * *'));
 
 		expect(screen.getAllByRole('link', { name: 'KubeTier assessment' })).toHaveLength(1);
-		expect(screen.getByRole('link', { name: 'KubeTier assessment' })).toHaveAttribute('href', 'https://kubetier.com/reference/?p=wildcard-all');
+		expect(screen.getByRole('link', { name: 'KubeTier assessment' })).toHaveAttribute(
+			'href',
+			'https://kubetier.com/reference/?p=wildcard-all'
+		);
 		expect(screen.getAllByRole('link', { name: 'Kubernetes documentation' })).toHaveLength(1);
 	});
 
@@ -200,8 +226,20 @@ describe('KubeTier entitlement presentation', () => {
 						scope: '*',
 						scopeKind: 'cluster'
 					}),
-					permission({ verb: 'get', resourceType: '', resourceName: '/healthz', scope: '*', scopeKind: 'cluster' }),
-					permission({ verb: 'get', resourceType: '', resourceName: '/healthz', scope: '*', scopeKind: 'cluster' })
+					permission({
+						verb: 'get',
+						resourceType: '',
+						resourceName: '/healthz',
+						scope: '*',
+						scopeKind: 'cluster'
+					}),
+					permission({
+						verb: 'get',
+						resourceType: '',
+						resourceName: '/healthz',
+						scope: '*',
+						scopeKind: 'cluster'
+					})
 				],
 				catalog
 			}

--- a/frontend/src/routes/components/entityInfo.svelte
+++ b/frontend/src/routes/components/entityInfo.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import Tree from '$lib/components/tree.svelte';
 	import EntitlementInfo from './entitlement_info.svelte';
 	import Icon from '@iconify/svelte';
 	import type { RBACPermission, TTP } from '$lib/api/index';
@@ -17,8 +16,6 @@
 	let { objectId, sendAction, class: className }: ObjectInfoProps = $props();
 
 	const campaignState = getCampaignState();
-	const items = [];
-	// const tree = new Tree({ items });
 	const obj = $derived(campaignState.getObjectById(objectId));
 
 	// Fields where the button should be suppressed for specific entity kinds.
@@ -188,7 +185,7 @@
 			// 	return obj.toString();
 			// } else if (typeof obj === 'boolean') {
 			// 	return obj ? 'true' : 'false';
-		} else if (obj?.hasOwnProperty('IP')) {
+		} else if (obj != null && Object.hasOwn(obj, 'IP')) {
 			// Handle special case for objects with 'IP' property
 			return obj.IP;
 		} else {
@@ -339,7 +336,7 @@
 						<span class="text-surface-500 text-xs">({data.length})</span>
 					</summary>
 					<div class="space-y-4 pl-4">
-						{#each data as container, idx}
+						{#each data as container}
 							<div class="border-surface-500 border-l-2 py-2 pl-3">
 								<!-- Top: name and command -->
 								<span>Name: </span>

--- a/frontend/src/routes/components/entityInfo.svelte
+++ b/frontend/src/routes/components/entityInfo.svelte
@@ -2,12 +2,11 @@
 	import Tree from '$lib/components/tree.svelte';
 	import EntitlementInfo from './entitlement_info.svelte';
 	import Icon from '@iconify/svelte';
-	import type {RBACPermission, TTP} from '$lib/api/index';
+	import type { RBACPermission, TTP } from '$lib/api/index';
 	import { showToast } from '$lib/components/toaster';
 	import { getCampaignState } from '$lib/components/CampaignState.svelte';
 	import { knowledgeProvenanceBadges } from '$lib/knowledgeProvenance';
 	import { WORKLOAD_KINDS } from './workload_compounds';
-
 
 	type ObjectInfoProps = {
 		objectId: string;
@@ -15,7 +14,7 @@
 		class: string | undefined;
 	};
 
-	let { objectId, sendAction, class: className } : ObjectInfoProps = $props();
+	let { objectId, sendAction, class: className }: ObjectInfoProps = $props();
 
 	const campaignState = getCampaignState();
 	const items = [];
@@ -24,17 +23,17 @@
 
 	// Fields where the button should be suppressed for specific entity kinds.
 	const FIELD_KIND_EXCLUDE: Record<string, string[]> = {
-		'service_account_name': ['ServiceAccount'],
+		service_account_name: ['ServiceAccount']
 	};
 
 	const EFFECT_FIELD_MAP: Record<string, string[]> = {
-		'linux.mounts':            ['mounts'],
-		'sys.envVar':              ['envVars'],
-		'sys.ip':                  ['ips'],
-		'sys.files':               ['files', 'binaries'],
-		'sys.userID':              ['user_id'],
-		'rawServiceaccountToken':       ['service_account_name'],
-		'k8s.SelfSubjectRulesReview':   ['can'],
+		'linux.mounts': ['mounts'],
+		'sys.envVar': ['envVars'],
+		'sys.ip': ['ips'],
+		'sys.files': ['files', 'binaries'],
+		'sys.userID': ['user_id'],
+		rawServiceaccountToken: ['service_account_name'],
+		'k8s.SelfSubjectRulesReview': ['can']
 	};
 
 	function isEmpty(data: any): boolean {
@@ -52,23 +51,34 @@
 		// exec access is gained (e.g. after an exec relation is created).
 		const _track = obj?.accessLevel;
 		const _track2 = obj?.compromised;
-		if (!id) { applicableTtps = []; return; }
+		if (!id) {
+			applicableTtps = [];
+			return;
+		}
 		const kind = campaignState.graph.nodes.find((node) => node.id === id)?.kind;
-		const podIds = kind && WORKLOAD_KINDS.has(kind)
-			? campaignState.graph.nodes
-				.filter((node) => node.kind === 'Pod' && node.parent === id)
-				.map((node) => node.id)
-			: [];
-		const request = podIds.length > 0
-			? Promise.all(podIds.map((podId) => campaignState.api.GetApplicableTTPs(podId))).then((results) => {
-				const byId = new Map<string, TTP>();
-				results.flat().forEach((ttp) => byId.set(ttp.id, ttp));
-				return [...byId.values()];
-			})
-			: campaignState.api.GetApplicableTTPs(id);
+		const podIds =
+			kind && WORKLOAD_KINDS.has(kind)
+				? campaignState.graph.nodes
+						.filter((node) => node.kind === 'Pod' && node.parent === id)
+						.map((node) => node.id)
+				: [];
+		const request =
+			podIds.length > 0
+				? Promise.all(podIds.map((podId) => campaignState.api.GetApplicableTTPs(podId))).then(
+						(results) => {
+							const byId = new Map<string, TTP>();
+							results.flat().forEach((ttp) => byId.set(ttp.id, ttp));
+							return [...byId.values()];
+						}
+					)
+				: campaignState.api.GetApplicableTTPs(id);
 		request
-			.then((ttps) => { applicableTtps = ttps; })
-			.catch(() => { applicableTtps = []; });
+			.then((ttps) => {
+				applicableTtps = ttps;
+			})
+			.catch(() => {
+				applicableTtps = [];
+			});
 	});
 
 	const fieldTtpIndex = $derived.by(() => {
@@ -82,7 +92,7 @@
 		}
 		return idx;
 	});
-	
+
 	// Track previous values and highlighted fields
 	let previousObjectId: string | null = null;
 	let previousValues: Record<string, any> = {};
@@ -93,7 +103,7 @@
 	// Track changes in object fields
 	$effect(() => {
 		if (!obj) return;
-		
+
 		// Check if the objectId changed (user selected a different entity)
 		if (previousObjectId !== objectId) {
 			// Different entity selected - reset without highlighting
@@ -105,16 +115,16 @@
 			}
 			// Clear all highlights
 			highlightedFields = {};
-			timeouts.forEach(timeout => clearTimeout(timeout));
+			timeouts.forEach((timeout) => clearTimeout(timeout));
 			timeouts.clear();
 			return;
 		}
-		
+
 		// Same entity - check each field for changes
 		for (const [key, value] of Object.entries(obj)) {
 			const isNewField = !(key in previousValues);
 			let shouldHighlight = false;
-			
+
 			if (isNewField) {
 				// New field added - highlight it
 				shouldHighlight = true;
@@ -123,7 +133,7 @@
 				try {
 					const prevStr = JSON.stringify(previousValues[key]);
 					const currStr = JSON.stringify(value);
-					
+
 					if (prevStr !== currStr) {
 						shouldHighlight = true;
 					}
@@ -132,33 +142,33 @@
 					console.warn('Error comparing values for key:', key, e);
 				}
 			}
-			
+
 			if (shouldHighlight) {
 				// Clear any existing timeout for this field
 				const existingTimeout = timeouts.get(key);
 				if (existingTimeout) {
 					clearTimeout(existingTimeout);
 				}
-				
+
 				// Highlight the field
 				highlightedFields[key] = true;
-				
+
 				// Remove highlight after animation completes (2 seconds)
 				const timeoutId = setTimeout(() => {
 					highlightedFields[key] = false;
 					timeouts.delete(key);
 				}, 2000) as unknown as number;
-				
+
 				timeouts.set(key, timeoutId);
 			}
-			
+
 			// Update previous value
 			previousValues[key] = value;
 		}
-		
+
 		// Cleanup function - clear all timeouts when effect re-runs or component unmounts
 		return () => {
-			timeouts.forEach(timeout => clearTimeout(timeout));
+			timeouts.forEach((timeout) => clearTimeout(timeout));
 			timeouts.clear();
 		};
 	});
@@ -187,7 +197,18 @@
 	}
 
 	// Fields handled explicitly in the header - skip from the generic loop
-	const HEADER_FIELDS = new Set(['id', 'name', 'namespace', 'kind', 'entityId', 'parent', 'entity', 'compromised', 'provenance', 'appServiceCount']);
+	const HEADER_FIELDS = new Set([
+		'id',
+		'name',
+		'namespace',
+		'kind',
+		'entityId',
+		'parent',
+		'entity',
+		'compromised',
+		'provenance',
+		'appServiceCount'
+	]);
 
 	function shouldShowField(label: string, data: any): boolean {
 		if (HEADER_FIELDS.has(label)) return false;
@@ -212,7 +233,9 @@
 		if (!obj) return;
 		navigator.clipboard.writeText(obj.id).then(() => {
 			idCopied = true;
-			setTimeout(() => { idCopied = false; }, 1500);
+			setTimeout(() => {
+				idCopied = false;
+			}, 1500);
 		});
 	}
 
@@ -220,7 +243,9 @@
 		if (!obj || !obj.token || !obj.token.Raw) return;
 		navigator.clipboard.writeText(obj.token.Raw).then(() => {
 			tokenCopied = true;
-			setTimeout(() => { tokenCopied = false; }, 1500);
+			setTimeout(() => {
+				tokenCopied = false;
+			}, 1500);
 		});
 	}
 
@@ -231,29 +256,30 @@
 	}
 
 	function readFile(path: string) {
-		const ttp = campaignState.getTtpById('read-file')
+		const ttp = campaignState.getTtpById('read-file');
 		if (ttp) {
 			if (sendAction) {
-				sendAction(ttp, {"PATH":path});
+				sendAction(ttp, { PATH: path });
 			} else {
-				showToast("No sendAction function provided", '', 'error');
+				showToast('No sendAction function provided', '', 'error');
 			}
 		} else {
 			showToast("TTP 'read-file' not found", '', 'error');
 		}
 	}
-
 </script>
 
 <!-- specify data-popup attr. for consistent styling via skeleton-ui -->
 <!-- class="card variant-filled-secondary details-popup bg-surface-50-950 z-100 flex w-96 flex-col overflow-auto p-4 {selectedNode  -->
-<div class="{className} pointer-events-auto overflow-auto border border-surface-600 rounded-lg bg-surface-100-900 p-4 shadow-xl text-xs md:text-sm w-full" >
+<div
+	class="{className} border-surface-600 bg-surface-100-900 pointer-events-auto w-full overflow-auto rounded-lg border p-4 text-xs shadow-xl md:text-sm"
+>
 	{#if obj}
 		{#snippet runBtn(label: string)}
 			{@const ttp = ttpForField(label)}
 			{#if ttp && sendAction}
 				<button
-					class="shrink-0 cursor-pointer rounded p-0.5 hover:bg-surface-300 dark:hover:bg-surface-700 transition-colors"
+					class="hover:bg-surface-300 dark:hover:bg-surface-700 shrink-0 cursor-pointer rounded p-0.5 transition-colors"
 					title="Run: {ttp.name}"
 					onclick={() => sendAction!(ttp!, {})}
 				>
@@ -262,14 +288,22 @@
 			{/if}
 		{/snippet}
 		<!-- Header: name + kind badge + copy-ID button -->
-		<div class="flex items-center gap-2 mb-1">
-			<span class="font-bold truncate text-sm md:text-base" class:field-changed={highlightedFields['name']}>{obj.name}{#if obj.meta?.name_confidence === 'derived'}<sup class="text-surface-400 dark:text-surface-600 cursor-help" title="Name is derived - inferred from heuristics or indirect sources, not confirmed by the Kubernetes API">*</sup>{/if}</span>
+		<div class="mb-1 flex items-center gap-2">
+			<span
+				class="truncate text-sm font-bold md:text-base"
+				class:field-changed={highlightedFields['name']}
+				>{obj.name}{#if obj.meta?.name_confidence === 'derived'}<sup
+						class="text-surface-400 dark:text-surface-600 cursor-help"
+						title="Name is derived - inferred from heuristics or indirect sources, not confirmed by the Kubernetes API"
+						>*</sup
+					>{/if}</span
+			>
 			{#if obj.kind}
-				<span class="badge bg-indigo-200 text-indigo-800 text-xs shrink-0">{obj.kind}</span>
+				<span class="badge shrink-0 bg-indigo-200 text-xs text-indigo-800">{obj.kind}</span>
 			{/if}
 			{#each knowledgeProvenanceBadges(obj.provenance) as badge}
 				<span
-					class="badge text-xs shrink-0"
+					class="badge shrink-0 text-xs"
 					class:bg-amber-200={badge.origin === 'scenario'}
 					class:text-amber-900={badge.origin === 'scenario'}
 				>
@@ -277,7 +311,7 @@
 				</span>
 			{/each}
 			<button
-				class="shrink-0 cursor-pointer rounded p-0.5 hover:bg-surface-300 dark:hover:bg-surface-700 transition-colors"
+				class="hover:bg-surface-300 dark:hover:bg-surface-700 shrink-0 cursor-pointer rounded p-0.5 transition-colors"
 				title={obj.id}
 				onclick={copyId}
 			>
@@ -290,50 +324,57 @@
 		</div>
 		{#if obj.namespace}
 			<div class="mb-1" class:field-changed={highlightedFields['namespace']}>
-				<span class="font-semibold mr-1">Namespace:</span>{obj.namespace}
+				<span class="mr-1 font-semibold">Namespace:</span>{obj.namespace}
 			</div>
 		{/if}
 
-		{#each Object.entries(obj || {}).filter(([label, data]) => shouldShowField(label, data)).sort(([a], [b]) => a.localeCompare(b)) as [label, data]}
+		{#each Object.entries(obj || {})
+			.filter(([label, data]) => shouldShowField(label, data))
+			.sort(([a], [b]) => a.localeCompare(b)) as [label, data]}
 			{#if label === 'containers' && Array.isArray(data) && data.length > 0}
 				<!-- Special drill-down view for containers -->
 				<details class="mb-1" class:field-changed={highlightedFields[label]}>
 					<summary>
 						<span class="font-bold">{label}</span>
-						<span class="text-xs text-surface-500">({data.length})</span>
+						<span class="text-surface-500 text-xs">({data.length})</span>
 					</summary>
-					<div class="pl-4 space-y-4">
+					<div class="space-y-4 pl-4">
 						{#each data as container, idx}
-							<div class="border-l-2 border-surface-500 pl-3 py-2">
+							<div class="border-surface-500 border-l-2 py-2 pl-3">
 								<!-- Top: name and command -->
-								 <span>Name: </span>
+								<span>Name: </span>
 								<div class="font-bold">{container.name}</div>
 								{#if container.command && container.command.length > 0}
 									<div class="mt-1">
 										<span class="text-surface-600 dark:text-surface-400 text-sm">Command:</span>
-										<code class="text-xs ml-1">{container.command.join(' ')}</code>
+										<code class="ml-1 text-xs">{container.command.join(' ')}</code>
 									</div>
 								{/if}
 								{#if container.args && container.args.length > 0}
 									<div class="mt-1">
 										<span class="text-surface-600 dark:text-surface-400 text-sm">Args:</span>
-										<code class="text-xs ml-1">{container.args.join(' ')}</code>
+										<code class="ml-1 text-xs">{container.args.join(' ')}</code>
 									</div>
 								{/if}
 
 								<!-- Second level: volumeMounts and ports -->
 								{#if container.volume_mounts && container.volume_mounts.length > 0}
 									<details class="mt-2">
-										<summary class="text-sm text-surface-600 dark:text-surface-400 cursor-pointer">
+										<summary class="text-surface-600 dark:text-surface-400 cursor-pointer text-sm">
 											Volume Mounts ({container.volume_mounts.length})
 										</summary>
-										<ul class="list-inside list-none pl-4 space-y-0.5 mt-1">
+										<ul class="mt-1 list-inside list-none space-y-0.5 pl-4">
 											{#each container.volume_mounts as vm}
-												<li class="flex items-center gap-1 flex-wrap text-xs">
+												<li class="flex flex-wrap items-center gap-1 text-xs">
 													<span class="font-mono">{vm.mount_point}</span>
 													<span class="text-surface-400">({vm.name})</span>
-													{#if vm.read_only}<span class="badge bg-warning-100 text-warning-800 text-xs">ro</span>{/if}
-													{#if vm.is_host_path}<span class="badge bg-error-100 text-error-800 text-xs">hostPath: {vm.mount_root}</span>{/if}
+													{#if vm.read_only}<span
+															class="badge bg-warning-100 text-warning-800 text-xs">ro</span
+														>{/if}
+													{#if vm.is_host_path}<span
+															class="badge bg-error-100 text-error-800 text-xs"
+															>hostPath: {vm.mount_root}</span
+														>{/if}
 												</li>
 											{/each}
 										</ul>
@@ -342,15 +383,19 @@
 
 								{#if container.ports && container.ports.length > 0}
 									<details class="mt-2">
-										<summary class="text-sm text-surface-600 dark:text-surface-400 cursor-pointer">
+										<summary class="text-surface-600 dark:text-surface-400 cursor-pointer text-sm">
 											Ports ({container.ports.length})
 										</summary>
-										<ul class="list-inside list-disc pl-4 text-sm mt-1">
+										<ul class="mt-1 list-inside list-disc pl-4 text-sm">
 											{#each container.ports as port}
 												<li>
-													{#if port.name}<span class="font-mono">{port.name}:</span> {/if}
-													<span class="font-mono">{port.containerPort}/{port.protocol || 'TCP'}</span>
-													{#if port.hostPort} → <span class="font-mono">{port.hostPort}</span>{/if}
+													{#if port.name}<span class="font-mono">{port.name}:</span>
+													{/if}
+													<span class="font-mono"
+														>{port.containerPort}/{port.protocol || 'TCP'}</span
+													>
+													{#if port.hostPort}
+														→ <span class="font-mono">{port.hostPort}</span>{/if}
 												</li>
 											{/each}
 										</ul>
@@ -361,16 +406,16 @@
 								{#if container.image}
 									<div class="mt-2 text-sm">
 										<span class="text-surface-600 dark:text-surface-400">Image:</span>
-										<span class="font-mono text-xs ml-1">{container.image}</span>
+										<span class="ml-1 font-mono text-xs">{container.image}</span>
 									</div>
 								{/if}
 
 								{#if container.env && container.env.length > 0}
 									<details class="mt-2">
-										<summary class="text-sm text-surface-600 dark:text-surface-400 cursor-pointer">
+										<summary class="text-surface-600 dark:text-surface-400 cursor-pointer text-sm">
 											Environment ({container.env.length})
 										</summary>
-										<ul class="list-inside list-none pl-4 text-xs mt-1 font-mono">
+										<ul class="mt-1 list-inside list-none pl-4 font-mono text-xs">
 											{#each container.env as env}
 												<li>
 													{env.name}={env.value || JSON.stringify(env.valueFrom)}
@@ -382,19 +427,27 @@
 
 								{#if container.securityContext}
 									<details class="mt-2">
-										<summary class="text-sm text-surface-600 dark:text-surface-400 cursor-pointer">
+										<summary class="text-surface-600 dark:text-surface-400 cursor-pointer text-sm">
 											Security Context
 										</summary>
-										<pre class="text-xs mt-1 pl-4 overflow-auto">{JSON.stringify(container.securityContext, null, 2)}</pre>
+										<pre class="mt-1 overflow-auto pl-4 text-xs">{JSON.stringify(
+												container.securityContext,
+												null,
+												2
+											)}</pre>
 									</details>
 								{/if}
 
 								{#if container.resources}
 									<details class="mt-2">
-										<summary class="text-sm text-surface-600 dark:text-surface-400 cursor-pointer">
+										<summary class="text-surface-600 dark:text-surface-400 cursor-pointer text-sm">
 											Resources
 										</summary>
-										<pre class="text-xs mt-1 pl-4 overflow-auto">{JSON.stringify(container.resources, null, 2)}</pre>
+										<pre class="mt-1 overflow-auto pl-4 text-xs">{JSON.stringify(
+												container.resources,
+												null,
+												2
+											)}</pre>
 									</details>
 								{/if}
 							</div>
@@ -405,11 +458,11 @@
 				<details class="mb-1" class:field-changed={highlightedFields[label]}>
 					<summary>
 						<span class="font-bold">Volume Mounts</span>
-						<span class="text-xs text-surface-500">({data.length})</span>
+						<span class="text-surface-500 text-xs">({data.length})</span>
 					</summary>
-					<ul class="list-inside list-none pl-4 space-y-1 mt-1">
+					<ul class="mt-1 list-inside list-none space-y-1 pl-4">
 						{#each data as m}
-							<li class="flex items-center gap-1 flex-wrap">
+							<li class="flex flex-wrap items-center gap-1">
 								<span class="font-mono text-xs">{m.mount_point ?? m.mountPath}</span>
 								{#if m.name}
 									<span class="text-surface-400 text-xs">({m.name})</span>
@@ -418,7 +471,9 @@
 									<span class="badge bg-warning-100 text-warning-800 text-xs">ro</span>
 								{/if}
 								{#if m.is_host_path}
-									<span class="badge bg-error-100 text-error-800 text-xs">hostPath: {m.mount_root}</span>
+									<span class="badge bg-error-100 text-error-800 text-xs"
+										>hostPath: {m.mount_root}</span
+									>
 								{/if}
 							</li>
 						{/each}
@@ -426,51 +481,65 @@
 				</details>
 			{:else if label === 'can'}
 				{#if typeof data === 'object' && data !== null && Object.keys(data).length > 0}
-					<details class="mb-1" class:field-changed={highlightedFields[label]} bind:open={canExpanded}>
+					<details
+						class="mb-1"
+						class:field-changed={highlightedFields[label]}
+						bind:open={canExpanded}
+					>
 						<summary class="flex items-center gap-1">
 							<span class="font-bold">{label}</span>
-							<span class="text-xs text-surface-500">({Array.isArray(data) ? data.length : Object.keys(data).length})</span>
+							<span class="text-surface-500 text-xs"
+								>({Array.isArray(data) ? data.length : Object.keys(data).length})</span
+							>
 							{#if campaignState.kubetier && canExpanded}
 								<span class="group relative inline-flex items-center">
 									<button
 										type="button"
-										class="inline-flex cursor-help items-center rounded-sm text-surface-500 hover:text-surface-700 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:hover:text-surface-200"
+										class="text-surface-500 hover:text-surface-700 focus:ring-primary-500 dark:hover:text-surface-200 inline-flex cursor-help items-center rounded-sm focus:ring-1 focus:outline-none"
 										aria-label="About KubeTier criticality assessment"
 										onclick={(event) => event.stopPropagation()}
 									>
 										<Icon icon="mdi:information-outline" width="15" />
 									</button>
 									<span
-										class="invisible absolute left-0 top-full z-30 w-72 pt-1 opacity-0 transition-opacity group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100"
+										class="invisible absolute top-full left-0 z-30 w-72 pt-1 opacity-0 transition-opacity group-focus-within:visible group-focus-within:opacity-100 group-hover:visible group-hover:opacity-100"
 									>
 										<span
 											role="tooltip"
-											class="block rounded-md border border-surface-300 bg-surface-50 p-3 text-left text-xs font-normal text-surface-700 shadow-lg dark:border-surface-600 dark:bg-surface-900 dark:text-surface-200"
+											class="border-surface-300 bg-surface-50 text-surface-700 dark:border-surface-600 dark:bg-surface-900 dark:text-surface-200 block rounded-md border p-3 text-left text-xs font-normal shadow-lg"
 										>
 											<span class="mb-1 block font-semibold">Permission criticality</span>
 											<span class="block">
-												<span class="font-semibold text-red-700 dark:text-red-300">Red T0</span> (highest) ·
-												<span class="font-semibold text-orange-700 dark:text-orange-300">orange T1</span> ·
+												<span class="font-semibold text-red-700 dark:text-red-300">Red T0</span>
+												(highest) ·
+												<span class="font-semibold text-orange-700 dark:text-orange-300"
+													>orange T1</span
+												>
+												·
 												<span class="text-green-700 dark:text-green-300">green T2</span> ·
-												<span class="text-surface-500 dark:text-surface-400">gray T3</span> (lowest).
+												<span class="text-surface-500 dark:text-surface-400">gray T3</span>
+												(lowest).
 												<a
-													class="ml-1 font-semibold text-primary-700 underline dark:text-primary-300"
+													class="text-primary-700 dark:text-primary-300 ml-1 font-semibold underline"
 													href="https://kubetier.com/"
 													target="_blank"
 													rel="noreferrer"
-													onclick={(event) => event.stopPropagation()}
-												>Informed by KubeTier ↗</a>
+													onclick={(event) => event.stopPropagation()}>Informed by KubeTier ↗</a
+												>
 											</span>
 										</span>
 									</span>
 								</span>
 							{/if}
 						</summary>
-						<EntitlementInfo entitlements={data as RBACPermission[]} catalog={campaignState.kubetier} />
+						<EntitlementInfo
+							entitlements={data as RBACPermission[]}
+							catalog={campaignState.kubetier}
+						/>
 					</details>
 				{:else}
 					<div class="mb-1" class:field-changed={highlightedFields[label]}>
-					<span class="font-bold mr-1">{label}</span>none
+						<span class="mr-1 font-bold">{label}</span>none
 					</div>
 					<!-- <button class="btn btn-sm preset-filled-primary-500" disabled>🔍</button> -->
 				{/if}
@@ -478,7 +547,7 @@
 				<details class="mb-1" class:field-changed={highlightedFields[label]} open>
 					<summary>
 						<span class="font-bold">permissions</span>
-						<span class="text-xs text-surface-500">({data.length})</span>
+						<span class="text-surface-500 text-xs">({data.length})</span>
 					</summary>
 					<EntitlementInfo
 						entitlements={data as RBACPermission[]}
@@ -491,12 +560,15 @@
 				<details class="mb-1" class:field-changed={highlightedFields[label]}>
 					<summary>
 						<span class="font-bold">{label}</span>
-						<span class="text-xs text-surface-500">({data.length})</span>
+						<span class="text-surface-500 text-xs">({data.length})</span>
 					</summary>
 					<ul class="list-inside list-none pl-5">
 						{#each data as item}
 							<li>
-								<button class="text-left hover:underline cursor-pointer" onclick={() => readFile(item)}>
+								<button
+									class="cursor-pointer text-left hover:underline"
+									onclick={() => readFile(item)}
+								>
 									{prettyPrint(item)}
 								</button>
 							</li>
@@ -506,20 +578,26 @@
 			{:else if label === 'host_ipc' || label === 'host_network' || label === 'host_pid'}
 				{#if data === 'Yes' || data === true}
 					<div class="mb-1 flex items-center gap-1" class:field-changed={highlightedFields[label]}>
-						<span class="badge bg-error-100 text-error-800 dark:bg-error-900 dark:text-error-200 text-xs font-bold">{label}</span>
+						<span
+							class="badge bg-error-100 text-error-800 dark:bg-error-900 dark:text-error-200 text-xs font-bold"
+							>{label}</span
+						>
 						<Icon icon="mdi:alert" width="14" class="text-error-500" />
 					</div>
 				{:else}
-					<div class="mb-1 text-surface-400 dark:text-surface-600" class:field-changed={highlightedFields[label]}>
-						<span class="font-semibold mr-1">{label}:</span>{data}
+					<div
+						class="text-surface-400 dark:text-surface-600 mb-1"
+						class:field-changed={highlightedFields[label]}
+					>
+						<span class="mr-1 font-semibold">{label}:</span>{data}
 					</div>
 				{/if}
 			{:else if label === 'owner_references' && Array.isArray(data) && data.length > 0}
 				<div class="mb-1" class:field-changed={highlightedFields[label]}>
-					<span class="font-bold mr-1">Owner:</span>
+					<span class="mr-1 font-bold">Owner:</span>
 					{#each data as oref}
 						<span class="inline-flex items-center gap-1">
-							<span class="badge bg-indigo-100 text-indigo-800 text-xs">{oref.kind}</span>
+							<span class="badge bg-indigo-100 text-xs text-indigo-800">{oref.kind}</span>
 							<span class="font-mono text-xs">{oref.name}</span>
 						</span>
 					{/each}
@@ -528,17 +606,23 @@
 				<details class="mb-1" class:field-changed={highlightedFields[label]}>
 					<summary>
 						<span class="font-bold">{label}</span>
-						<span class="text-xs text-surface-500">({data.length})</span>
+						<span class="text-surface-500 text-xs">({data.length})</span>
 					</summary>
-					<ul class="list-inside list-none pl-4 space-y-1 mt-1">
+					<ul class="mt-1 list-inside list-none space-y-1 pl-4">
 						{#each data as session}
-							<li class="flex items-center gap-1 flex-wrap text-xs">
-								<span class="badge text-xs {session.status === 'Active' ? 'bg-success-100 text-success-800' : session.status === 'Lost' ? 'bg-error-100 text-error-800' : 'bg-warning-100 text-warning-800'}">{session.status}</span>
+							<li class="flex flex-wrap items-center gap-1 text-xs">
+								<span
+									class="badge text-xs {session.status === 'Active'
+										? 'bg-success-100 text-success-800'
+										: session.status === 'Lost'
+											? 'bg-error-100 text-error-800'
+											: 'bg-warning-100 text-warning-800'}">{session.status}</span
+								>
 								<span class="font-mono">{session.kind}</span>
 								{#if session.port}
 									<span class="text-surface-400">:{session.port}</span>
 								{/if}
-								<span class="text-surface-400 font-mono truncate">{session.id}</span>
+								<span class="text-surface-400 truncate font-mono">{session.id}</span>
 							</li>
 						{/each}
 					</ul>
@@ -547,7 +631,7 @@
 				<details class="mb-1" class:field-changed={highlightedFields[label]}>
 					<summary class="cursor-pointer">
 						<span class="font-bold">Services</span>
-						<span class="text-xs text-surface-500">({data.length})</span>
+						<span class="text-surface-500 text-xs">({data.length})</span>
 					</summary>
 					<div class="mt-1 space-y-1 pl-4">
 						{#each data as service}
@@ -555,20 +639,30 @@
 								<summary class="cursor-pointer">
 									<span class="font-mono font-semibold">{service.port}/{service.transport}</span>
 									{#if service.port_name}
-										<span class="ml-1 text-surface-500">· {service.port_name}</span>
+										<span class="text-surface-500 ml-1">· {service.port_name}</span>
 									{/if}
 									{#if service.product && service.product !== service.port_name}
-										<span class="ml-1 text-surface-500">· {service.product}?</span>
+										<span class="text-surface-500 ml-1">· {service.product}?</span>
 									{/if}
 								</summary>
 								<dl class="grid grid-cols-[auto_1fr] gap-x-2 pl-4 text-xs">
-									<dt class="font-semibold">Address</dt><dd class="font-mono">{service.address}</dd>
-									<dt class="font-semibold">Endpoint</dt><dd class="font-mono">{service.port}/{service.transport}</dd>
-									<dt class="font-semibold">State</dt><dd class="capitalize">{service.state}</dd>
-									{#if service.port_name}<dt class="font-semibold">Name</dt><dd>{service.port_name}</dd>{/if}
-									{#if service.product}<dt class="font-semibold">Assume</dt><dd>{service.product}{#if service.version} {service.version}{/if}</dd>{/if}
-									{#if service.banner}<dt class="font-semibold">Banner</dt><dd>{service.banner}</dd>{/if}
-									{#if service.cpes?.length}<dt class="font-semibold">CPE</dt><dd>{service.cpes.join(', ')}</dd>{/if}
+									<dt class="font-semibold">Address</dt>
+									<dd class="font-mono">{service.address}</dd>
+									<dt class="font-semibold">Endpoint</dt>
+									<dd class="font-mono">{service.port}/{service.transport}</dd>
+									<dt class="font-semibold">State</dt>
+									<dd class="capitalize">{service.state}</dd>
+									{#if service.port_name}<dt class="font-semibold">Name</dt>
+										<dd>{service.port_name}</dd>{/if}
+									{#if service.product}<dt class="font-semibold">Assume</dt>
+										<dd>
+											{service.product}{#if service.version}
+												{service.version}{/if}
+										</dd>{/if}
+									{#if service.banner}<dt class="font-semibold">Banner</dt>
+										<dd>{service.banner}</dd>{/if}
+									{#if service.cpes?.length}<dt class="font-semibold">CPE</dt>
+										<dd>{service.cpes.join(', ')}</dd>{/if}
 								</dl>
 							</details>
 						{/each}
@@ -576,29 +670,39 @@
 				</details>
 			{:else if Array.isArray(data) && data.length > 0}
 				{#if data.length === 1}
-					<div class="mb-1 flex items-center gap-1" class:field-changed={highlightedFields[label]}><span class="font-bold mr-1">{label}:</span>{prettyPrint(data[0])}{@render runBtn(label)}</div>
+					<div class="mb-1 flex items-center gap-1" class:field-changed={highlightedFields[label]}>
+						<span class="mr-1 font-bold">{label}:</span>{prettyPrint(data[0])}{@render runBtn(
+							label
+						)}
+					</div>
 				{:else}
-				<details class="mb-1" class:field-changed={highlightedFields[label]}>
-					<summary class="flex items-center gap-1">
-						<span class="font-bold">{label}</span>
-						<span class="text-xs text-surface-500">({data.length})</span>
-						{@render runBtn(label)}
-					</summary>
-					<ul class="list-inside list-none pl-5">
-						{#each data as item}
-							<li>{prettyPrint(item)}</li>
-						{/each}
-					</ul>
-				</details>
-				{/if }
+					<details class="mb-1" class:field-changed={highlightedFields[label]}>
+						<summary class="flex items-center gap-1">
+							<span class="font-bold">{label}</span>
+							<span class="text-surface-500 text-xs">({data.length})</span>
+							{@render runBtn(label)}
+						</summary>
+						<ul class="list-inside list-none pl-5">
+							{#each data as item}
+								<li>{prettyPrint(item)}</li>
+							{/each}
+						</ul>
+					</details>
+				{/if}
 			{:else if (label === 'binaries' || label === 'envVars') && typeof data === 'object' && data !== null}
 				{@const dictEmpty = Object.keys(data).length === 0}
 				<!-- Special formatting for binaries and envVars dictionary -->
 				<details class="mb-1" class:field-changed={highlightedFields[label]}>
 					<summary>
 						<span class="inline-flex items-center gap-1">
-							<span class:font-bold={!dictEmpty} class:text-surface-400={dictEmpty} class:opacity-40={dictEmpty}>{label}</span>
-							<span class="text-xs text-surface-500" class:opacity-40={dictEmpty}>({Object.keys(data).length})</span>
+							<span
+								class:font-bold={!dictEmpty}
+								class:text-surface-400={dictEmpty}
+								class:opacity-40={dictEmpty}>{label}</span
+							>
+							<span class="text-surface-500 text-xs" class:opacity-40={dictEmpty}
+								>({Object.keys(data).length})</span
+							>
 							{@render runBtn(label)}
 						</span>
 					</summary>
@@ -621,30 +725,35 @@
 				{@const uid = data.uid}
 				{@const createdAt = data.created_at}
 				{@const labels = data.labels && Object.keys(data.labels).length > 0 ? data.labels : null}
-				{@const annotations = data.annotations && Object.keys(data.annotations).length > 0 ? data.annotations : null}
+				{@const annotations =
+					data.annotations && Object.keys(data.annotations).length > 0 ? data.annotations : null}
 				{@const owner = data.owner ?? null}
 				{#if uid || createdAt || labels || annotations || owner}
 					<div class="mb-1 space-y-0.5" class:field-changed={highlightedFields[label]}>
 						{#if createdAt}
-							<div><span class="font-semibold mr-1">Created:</span>{createdAt}</div>
+							<div><span class="mr-1 font-semibold">Created:</span>{createdAt}</div>
 						{/if}
 						{#if uid}
-							<div><span class="font-semibold mr-1">UID:</span><span class="font-mono text-xs">{uid}</span></div>
+							<div>
+								<span class="mr-1 font-semibold">UID:</span><span class="font-mono text-xs"
+									>{uid}</span
+								>
+							</div>
 						{/if}
 						{#if owner}
 							<div>
-								<span class="font-semibold mr-1">Owner:</span>
-								<span class="badge bg-indigo-100 text-indigo-800 text-xs">{owner.kind}</span>
-								<span class="font-mono text-xs ml-1">{owner.name}</span>
+								<span class="mr-1 font-semibold">Owner:</span>
+								<span class="badge bg-indigo-100 text-xs text-indigo-800">{owner.kind}</span>
+								<span class="ml-1 font-mono text-xs">{owner.name}</span>
 							</div>
 						{/if}
 						{#if labels}
 							<details>
 								<summary class="cursor-pointer">
 									<span class="font-semibold">Labels</span>
-									<span class="text-xs text-surface-500">({Object.keys(labels).length})</span>
+									<span class="text-surface-500 text-xs">({Object.keys(labels).length})</span>
 								</summary>
-								<ul class="pl-4 list-none font-mono text-xs space-y-0.5 mt-1">
+								<ul class="mt-1 list-none space-y-0.5 pl-4 font-mono text-xs">
 									{#each Object.entries(labels).sort(([a], [b]) => a.localeCompare(b)) as [k, v]}
 										<li><span class="text-surface-500">{k}=</span>{v}</li>
 									{/each}
@@ -655,10 +764,10 @@
 							<details>
 								<summary class="cursor-pointer">
 									<span class="font-semibold">Annotations</span>
-									<span class="text-xs text-surface-500">({Object.keys(annotations).length})</span>
+									<span class="text-surface-500 text-xs">({Object.keys(annotations).length})</span>
 								</summary>
-								<ul class="pl-4 list-none font-mono text-xs space-y-0.5 mt-1">
-									{#each Object.entries(annotations).sort(([a], [b]) => a.localeCompare(b)) as [k, v]}
+								<ul class="mt-1 list-none space-y-0.5 pl-4 font-mono text-xs">
+									{#each Object.entries(annotations).sort( ([a], [b]) => a.localeCompare(b) ) as [k, v]}
 										<li><span class="text-surface-500">{k}=</span>{v}</li>
 									{/each}
 								</ul>
@@ -672,35 +781,47 @@
 					<details class="mb-1" class:field-changed={highlightedFields[label]}>
 						<summary>
 							<span class="font-bold">{label}</span>
-							<span class="text-xs text-surface-500">({Array.isArray(data) ? data.length : Object.keys(data).length})</span>
+							<span class="text-surface-500 text-xs"
+								>({Array.isArray(data) ? data.length : Object.keys(data).length})</span
+							>
 						</summary>
 						<pre class="max-h-80 overflow-scroll">{JSON.stringify(data, null, 2)}</pre>
 					</details>
-						<button
-							class="shrink-0 cursor-pointer rounded p-0.5 hover:bg-surface-300 dark:hover:bg-surface-700 transition-colors"
-							title="Copy token"
-							onclick={copyToken}
-						>
-							{#if tokenCopied}
-								<Icon icon="mdi:check" width="16" class="text-success-500" />
-							{:else}
-								<Icon icon="mdi:content-copy" width="16" class="text-surface-500" />
-							{/if}
-						</button>
+					<button
+						class="hover:bg-surface-300 dark:hover:bg-surface-700 shrink-0 cursor-pointer rounded p-0.5 transition-colors"
+						title="Copy token"
+						onclick={copyToken}
+					>
+						{#if tokenCopied}
+							<Icon icon="mdi:check" width="16" class="text-success-500" />
+						{:else}
+							<Icon icon="mdi:content-copy" width="16" class="text-surface-500" />
+						{/if}
+					</button>
 				</div>
 			{:else if typeof data === 'object' && data !== null}
 				{@const isEmpty = Array.isArray(data) ? data.length === 0 : Object.keys(data).length === 0}
 				<details class="mb-1" class:field-changed={highlightedFields[label]}>
 					<summary class="flex items-center gap-1">
-						<span class:font-bold={!isEmpty} class:text-surface-400={isEmpty} class:opacity-40={isEmpty}>{label}</span>
-						<span class="text-xs text-surface-500 " class:opacity-40={isEmpty}>({Array.isArray(data) ? data.length : Object.keys(data).length})</span>
+						<span
+							class:font-bold={!isEmpty}
+							class:text-surface-400={isEmpty}
+							class:opacity-40={isEmpty}>{label}</span
+						>
+						<span class="text-surface-500 text-xs" class:opacity-40={isEmpty}
+							>({Array.isArray(data) ? data.length : Object.keys(data).length})</span
+						>
 						{@render runBtn(label)}
 					</summary>
-					<pre class="max-h-80 overflow-scroll" class:opacity-40={isEmpty}>{JSON.stringify(data, null, 2)}</pre>
+					<pre class="max-h-80 overflow-scroll" class:opacity-40={isEmpty}>{JSON.stringify(
+							data,
+							null,
+							2
+						)}</pre>
 				</details>
 			{:else if data !== undefined}
 				<div class="mb-1 flex items-center gap-1" class:field-changed={highlightedFields[label]}>
-					<span class="font-bold mr-1">{label}:</span>{prettyPrint(data)}
+					<span class="mr-1 font-bold">{label}:</span>{prettyPrint(data)}
 					{@render runBtn(label)}
 				</div>
 			{/if}
@@ -710,10 +831,10 @@
 			{@const ttp = ttpForField(field)}
 			{#if ttp && sendAction}
 				<div class="mb-1 flex items-center gap-1">
-					<span class="opacity-40 text-surface-400 mr-1">{field}:</span>
-					<span class="opacity-40 italic text-surface-400">-</span>
+					<span class="text-surface-400 mr-1 opacity-40">{field}:</span>
+					<span class="text-surface-400 italic opacity-40">-</span>
 					<button
-						class="shrink-0 cursor-pointer rounded p-0.5 hover:bg-surface-300 dark:hover:bg-surface-700 transition-colors"
+						class="hover:bg-surface-300 dark:hover:bg-surface-700 shrink-0 cursor-pointer rounded p-0.5 transition-colors"
 						title="Run: {ttp.name}"
 						onclick={() => sendAction!(ttp, {})}
 					>
@@ -725,12 +846,11 @@
 	{:else}
 		<h3>Unknown Object type</h3>
 		<div>
-			<span class="font-bold mr-1">ID</span>
+			<span class="mr-1 font-bold">ID</span>
 			{objectId}
 		</div>
 		{prettyPrint(obj)}
 	{/if}
-
 </div>
 
 <style>

--- a/frontend/src/routes/components/graph.svelte
+++ b/frontend/src/routes/components/graph.svelte
@@ -2,9 +2,9 @@
 	import { onMount, onDestroy, getContext, untrack } from 'svelte';
 	import { browser } from '$app/environment';
 	import cytoscape from 'cytoscape';
-	// @ts-ignore
+	// @ts-expect-error - cytoscape-elk ships no type declarations
 	import elk from 'cytoscape-elk';
-	// @ts-ignore
+	// @ts-expect-error - cytoscape-expand-collapse ships no type declarations
 	import expandCollapse from 'cytoscape-expand-collapse';
 	import { toaster } from '$lib/components/toaster';
 	import { hasKnowledgeProvenance } from '$lib/knowledgeProvenance';
@@ -358,7 +358,9 @@
 								});
 								try {
 									ecApi.collapse(node);
-								} catch (_) {}
+								} catch {
+									// the plugin throws if the node is already collapsed
+								}
 							}
 						});
 					};
@@ -369,7 +371,9 @@
 							const stored = sessionStorage.getItem(COLLAPSED_KEY);
 							hasStoredCollapseState = stored !== null;
 							if (stored) (JSON.parse(stored) as string[]).forEach((id) => collapsedNodes.push(id));
-						} catch (_) {}
+						} catch {
+							// unreadable or malformed sessionStorage: fall back to the defaults
+						}
 					}
 					// Multi-pod workload compounds start collapsed. An explicitly persisted
 					// expansion wins on remount; workloads that newly gain a second pod are
@@ -388,7 +392,9 @@
 								collapsedNodes.push(n.id());
 								try {
 									ecApi.expand(n);
-								} catch (_) {}
+								} catch {
+									// the plugin throws if the node is already expanded
+								}
 							});
 						} finally {
 							isRestoringCollapsedState = false;
@@ -698,7 +704,7 @@
 		console.groupEnd();
 	}
 
-	function resetSelection(event: cytoscape.EventObject) {
+	function resetSelection(_event: cytoscape.EventObject) {
 		// Switching selection selects the new element before unselecting the old
 		// one. Do not let the old element's event clear the shared selection.
 		if (cy.$(':selected').length > 0) return;
@@ -769,7 +775,7 @@
 			cyNode.data.parent = n.parent;
 		}
 
-		if (nodePos.hasOwnProperty(n.id)) {
+		if (Object.hasOwn(nodePos, n.id)) {
 			cyNode.position = nodePos[n.id];
 		} else {
 			// Set default positions for initial nodes and save them to positions

--- a/frontend/src/routes/components/graph.svelte
+++ b/frontend/src/routes/components/graph.svelte
@@ -84,7 +84,7 @@
 	}
 
 	// cytoscape("layout", "hierarchyFlow", hierarchyLayout);
-    // cytoscape('layout', 'claude', K8sAttackGraphLayout);
+	// cytoscape('layout', 'claude', K8sAttackGraphLayout);
 
 	let cy: cytoscape.Core = $state() as cytoscape.Core;
 	let graphContainer: HTMLElement;
@@ -148,7 +148,7 @@
 				);
 			});
 			cy.edges('[!informational]').style({
-				'color': textColor,
+				color: textColor,
 				'line-color': textColor,
 				'target-arrow-color': textColor
 			});
@@ -219,7 +219,7 @@
 				expandCollapseCueLineSize: 8,
 				expandCollapseCueSensitivity: 1,
 				allowNestedEdgeCollapse: true,
-				edgeTypeInfo: "name",
+				edgeTypeInfo: 'name',
 				groupEdgesOfSameTypeOnCollapse: true,
 				zIndex: 999
 			});
@@ -276,11 +276,14 @@
 		const currentCampaignId = campaignState.campaignId;
 		// Only reset if campaign actually changed (not just on mount)
 		if (previousCampaignId !== currentCampaignId && previousCampaignId !== undefined) {
-			console.log(`Campaign changed from ${previousCampaignId} to ${currentCampaignId}, resetting layout`);
+			console.log(
+				`Campaign changed from ${previousCampaignId} to ${currentCampaignId}, resetting layout`
+			);
 			// Clear only graph-specific keys, not all sessionStorage
 			sessionStorage.removeItem(POS_KEY);
 			sessionStorage.removeItem(PAN_KEY);
-			sessionStorage.removeItem(ZOOM_KEY);				sessionStorage.removeItem(COLLAPSED_KEY);			// Don't clear FILTER_NS_KEY - preserve namespace filter across campaigns
+			sessionStorage.removeItem(ZOOM_KEY);
+			sessionStorage.removeItem(COLLAPSED_KEY); // Don't clear FILTER_NS_KEY - preserve namespace filter across campaigns
 			positions = {};
 			previousNodeIds.clear();
 			previousWorkloadCompoundIds.clear();
@@ -311,9 +314,9 @@
 				} else {
 					const currentWorkloadCompoundIds = workloadCompoundIds(graph.nodes);
 					// Clean up stale position entries before processing
-					const currentNodeIds = new Set(graph.nodes.map(n => n.id));
+					const currentNodeIds = new Set(graph.nodes.map((n) => n.id));
 					let positionsChanged = false;
-					Object.keys(positions).forEach(id => {
+					Object.keys(positions).forEach((id) => {
 						if (!currentNodeIds.has(id)) {
 							delete positions[id];
 							positionsChanged = true;
@@ -325,11 +328,11 @@
 						sessionStorage.setItem(POS_KEY, JSON.stringify(positions));
 					}
 
-					let nodes = graph.nodes.map(n => toCyNode(n, positions));
+					let nodes = graph.nodes.map((n) => toCyNode(n, positions));
 					let edges = graph.edges.map(toCyEdge);
 
 					// Check if there are new nodes
-					const hasNewNodes = graph.nodes.some(n => !previousNodeIds.has(n.id));
+					const hasNewNodes = graph.nodes.some((n) => !previousNodeIds.has(n.id));
 					const hasFewerNodes = previousNodeIds.size > currentNodeIds.size;
 
 					// Expand collapsed nodes FIRST so their children are restored into the graph
@@ -341,7 +344,7 @@
 					let addedNodeIds = new Set<string>();
 					const recollapseNodes = () => {
 						if (!ecApi || collapsedNodes.length === 0) return;
-						new Set(collapsedNodes).forEach(id => {
+						new Set(collapsedNodes).forEach((id) => {
 							const node = cy.getElementById(id);
 							if (node.length > 0 && node.isParent()) {
 								// The collapse plugin restores children by applying the parent's
@@ -353,7 +356,9 @@
 									child.position(position);
 									positions[child.id()] = position;
 								});
-								try { ecApi.collapse(node); } catch (_) {}
+								try {
+									ecApi.collapse(node);
+								} catch (_) {}
 							}
 						});
 					};
@@ -363,16 +368,16 @@
 						try {
 							const stored = sessionStorage.getItem(COLLAPSED_KEY);
 							hasStoredCollapseState = stored !== null;
-							if (stored) (JSON.parse(stored) as string[]).forEach(id => collapsedNodes.push(id));
+							if (stored) (JSON.parse(stored) as string[]).forEach((id) => collapsedNodes.push(id));
 						} catch (_) {}
 					}
 					// Multi-pod workload compounds start collapsed. An explicitly persisted
 					// expansion wins on remount; workloads that newly gain a second pod are
 					// collapsed when they first become useful as a group.
 					if (previousNodeIds.size === 0 && !hasStoredCollapseState) {
-						currentWorkloadCompoundIds.forEach(id => collapsedNodes.push(id));
+						currentWorkloadCompoundIds.forEach((id) => collapsedNodes.push(id));
 					} else if (previousNodeIds.size > 0) {
-						currentWorkloadCompoundIds.forEach(id => {
+						currentWorkloadCompoundIds.forEach((id) => {
 							if (!previousWorkloadCompoundIds.has(id)) collapsedNodes.push(id);
 						});
 					}
@@ -381,7 +386,9 @@
 						try {
 							cy.nodes('.cy-expand-collapse-collapsed-node').forEach((n: any) => {
 								collapsedNodes.push(n.id());
-								try { ecApi.expand(n); } catch (_) {}
+								try {
+									ecApi.expand(n);
+								} catch (_) {}
 							});
 						} finally {
 							isRestoringCollapsedState = false;
@@ -390,32 +397,50 @@
 
 					// Snapshot element IDs AFTER expansion so restored children are included
 					const cyNodeIdSet = new Set<string>();
-					cy.nodes().forEach((n: any) => { cyNodeIdSet.add(n.id()); });
+					cy.nodes().forEach((n: any) => {
+						cyNodeIdSet.add(n.id());
+					});
 					const cyEdgeIdSet = new Set<string>();
-					cy.edges().forEach((e: any) => { cyEdgeIdSet.add(e.id()); });
+					cy.edges().forEach((e: any) => {
+						cyEdgeIdSet.add(e.id());
+					});
 
 					// Compute diffs: what to add, what to remove (guard against empty IDs)
-					const newEdgeIds = new Set<string>(edges.filter((e: any) => e.data.id).map((e: any) => e.data.id as string));
-					const nodesToAdd = nodes.filter((n: any) => n.data.id && !cyNodeIdSet.has(n.data.id as string));
+					const newEdgeIds = new Set<string>(
+						edges.filter((e: any) => e.data.id).map((e: any) => e.data.id as string)
+					);
+					const nodesToAdd = nodes.filter(
+						(n: any) => n.data.id && !cyNodeIdSet.has(n.data.id as string)
+					);
 					addedNodeIds = new Set(nodesToAdd.map((node: any) => node.data.id as string));
-					const edgesToAdd = edges.filter((e: any) => e.data.id && !cyEdgeIdSet.has(e.data.id as string));
+					const edgesToAdd = edges.filter(
+						(e: any) => e.data.id && !cyEdgeIdSet.has(e.data.id as string)
+					);
 
 					// Remove elements no longer in the graph
-					cy.nodes().filter((n: any) => n.id() && !currentNodeIds.has(n.id())).remove();
-					cy.edges().filter((e: any) => e.id() && !newEdgeIds.has(e.id())).remove();
+					cy.nodes()
+						.filter((n: any) => n.id() && !currentNodeIds.has(n.id()))
+						.remove();
+					cy.edges()
+						.filter((e: any) => e.id() && !newEdgeIds.has(e.id()))
+						.remove();
 
 					// Update data for existing nodes (e.g. compromised/isRunning status changes)
-					nodes.filter((n: any) => n.data.id && cyNodeIdSet.has(n.data.id as string)).forEach((n: any) => {
-						cy.getElementById(n.data.id).data(n.data);
-					});
+					nodes
+						.filter((n: any) => n.data.id && cyNodeIdSet.has(n.data.id as string))
+						.forEach((n: any) => {
+							cy.getElementById(n.data.id).data(n.data);
+						});
 
 					// Update data for existing edges too. An edge's id is stable across a
 					// status change (e.g. a session breaking flips `broken` while source,
 					// target and name stay the same), so without this refresh the
 					// edge[?broken] restyle would not apply until a full remount.
-					edges.filter((e: any) => e.data.id && cyEdgeIdSet.has(e.data.id as string)).forEach((e: any) => {
-						cy.getElementById(e.data.id).data(e.data);
-					});
+					edges
+						.filter((e: any) => e.data.id && cyEdgeIdSet.has(e.data.id as string))
+						.forEach((e: any) => {
+							cy.getElementById(e.data.id).data(e.data);
+						});
 
 					// Pre-position new nodes near their connected existing nodes so they don't spawn randomly
 					if (nodesToAdd.length > 0) {
@@ -461,8 +486,10 @@
 								}
 							});
 							if (neighborPositions.length > 0) {
-								const avgX = neighborPositions.reduce((s, p) => s + p.x, 0) / neighborPositions.length;
-								const avgY = neighborPositions.reduce((s, p) => s + p.y, 0) / neighborPositions.length;
+								const avgX =
+									neighborPositions.reduce((s, p) => s + p.x, 0) / neighborPositions.length;
+								const avgY =
+									neighborPositions.reduce((s, p) => s + p.y, 0) / neighborPositions.length;
 								// Place near neighbor centroid with a small offset to avoid exact overlap
 								const angle = Math.random() * 2 * Math.PI;
 								const r = 80 + Math.random() * 40;
@@ -509,7 +536,9 @@
 
 					// Only re-layout if there are new nodes or nodes were removed
 					if (hasNewNodes || hasFewerNodes || previousNodeIds.size === 0) {
-						console.log(`Graph changed: ${hasNewNodes ? 'new nodes' : hasFewerNodes ? 'nodes removed' : 'initial load'}`);
+						console.log(
+							`Graph changed: ${hasNewNodes ? 'new nodes' : hasFewerNodes ? 'nodes removed' : 'initial load'}`
+						);
 
 						const containerRect = graphContainer.getBoundingClientRect();
 						if (containerRect.width === 0 || containerRect.height === 0) {
@@ -522,7 +551,10 @@
 						const currentZoom = cy.zoom();
 						const isInitialLoad = previousNodeIds.size === 0;
 
-						const layoutOptions = createElkLayout(positions, untrack(() => layoutParams));
+						const layoutOptions = createElkLayout(
+							positions,
+							untrack(() => layoutParams)
+						);
 						const l = cy.elements(':visible').layout(layoutOptions as any);
 
 						l.one('layoutstop', () => {
@@ -567,11 +599,15 @@
 								selectedObject = el;
 							}
 						}
-					})
+					});
 				}
 			} catch (e) {
 				console.error('Error updating graph:', e);
-				toaster.create({ title: "Graph error", description: 'Error updating graph: ' + e, type: 'error' });
+				toaster.create({
+					title: 'Graph error',
+					description: 'Error updating graph: ' + e,
+					type: 'error'
+				});
 			}
 		}
 	});
@@ -579,39 +615,42 @@
 	function saveCollapsedNodes() {
 		if (!browser || !cy) return;
 		const ids: string[] = [];
-		cy.nodes('.cy-expand-collapse-collapsed-node').forEach((n: any) => { ids.push(n.id()); });
+		cy.nodes('.cy-expand-collapse-collapsed-node').forEach((n: any) => {
+			ids.push(n.id());
+		});
 		sessionStorage.setItem(COLLAPSED_KEY, JSON.stringify(ids));
 	}
 
 	function savePositions() {
 		if (cy === undefined) {
-			console.error("Cytoscape instance is undefined, cannot save positions");
+			console.error('Cytoscape instance is undefined, cannot save positions');
 			return;
 		}
 		const map: PosMap = {};
-		cy.nodes().forEach(n => { map[n.id()] = n.position(); });
+		cy.nodes().forEach((n) => {
+			map[n.id()] = n.position();
+		});
 		positions = map;
 		sessionStorage.setItem(POS_KEY, JSON.stringify(positions));
-
-	};
+	}
 	function saveZoom() {
 		if (browser) {
 			sessionStorage.setItem(ZOOM_KEY, JSON.stringify(cy.zoom()));
 		}
-	};
+	}
 
 	function saveGraphLayout() {
 		if (browser) {
 			if (cy === undefined) {
-				console.error("Cytoscape instance is undefined, cannot save graph layout");
+				console.error('Cytoscape instance is undefined, cannot save graph layout');
 				return;
 			}
-			console.log("Saving graph layout");
+			console.log('Saving graph layout');
 			savePositions();
 			saveZoom();
 			sessionStorage.setItem(PAN_KEY, JSON.stringify(cy.pan()));
 		}
-	};
+	}
 
 	function loadPositions(): PosMap {
 		if (!browser) return {};
@@ -653,7 +692,7 @@
 		selectedObject = el.data();
 		selectedObjectId = el.data()['id'];
 		focusSelection(el);
-		console.group("Selected Graph object");
+		console.group('Selected Graph object');
 		console.log(el.data());
 		console.log(el.classes());
 		console.groupEnd();
@@ -692,10 +731,15 @@
 				const children = element.children();
 				context = context.union(children);
 				const contextNodeIds = new Set<string>();
-				context.nodes().forEach((node) => { contextNodeIds.add(node.id()); });
-				const internalEdges = visible.edges().filter((edge) =>
-					contextNodeIds.has(edge.source().id()) && contextNodeIds.has(edge.target().id())
-				);
+				context.nodes().forEach((node) => {
+					contextNodeIds.add(node.id());
+				});
+				const internalEdges = visible
+					.edges()
+					.filter(
+						(edge) =>
+							contextNodeIds.has(edge.source().id()) && contextNodeIds.has(edge.target().id())
+					);
 				context = context.union(internalEdges);
 			}
 		} else {
@@ -773,7 +817,6 @@
 		// external neighbour instead of one per hidden child.
 		consolidateCollapsedEdges(cy, node);
 	}
-
 
 	/**
 	 * Hide nodes (and their edges) belonging to the specified namespaces.
@@ -874,11 +917,12 @@
 		const shift = addedWidth + EXPANSION_GUTTER;
 		const candidates = snapshot.visibleNodeIds
 			.map((id) => cy.getElementById(id))
-			.filter((candidate: any) =>
-				candidate.length > 0 &&
-				candidate.visible() &&
-				candidate.id() !== node.id() &&
-				candidate.boundingBox().x1 >= snapshot.right
+			.filter(
+				(candidate: any) =>
+					candidate.length > 0 &&
+					candidate.visible() &&
+					candidate.id() !== node.id() &&
+					candidate.boundingBox().x1 >= snapshot.right
 			);
 		const candidateIds = new Set(candidates.map((candidate: any) => candidate.id()));
 		const nodesToShift = candidates.filter((candidate: any) =>
@@ -908,7 +952,6 @@
 			}
 		});
 	}
-
 </script>
 
 <div class={['graph-wrapper', className]}>

--- a/frontend/src/routes/components/graph_edges.svelte.test.ts
+++ b/frontend/src/routes/components/graph_edges.svelte.test.ts
@@ -178,11 +178,7 @@ describe('consolidateCollapsedEdges', () => {
 		consolidateCollapsedEdges(cy, cy.getElementById('ns'));
 
 		// Each pair has a single edge - nothing to consolidate; all stay as-is.
-		expect(visibleEdges(cy)).toEqual([
-			'nodeX->ns [e3]',
-			'ns->nodeX [e1]',
-			'ns->nodeY [e2]'
-		]);
+		expect(visibleEdges(cy)).toEqual(['nodeX->ns [e3]', 'ns->nodeX [e1]', 'ns->nodeY [e2]']);
 	});
 });
 

--- a/frontend/src/routes/components/graph_filter.svelte
+++ b/frontend/src/routes/components/graph_filter.svelte
@@ -14,7 +14,9 @@
 	const activeFilterCount = $derived(hiddenNamespaces.size);
 
 	// Custom filters: those not in the detected namespace list
-	const customFilters = $derived([...hiddenNamespaces].filter((ns) => !availableNamespaces.includes(ns)));
+	const customFilters = $derived(
+		[...hiddenNamespaces].filter((ns) => !availableNamespaces.includes(ns))
+	);
 
 	function toggleNamespace(ns: string) {
 		const next = new Set(hiddenNamespaces);
@@ -46,14 +48,10 @@
 
 <!-- Backdrop to close panel -->
 {#if panelOpen}
-	<div
-		class="fixed inset-0 z-40"
-		role="presentation"
-		onclick={() => (panelOpen = false)}
-	></div>
+	<div class="fixed inset-0 z-40" role="presentation" onclick={() => (panelOpen = false)}></div>
 {/if}
 
-<div class="absolute bottom-1 right-3 z-50  text-surface-700-300">
+<div class="text-surface-700-300 absolute right-3 bottom-1 z-50">
 	<!-- Filter toggle button -->
 	<button
 		class="chip preset-outlined-surface-100-900 border-surface-400-600"
@@ -62,27 +60,27 @@
 		aria-label="Toggle namespace filter"
 	>
 		<!-- Funnel icon -->
-		<Icon icon="mdi:funnel" class="inline-block text-surface-400-600" />
+		<Icon icon="mdi:funnel" class="text-surface-400-600 inline-block" />
 	</button>
 
 	<!-- Filter panel -->
 	{#if panelOpen}
 		<div
-			class="absolute bottom-full right-0 mb-1 w-64 bg-surface-50-950 border border-gray-200 rounded-lg shadow-xl p-4 z-50"
+			class="bg-surface-50-950 absolute right-0 bottom-full z-50 mb-1 w-64 rounded-lg border border-gray-200 p-4 shadow-xl"
 			role="dialog"
 			aria-label="Namespace filter options"
 		>
-			<h3 class="text-sm font-semibold text-surface-700-300 mb-3">Hide Namespaces</h3>
+			<h3 class="text-surface-700-300 mb-3 text-sm font-semibold">Hide Namespaces</h3>
 
 			{#if availableNamespaces.length > 0}
-				<div class="space-y-1.5 mb-3">
+				<div class="mb-3 space-y-1.5">
 					{#each availableNamespaces as ns}
-						<label class="flex items-center gap-2 cursor-pointer group">
+						<label class="group flex cursor-pointer items-center gap-2">
 							<input
 								type="checkbox"
 								checked={hiddenNamespaces.has(ns)}
 								onchange={() => toggleNamespace(ns)}
-								class="w-3.5 h-3.5 rounded checkbox cursor-pointer"
+								class="checkbox h-3.5 w-3.5 cursor-pointer rounded"
 							/>
 							<span
 								class="text-sm {hiddenNamespaces.has(ns)
@@ -95,7 +93,7 @@
 					{/each}
 				</div>
 			{:else}
-				<p class="text-xs text-surface-400-600 mb-3">No namespaces detected in graph.</p>
+				<p class="text-surface-400-600 mb-3 text-xs">No namespaces detected in graph.</p>
 			{/if}
 
 			<!-- Custom filters -->
@@ -154,8 +152,10 @@
 
 			{#if activeFilterCount > 0}
 				<button
-					onclick={() => { hiddenNamespaces = new Set(); }}
-					class="mt-3 w-full text-xs text-surface-400-600 hover:text-red-400 transition-colors cursor-pointer text-left"
+					onclick={() => {
+						hiddenNamespaces = new Set();
+					}}
+					class="text-surface-400-600 mt-3 w-full cursor-pointer text-left text-xs transition-colors hover:text-red-400"
 				>
 					Clear all filters
 				</button>

--- a/frontend/src/routes/components/graph_filter.svelte
+++ b/frontend/src/routes/components/graph_filter.svelte
@@ -9,14 +9,8 @@
 	let { availableNamespaces, hiddenNamespaces = $bindable() }: GraphFilterProps = $props();
 
 	let panelOpen = $state(false);
-	let customInput = $state('');
 
 	const activeFilterCount = $derived(hiddenNamespaces.size);
-
-	// Custom filters: those not in the detected namespace list
-	const customFilters = $derived(
-		[...hiddenNamespaces].filter((ns) => !availableNamespaces.includes(ns))
-	);
 
 	function toggleNamespace(ns: string) {
 		const next = new Set(hiddenNamespaces);
@@ -25,23 +19,6 @@
 		} else {
 			next.add(ns);
 		}
-		hiddenNamespaces = next;
-	}
-
-	// function addCustomFilter() {
-	// 	const ns = customInput.trim();
-	// 	if (!ns) return;
-	// 	hiddenNamespaces = new Set([...hiddenNamespaces, ns]);
-	// 	customInput = '';
-	// }
-
-	// function handleCustomInputKeydown(e: KeyboardEvent) {
-	// 	if (e.key === 'Enter') addCustomFilter();
-	// }
-
-	function removeFilter(ns: string) {
-		const next = new Set(hiddenNamespaces);
-		next.delete(ns);
 		hiddenNamespaces = next;
 	}
 </script>

--- a/frontend/src/routes/components/graph_node_selector.svelte
+++ b/frontend/src/routes/components/graph_node_selector.svelte
@@ -23,9 +23,9 @@
 	// Global keydown handler for Escape key
 	function handleGlobalKeydown(event: KeyboardEvent) {
 		if (!isOpen) return;
-		
+
 		console.log('Global key pressed:', event.key, 'Code:', event.code, 'KeyCode:', event.keyCode);
-		
+
 		if (event.key === 'Escape' || event.code === 'Escape' || event.keyCode === 27) {
 			event.preventDefault();
 			event.stopPropagation();
@@ -46,7 +46,7 @@
 				window.removeEventListener('keydown', handleGlobalKeydown);
 			}
 		}
-		
+
 		return () => {
 			if (browser) {
 				window.removeEventListener('keydown', handleGlobalKeydown);
@@ -61,16 +61,15 @@
 		}
 
 		const query = searchQuery.toLowerCase();
-		const allNodes = cy.nodes().map(n => ({
+		const allNodes = cy.nodes().map((n) => ({
 			id: n.id(),
 			label: n.data('name') || n.data('label') || n.id(),
 			data: n.data()
 		}));
 
 		// Filter nodes by matching query in label or id
-		searchResults = allNodes.filter(n => 
-			n.label.toLowerCase().includes(query) || 
-			n.id.toLowerCase().includes(query)
+		searchResults = allNodes.filter(
+			(n) => n.label.toLowerCase().includes(query) || n.id.toLowerCase().includes(query)
 		);
 		selectedSearchIndex = 0;
 	}
@@ -80,7 +79,7 @@
 
 		const result = searchResults[index];
 		const node = cy.getElementById(result.id);
-		
+
 		if (node) {
 			// Unselect all nodes first
 			cy.elements().unselect();
@@ -157,20 +156,20 @@
 
 {#if isOpen}
 	<div class="fixed inset-0 z-50 flex items-start justify-center pt-20">
-		<div 
-			class="fixed inset-0 bg-black/50" 
-			role="button" 
+		<div
+			class="fixed inset-0 bg-black/50"
+			role="button"
 			tabindex="0"
 			onclick={() => (isOpen = false)}
 			onkeydown={(e) => e.key === 'Enter' && (isOpen = false)}
 		></div>
 		<div
-			class="relative w-full max-w-lg bg-surface-200-800 border border-gray-700 rounded-lg shadow-lg p-6"
+			class="bg-surface-200-800 relative w-full max-w-lg rounded-lg border border-gray-700 p-6 shadow-lg"
 			role="dialog"
 			aria-modal="true"
 		>
-			<h2 class="text-xl font-semibold mb-2 text-surface-contract-400">Search Nodes</h2>
-			<p class="text-sm text-surface-contract-300 mb-4">
+			<h2 class="text-surface-contract-400 mb-2 text-xl font-semibold">Search Nodes</h2>
+			<p class="text-surface-contract-300 mb-4 text-sm">
 				Search for nodes by name or ID. Use arrow keys to navigate, Enter to select.
 			</p>
 
@@ -184,11 +183,11 @@
 			/>
 
 			{#if searchResults.length > 0}
-				<div class="mt-4 max-h-64 overflow-y-auto border border-gray-700 rounded-md">
+				<div class="mt-4 max-h-64 overflow-y-auto rounded-md border border-gray-700">
 					{#each searchResults as result, index}
 						<button
 							type="button"
-							class="w-full px-4 py-2 text-left bg-surface-300-700 hover:bg-surface-100-900 transition-colors {index ===
+							class="bg-surface-300-700 hover:bg-surface-100-900 w-full px-4 py-2 text-left transition-colors {index ===
 							selectedSearchIndex
 								? 'bg-gray-700'
 								: 'bg-gray-800'}"
@@ -196,24 +195,27 @@
 							onmouseenter={() => (selectedSearchIndex = index)}
 						>
 							<div class="flex items-center justify-between">
-								<div class="font-medium text-surface-contrast-400-600">{result.label}</div>
+								<div class="text-surface-contrast-400-600 font-medium">{result.label}</div>
 							</div>
-							<div class="text-sm text-surface-contrast-300-700">{result.id}</div>
+							<div class="text-surface-contrast-300-700 text-sm">{result.id}</div>
 						</button>
 					{/each}
 				</div>
 			{:else if searchQuery.trim() !== ''}
-				<div class="mt-4 text-center text-gray-500 py-4">No nodes found</div>
+				<div class="mt-4 py-4 text-center text-gray-500">No nodes found</div>
 			{/if}
 
-			<div class="mt-4 text-xs text-surface-contrast-200-800">
+			<div class="text-surface-contrast-200-800 mt-4 text-xs">
 				Press
-				<kbd class="px-1.5 py-0.5 bg-gray-800 border border-gray-600 rounded text-gray-300">↑</kbd>
-				<kbd class="px-1.5 py-0.5 bg-gray-800 border border-gray-600 rounded text-gray-300">↓</kbd>
+				<kbd class="rounded border border-gray-600 bg-gray-800 px-1.5 py-0.5 text-gray-300">↑</kbd>
+				<kbd class="rounded border border-gray-600 bg-gray-800 px-1.5 py-0.5 text-gray-300">↓</kbd>
 				to navigate,
-				<kbd class="px-1.5 py-0.5 bg-gray-800 border border-gray-600 rounded text-gray-300">Enter</kbd>
+				<kbd class="rounded border border-gray-600 bg-gray-800 px-1.5 py-0.5 text-gray-300"
+					>Enter</kbd
+				>
 				to select,
-				<kbd class="px-1.5 py-0.5 bg-gray-800 border border-gray-600 rounded text-gray-300">Esc</kbd>
+				<kbd class="rounded border border-gray-600 bg-gray-800 px-1.5 py-0.5 text-gray-300">Esc</kbd
+				>
 				to close
 			</div>
 		</div>

--- a/frontend/src/routes/components/graph_style.test.ts
+++ b/frontend/src/routes/components/graph_style.test.ts
@@ -45,9 +45,7 @@ describe('getK8sCredentialIcon', () => {
 			style: Record<string, unknown>;
 		}>;
 		const heptagonIndex = styles.findIndex((rule) => rule.selector === 'node[?kind]');
-		const systemIndex = styles.findIndex(
-			(rule) => rule.selector === "node[kind='UnknownSystem']"
-		);
+		const systemIndex = styles.findIndex((rule) => rule.selector === "node[kind='UnknownSystem']");
 
 		expect(systemIndex).toBeGreaterThan(heptagonIndex);
 		expect(styles[systemIndex].style.shape).toBe('rectangle');
@@ -74,9 +72,7 @@ describe('getK8sCredentialIcon', () => {
 
 	it('shows edge labels on interaction without increasing their width', () => {
 		const style = getGraphStyle(false);
-		const baseEdgeStyle = style.find(
-			(rule: { selector: string }) => rule.selector === 'edge'
-		);
+		const baseEdgeStyle = style.find((rule: { selector: string }) => rule.selector === 'edge');
 		const hoveredEdgeStyle = style.find(
 			(rule: { selector: string }) => rule.selector === 'edge.hovered, edge:selected'
 		);

--- a/frontend/src/routes/components/graph_style.ts
+++ b/frontend/src/routes/components/graph_style.ts
@@ -1,4 +1,4 @@
-import type cytoscape from "cytoscape";
+import type cytoscape from 'cytoscape';
 import { WORKLOAD_KINDS } from './workload_compounds';
 
 const KIND_SVG_MAP = {
@@ -70,7 +70,7 @@ function mapKindIcons(obj: Record<string, string>) {
 		return {
 			selector: `node[kind='${kind}']`,
 			style: {
-				'background-image': [`/${icon}`]//, 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100%" height="100%" fill="red" fill-opacity="0.4"/></svg>'],
+				'background-image': [`/${icon}`] //, 'data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100%" height="100%" fill="red" fill-opacity="0.4"/></svg>'],
 			}
 		};
 	});
@@ -120,7 +120,7 @@ export function getGraphStyle(isDark: boolean = false) {
 		{
 			selector: '[kind="Namespace"]:parent',
 			style: {
-				'border-color': '#326CE5',
+				'border-color': '#326CE5'
 			}
 		},
 		{
@@ -176,7 +176,7 @@ export function getGraphStyle(isDark: boolean = false) {
 			selector: "node[kind='Pod']",
 			style: {
 				width: '30',
-				height: '30',
+				height: '30'
 			}
 		},
 		{
@@ -184,7 +184,7 @@ export function getGraphStyle(isDark: boolean = false) {
 			style: {
 				width: '20',
 				height: '20',
-				'background-image': '/k8s/pod_transparent.svg',
+				'background-image': '/k8s/pod_transparent.svg'
 			}
 		},
 
@@ -192,7 +192,7 @@ export function getGraphStyle(isDark: boolean = false) {
 			selector: "node[kind='Node']",
 			style: {
 				width: '30',
-				height: '30',
+				height: '30'
 			}
 		},
 		{
@@ -210,7 +210,7 @@ export function getGraphStyle(isDark: boolean = false) {
 		{
 			selector: 'node[?kind]',
 			style: {
-				shape: 'heptagon',
+				shape: 'heptagon'
 				// 'background-color': 'steelblue'
 			}
 		},
@@ -281,7 +281,7 @@ export function getGraphStyle(isDark: boolean = false) {
 			style: {
 				shape: 'rectangle',
 				'background-opacity': 0,
-				'background-image': '/session.svg',
+				'background-image': '/session.svg'
 			}
 		},
 		// {
@@ -322,7 +322,7 @@ export function getGraphStyle(isDark: boolean = false) {
 				'border-width': 3,
 				'border-color': 'green',
 				width: '40',
-				height: '40',
+				height: '40'
 			}
 		},
 		// {
@@ -381,7 +381,7 @@ export function getGraphStyle(isDark: boolean = false) {
 			// Style for meta-edges (grouped edges from collapsed nodes)
 			selector: 'edge[?isMetaEdge]',
 			style: {
-				'width': '3',
+				width: '3',
 				'font-weight': 'bold',
 				'font-size': '11',
 				color: primary,
@@ -483,29 +483,36 @@ export function getGraphStyle(isDark: boolean = false) {
 	return [...mapKindIcons(KIND_SVG_MAP), ...graph_style] as any;
 }
 
-const redTintSvg = 'data:image/svg+xml,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100%" height="100%" fill="red" fill-opacity="0.4"/></svg>');
+const redTintSvg =
+	'data:image/svg+xml,' +
+	encodeURIComponent(
+		'<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100"><rect width="100%" height="100%" fill="red" fill-opacity="0.4"/></svg>'
+	);
 
 export function applyCompromisedStyle(cy: cytoscape.Core) {
-	cy.nodes().forEach(n => {
-		const shouldTint = Boolean(n.data('compromised')) || (
-			n.hasClass('cy-expand-collapse-collapsed-node') && Boolean(n.data('containsCompromised'))
-		);
+	cy.nodes().forEach((n) => {
+		const shouldTint =
+			Boolean(n.data('compromised')) ||
+			(n.hasClass('cy-expand-collapse-collapsed-node') && Boolean(n.data('containsCompromised')));
 		const img = n.style('background-image');
 		const hasTint = typeof img === 'string' && img.includes(redTintSvg);
 
 		if (!shouldTint && hasTint) {
-			const layers = img.split(',').map((l: string) => l.trim()).filter((l: string) => l !== redTintSvg);
+			const layers = img
+				.split(',')
+				.map((l: string) => l.trim())
+				.filter((l: string) => l !== redTintSvg);
 			n.removeStyle('background-color');
 			n.removeStyle('background-opacity');
 			n.style({
-				'color': '',
-				'background-image': layers.length > 0 ? layers.join(', ') : 'none',
+				color: '',
+				'background-image': layers.length > 0 ? layers.join(', ') : 'none'
 			});
 		} else if (shouldTint && !hasTint) {
 			n.style({
 				'background-color': 'red',
 				'background-image': [img, redTintSvg],
-				'background-opacity': 0.4,
+				'background-opacity': 0.4
 			});
 		}
 	});

--- a/frontend/src/routes/components/recommendations.svelte
+++ b/frontend/src/routes/components/recommendations.svelte
@@ -125,13 +125,13 @@
 	}
 </script>
 
-<div class="bg-surface-100-900 flex flex-col h-full min-h-0 {className}">
+<div class="bg-surface-100-900 flex h-full min-h-0 flex-col {className}">
 	<!-- Toolbar: title + show-count, mirroring the Actions tab's toolbar row -->
-	<div class="flex-shrink-0 flex items-center gap-2 px-2 py-2 border-b border-surface-200-800">
+	<div class="border-surface-200-800 flex flex-shrink-0 items-center gap-2 border-b px-2 py-2">
 		<Icon icon="mdi:lightbulb-on-outline" width="16" class="text-warning-500 flex-shrink-0" />
-		<span class="text-sm font-semibold flex-1 truncate">Recommended Next Steps</span>
+		<span class="flex-1 truncate text-sm font-semibold">Recommended Next Steps</span>
 		<select
-			class="text-xs bg-surface-200-800 border border-surface-300-700 rounded px-1 py-0.5"
+			class="bg-surface-200-800 border-surface-300-700 rounded border px-1 py-0.5 text-xs"
 			bind:value={limitChoice}
 			title="Number of recommendations to show"
 			aria-label="Number of recommendations to show"
@@ -141,7 +141,7 @@
 			<option value={100}>100</option>
 			<option value={0}>All</option>
 		</select>
-		<span class="text-xs text-surface-500 w-6 text-right" title="{shownGroups.length} shown">
+		<span class="text-surface-500 w-6 text-right text-xs" title="{shownGroups.length} shown">
 			{shownGroups.length}
 		</span>
 		{#if actions}
@@ -149,91 +149,98 @@
 		{/if}
 	</div>
 
-	<div class="flex-1 overflow-y-auto min-h-0 flex flex-col">
+	<div class="flex min-h-0 flex-1 flex-col overflow-y-auto">
 		{#if isLoading && groups.length === 0}
-				<div class="px-3 py-4 text-xs text-surface-500">Scoring actions…</div>
-			{:else if groups.length === 0}
-				<div class="px-3 py-4 text-xs text-surface-500">
-					No applicable actions yet. Gain a foothold to get recommendations.
-				</div>
-			{:else}
-				{#each shownGroups as g, i (keyOf(g))}
-					{@const expanded = expandedKey === keyOf(g)}
-					{@const multi = g.targets.length > 1}
-					<div class="border-b border-surface-200-800 last:border-b-0">
-						<div class="flex items-start gap-2 px-3 py-2">
-							<span class="text-xs text-surface-500 w-4 text-right pt-0.5">{i + 1}</span>
-							<Icon
-								icon={iconMap[ttpTactic(g.ttp_id) ?? ''] ?? 'mdi:flash'}
-								width="18"
-								class="flex-shrink-0 mt-0.5"
-							/>
-							<div class="flex-1 min-w-0">
-								<div class="flex items-center gap-2">
-									<span class="text-sm truncate" title={ttpName(g.ttp_id)}>{ttpName(g.ttp_id)}</span>
-									<span class="text-xs text-surface-500 ml-auto flex-shrink-0">{Math.round(g.utility * 100)}</span>
-								</div>
-								<!-- Utility bar -->
-								<div class="h-1.5 mt-1 rounded bg-surface-300-700 overflow-hidden">
-									<div class="h-full {utilityClass(g.utility)}" style="width: {Math.round(g.utility * 100)}%"></div>
-								</div>
-								<div class="flex items-center gap-2 mt-1">
-									<button
-										class="text-xs text-surface-500 hover:text-primary-500 truncate"
-										title={multi ? `${g.targets.length} targets, same utility` : `Focus ${targetName(g.targets[0])}`}
-										onclick={() => toggleExpanded(g)}
-									>
-										{#if multi}
-											→ {g.targets.length} targets
-										{:else}
-											→ {targetName(g.targets[0])}
-										{/if}
-									</button>
-									<button
-										class="text-xs text-surface-500 hover:text-primary-500 ml-auto flex items-center gap-0.5"
-										onclick={() => toggleExpanded(g)}
-									>
-										why
-										<Icon icon={expanded ? 'mdi:chevron-up' : 'mdi:chevron-down'} width="12" />
-									</button>
-								</div>
-							</div>
-							{#if !multi}
-								<button
-									class="btn btn-sm preset-filled-primary-500 text-xs px-2 py-1 flex-shrink-0"
-									title="Execute against {targetName(g.targets[0])}"
-									onclick={() => runTarget(g, g.targets[0])}
+			<div class="text-surface-500 px-3 py-4 text-xs">Scoring actions…</div>
+		{:else if groups.length === 0}
+			<div class="text-surface-500 px-3 py-4 text-xs">
+				No applicable actions yet. Gain a foothold to get recommendations.
+			</div>
+		{:else}
+			{#each shownGroups as g, i (keyOf(g))}
+				{@const expanded = expandedKey === keyOf(g)}
+				{@const multi = g.targets.length > 1}
+				<div class="border-surface-200-800 border-b last:border-b-0">
+					<div class="flex items-start gap-2 px-3 py-2">
+						<span class="text-surface-500 w-4 pt-0.5 text-right text-xs">{i + 1}</span>
+						<Icon
+							icon={iconMap[ttpTactic(g.ttp_id) ?? ''] ?? 'mdi:flash'}
+							width="18"
+							class="mt-0.5 flex-shrink-0"
+						/>
+						<div class="min-w-0 flex-1">
+							<div class="flex items-center gap-2">
+								<span class="truncate text-sm" title={ttpName(g.ttp_id)}>{ttpName(g.ttp_id)}</span>
+								<span class="text-surface-500 ml-auto flex-shrink-0 text-xs"
+									>{Math.round(g.utility * 100)}</span
 								>
-									Run
+							</div>
+							<!-- Utility bar -->
+							<div class="bg-surface-300-700 mt-1 h-1.5 overflow-hidden rounded">
+								<div
+									class="h-full {utilityClass(g.utility)}"
+									style="width: {Math.round(g.utility * 100)}%"
+								></div>
+							</div>
+							<div class="mt-1 flex items-center gap-2">
+								<button
+									class="text-surface-500 hover:text-primary-500 truncate text-xs"
+									title={multi
+										? `${g.targets.length} targets, same utility`
+										: `Focus ${targetName(g.targets[0])}`}
+									onclick={() => toggleExpanded(g)}
+								>
+									{#if multi}
+										→ {g.targets.length} targets
+									{:else}
+										→ {targetName(g.targets[0])}
+									{/if}
 								</button>
-							{/if}
+								<button
+									class="text-surface-500 hover:text-primary-500 ml-auto flex items-center gap-0.5 text-xs"
+									onclick={() => toggleExpanded(g)}
+								>
+									why
+									<Icon icon={expanded ? 'mdi:chevron-up' : 'mdi:chevron-down'} width="12" />
+								</button>
+							</div>
 						</div>
-
-						{#if expanded}
-							{#if multi}
-								<!-- Per-target run list (all share the same utility) -->
-								<div class="px-3 pb-2 pl-9 space-y-1">
-									{#each g.targets as t (t)}
-										<div class="flex items-center gap-2">
-											<span class="text-xs text-surface-500 flex-1 truncate" title={targetName(t)}>
-												→ {targetName(t)}
-											</span>
-											<button
-												class="btn btn-sm preset-filled-primary-500 text-xs px-2 py-0.5 flex-shrink-0"
-												title="Execute against {targetName(t)}"
-												onclick={() => runTarget(g, t)}
-											>
-												Run
-											</button>
-										</div>
-									{/each}
-								</div>
-							{/if}
-							<!-- Per-consideration breakdown -->
-							<ConsiderationBreakdown breakdown={g.breakdown} class="px-3 pb-2 pl-9" />
+						{#if !multi}
+							<button
+								class="btn btn-sm preset-filled-primary-500 flex-shrink-0 px-2 py-1 text-xs"
+								title="Execute against {targetName(g.targets[0])}"
+								onclick={() => runTarget(g, g.targets[0])}
+							>
+								Run
+							</button>
 						{/if}
 					</div>
-				{/each}
-			{/if}
-		</div>
+
+					{#if expanded}
+						{#if multi}
+							<!-- Per-target run list (all share the same utility) -->
+							<div class="space-y-1 px-3 pb-2 pl-9">
+								{#each g.targets as t (t)}
+									<div class="flex items-center gap-2">
+										<span class="text-surface-500 flex-1 truncate text-xs" title={targetName(t)}>
+											→ {targetName(t)}
+										</span>
+										<button
+											class="btn btn-sm preset-filled-primary-500 flex-shrink-0 px-2 py-0.5 text-xs"
+											title="Execute against {targetName(t)}"
+											onclick={() => runTarget(g, t)}
+										>
+											Run
+										</button>
+									</div>
+								{/each}
+							</div>
+						{/if}
+						<!-- Per-consideration breakdown -->
+						<ConsiderationBreakdown breakdown={g.breakdown} class="px-3 pb-2 pl-9" />
+					{/if}
+				</div>
+			{/each}
+		{/if}
+	</div>
 </div>

--- a/frontend/src/routes/components/scoring_tuner.svelte
+++ b/frontend/src/routes/components/scoring_tuner.svelte
@@ -175,7 +175,7 @@
 {#if profile?.tuningEnabled}
 	<!-- Trigger -->
 	<button
-		class="bg-surface-200-800 hover:bg-surface-300-700 border border-surface-400-600 rounded-full p-2 shadow-lg"
+		class="bg-surface-200-800 hover:bg-surface-300-700 border-surface-400-600 rounded-full border p-2 shadow-lg"
 		title="Tune scoring"
 		aria-label="Tune scoring"
 		onclick={() => (open = !open)}
@@ -186,28 +186,28 @@
 	<!-- Flyout -->
 	{#if open}
 		<div
-			class="fixed inset-y-0 right-0 z-[80] w-[380px] max-w-[90vw] bg-surface-100-900 border-l border-surface-300-700 shadow-2xl flex flex-col"
+			class="bg-surface-100-900 border-surface-300-700 fixed inset-y-0 right-0 z-[80] flex w-[380px] max-w-[90vw] flex-col border-l shadow-2xl"
 		>
-			<div class="flex items-center gap-2 px-3 py-2 border-b border-surface-200-800 shrink-0">
+			<div class="border-surface-200-800 flex shrink-0 items-center gap-2 border-b px-3 py-2">
 				<Icon icon="mdi:tune-variant" width="18" class="text-primary-500" />
-				<span class="text-sm font-semibold flex-1">Scoring Tuner</span>
-				{#if saving}<span class="text-xs text-surface-500">saving…</span>{/if}
+				<span class="flex-1 text-sm font-semibold">Scoring Tuner</span>
+				{#if saving}<span class="text-surface-500 text-xs">saving…</span>{/if}
 				<button
-					class="text-xs px-2 py-0.5 rounded bg-surface-200-800 hover:bg-surface-300-700 border border-surface-400-600"
+					class="bg-surface-200-800 hover:bg-surface-300-700 border-surface-400-600 rounded border px-2 py-0.5 text-xs"
 					title="Persist to ran.scoring.yaml (survives restart)"
 					onclick={persist}
 				>
 					Save
 				</button>
 				<button
-					class="text-xs px-2 py-0.5 rounded bg-surface-200-800 hover:bg-surface-300-700 border border-surface-400-600"
+					class="bg-surface-200-800 hover:bg-surface-300-700 border-surface-400-600 rounded border px-2 py-0.5 text-xs"
 					title="Revert to configured defaults and drop saved overrides"
 					onclick={reset}
 				>
 					Reset
 				</button>
 				<button
-					class="text-xs px-2 py-0.5 rounded bg-primary-500/20 hover:bg-primary-500/30 border border-primary-500/50 disabled:opacity-50"
+					class="bg-primary-500/20 hover:bg-primary-500/30 border-primary-500/50 rounded border px-2 py-0.5 text-xs disabled:opacity-50"
 					title="Fit weights from the operator decisions captured this and prior sessions"
 					disabled={calibrating}
 					onclick={calibrate}
@@ -220,41 +220,47 @@
 			</div>
 
 			{#if calibrateError}
-				<div class="px-3 py-2 text-xs text-error-400 border-b border-surface-200-800 shrink-0">
+				<div class="text-error-400 border-surface-200-800 shrink-0 border-b px-3 py-2 text-xs">
 					{calibrateError}
 				</div>
 			{/if}
 
 			{#if calibration}
 				{@const m = calibration.metrics}
-				<div class="px-3 py-2 border-b border-surface-200-800 shrink-0 bg-primary-500/5 space-y-1.5">
+				<div
+					class="border-surface-200-800 bg-primary-500/5 shrink-0 space-y-1.5 border-b px-3 py-2"
+				>
 					<div class="flex items-center gap-2">
 						<Icon icon="mdi:auto-fix" width="15" class="text-primary-500" />
-						<span class="text-xs font-semibold flex-1">Calibration preview</span>
+						<span class="flex-1 text-xs font-semibold">Calibration preview</span>
 						<button
-							class="text-xs px-2 py-0.5 rounded bg-primary-500 text-white hover:bg-primary-600"
+							class="bg-primary-500 hover:bg-primary-600 rounded px-2 py-0.5 text-xs text-white"
 							title="Apply the fitted weights to the live profile"
 							onclick={applyCalibration}
 						>
 							Apply
 						</button>
 						<button
-							class="text-xs px-2 py-0.5 rounded bg-surface-200-800 hover:bg-surface-300-700 border border-surface-400-600"
+							class="bg-surface-200-800 hover:bg-surface-300-700 border-surface-400-600 rounded border px-2 py-0.5 text-xs"
 							onclick={() => (calibration = null)}
 						>
 							Dismiss
 						</button>
 					</div>
-					<div class="grid grid-cols-2 gap-x-3 gap-y-0.5 text-xs text-surface-600-400">
+					<div class="text-surface-600-400 grid grid-cols-2 gap-x-3 gap-y-0.5 text-xs">
 						<span title="Fraction of decisions where the operator's choice ranks first"
-							>Match (top-1): <span class="font-mono text-surface-900-100">{pct(m.top1Accuracy)}</span></span
+							>Match (top-1): <span class="text-surface-900-100 font-mono"
+								>{pct(m.top1Accuracy)}</span
+							></span
 						>
 						<span title="Mean probability the fitted model assigns the operator's choices"
-							>Confidence: <span class="font-mono text-surface-900-100">{pct(m.meanChosenProb)}</span></span
+							>Confidence: <span class="text-surface-900-100 font-mono"
+								>{pct(m.meanChosenProb)}</span
+							></span
 						>
-						<span>Decisions: <span class="font-mono text-surface-900-100">{m.decisions}</span></span>
-						<span
-							title="Choices no non-negative weighting can reproduce - a missing consideration"
+						<span>Decisions: <span class="text-surface-900-100 font-mono">{m.decisions}</span></span
+						>
+						<span title="Choices no non-negative weighting can reproduce - a missing consideration"
 							>Unreproducible:
 							<span
 								class="font-mono {m.infeasible > 0 ? 'text-warning-500' : 'text-surface-900-100'}"
@@ -263,7 +269,7 @@
 						>
 					</div>
 					{#if m.infeasible > 0}
-						<p class="text-[11px] text-warning-500/90 leading-snug">
+						<p class="text-warning-500/90 text-[11px] leading-snug">
 							{m.infeasible} decision{m.infeasible === 1 ? '' : 's'} can't be reproduced by any weighting
 							- the operator valued something the current considerations don't measure.
 						</p>
@@ -271,17 +277,24 @@
 				</div>
 			{/if}
 
-			<div class="overflow-y-auto flex-1 p-3 space-y-3">
-				<div class="rounded border border-primary-500/30 bg-primary-500/5 p-2 text-[11px] leading-snug text-surface-600-400 space-y-1">
+			<div class="flex-1 space-y-3 overflow-y-auto p-3">
+				<div
+					class="border-primary-500/30 bg-primary-500/5 text-surface-600-400 space-y-1 rounded border p-2 text-[11px] leading-snug"
+				>
 					<p><strong class="text-surface-900-100">Scoring pipeline</strong></p>
-					<code class="block">raw measurement → response curve → weight / gate → utility × reliability</code>
-					<p>Controls below tune the profile at runtime. Formula constants shown under “Raw model” are compile-time policy and are documented here for transparency.</p>
+					<code class="block"
+						>raw measurement → response curve → weight / gate → utility × reliability</code
+					>
+					<p>
+						Controls below tune the profile at runtime. Formula constants shown under “Raw model”
+						are compile-time policy and are documented here for transparency.
+					</p>
 				</div>
 				<!-- Combination mode -->
 				<label class="flex items-center gap-2 text-xs">
 					<span class="text-surface-500 w-24">combination</span>
 					<select
-						class="flex-1 bg-surface-200-800 border border-surface-300-700 rounded px-1 py-0.5"
+						class="bg-surface-200-800 border-surface-300-700 flex-1 rounded border px-1 py-0.5"
 						bind:value={profile.combination}
 						onchange={scheduleSave}
 					>
@@ -294,36 +307,44 @@
 				{#each profile.considerations as c (c.name)}
 					{@const help = helpFor(c.name)}
 					<div
-						class="border border-surface-200-800 rounded p-2 space-y-2"
+						class="border-surface-200-800 space-y-2 rounded border p-2"
 						class:opacity-50={!c.enabled}
 					>
 						<div class="flex items-center gap-2">
-							<div class="flex-1 min-w-0">
-								<span class="text-sm font-medium block truncate">{help?.label ?? c.name}</span>
-								<span class="text-[10px] text-surface-500">{c.name} · {help?.kind ?? 'utility'}</span>
+							<div class="min-w-0 flex-1">
+								<span class="block truncate text-sm font-medium">{help?.label ?? c.name}</span>
+								<span class="text-surface-500 text-[10px]"
+									>{c.name} · {help?.kind ?? 'utility'}</span
+								>
 							</div>
-							<label class="flex items-center gap-1 text-[10px] text-surface-500" title="Veto gate">
+							<label class="text-surface-500 flex items-center gap-1 text-[10px]" title="Veto gate">
 								<input type="checkbox" bind:checked={c.veto} onchange={scheduleSave} />
 								veto
 							</label>
-							<label class="flex items-center gap-1 text-[10px] text-surface-500" title="Enabled">
+							<label class="text-surface-500 flex items-center gap-1 text-[10px]" title="Enabled">
 								<input type="checkbox" bind:checked={c.enabled} onchange={scheduleSave} />
 								on
 							</label>
 						</div>
 
 						{#if help}
-							<details class="rounded bg-surface-200-800/60 border border-surface-300-700 px-2 py-1">
-								<summary class="cursor-pointer text-[11px] font-medium">Raw model and exact formula</summary>
-								<div class="pt-1 space-y-1 text-[11px] leading-snug text-surface-600-400">
+							<details
+								class="bg-surface-200-800/60 border-surface-300-700 rounded border px-2 py-1"
+							>
+								<summary class="cursor-pointer text-[11px] font-medium"
+									>Raw model and exact formula</summary
+								>
+								<div class="text-surface-600-400 space-y-1 pt-1 text-[11px] leading-snug">
 									<p>{help.summary}</p>
-									<code class="block rounded bg-surface-100-900 px-1.5 py-1 text-surface-900-100">{help.formula}</code>
-									<ul class="list-disc pl-4 space-y-0.5">
+									<code class="bg-surface-100-900 text-surface-900-100 block rounded px-1.5 py-1"
+										>{help.formula}</code
+									>
+									<ul class="list-disc space-y-0.5 pl-4">
 										{#each help.details as detail}<li>{detail}</li>{/each}
 									</ul>
 									{#if help.constants?.length}
-										<p class="font-medium text-surface-900-100">Current constants</p>
-										<ul class="list-disc pl-4 space-y-0.5">
+										<p class="text-surface-900-100 font-medium">Current constants</p>
+										<ul class="list-disc space-y-0.5 pl-4">
 											{#each help.constants as constant}<li>{constant}</li>{/each}
 										</ul>
 									{/if}
@@ -336,7 +357,7 @@
 							<svg
 								width={PLOT_W}
 								height={PLOT_H}
-								class="shrink-0 bg-surface-200-800 rounded border border-surface-300-700"
+								class="bg-surface-200-800 border-surface-300-700 shrink-0 rounded border"
 							>
 								<!-- identity reference -->
 								<line
@@ -361,10 +382,9 @@
 							<!-- Controls -->
 							<div class="flex-1 space-y-1">
 								<select
-									class="w-full text-xs bg-surface-200-800 border border-surface-300-700 rounded px-1 py-0.5"
+									class="bg-surface-200-800 border-surface-300-700 w-full rounded border px-1 py-0.5 text-xs"
 									value={c.curve.type}
-									onchange={(e) =>
-										setCurveType(c, e.currentTarget.value as ResponseCurve['type'])}
+									onchange={(e) => setCurveType(c, e.currentTarget.value as ResponseCurve['type'])}
 								>
 									{#each curveTypes as t}
 										<option value={t}>{t}</option>
@@ -377,7 +397,7 @@
 										<input
 											type="number"
 											step="0.1"
-											class="num-input flex-1 w-0 h-5 text-[10px] leading-none bg-surface-200-800 border border-surface-300-700 rounded px-1"
+											class="num-input bg-surface-200-800 border-surface-300-700 h-5 w-0 flex-1 rounded border px-1 text-[10px] leading-none"
 											value={(c.curve as unknown as Record<string, number>)[key] ?? 0}
 											oninput={(e) => {
 												(c.curve as unknown as Record<string, number>)[key] =

--- a/frontend/src/routes/components/workload_compounds.test.ts
+++ b/frontend/src/routes/components/workload_compounds.test.ts
@@ -8,10 +8,7 @@ function node(id: string, kind: string, parent?: string): Node {
 
 describe('workloadCompoundIds', () => {
 	it('selects a workload that owns one pod', () => {
-		const nodes = [
-			node('deployment/one', 'Deployment'),
-			node('pod/one', 'Pod', 'deployment/one')
-		];
+		const nodes = [node('deployment/one', 'Deployment'), node('pod/one', 'Pod', 'deployment/one')];
 
 		expect([...workloadCompoundIds(nodes)]).toEqual(['deployment/one']);
 	});

--- a/frontend/src/routes/flow/+page.svelte
+++ b/frontend/src/routes/flow/+page.svelte
@@ -1,144 +1,144 @@
 <script lang="ts">
-    import { type FlowEdge, type AttackFlow, type AttackStep } from '$lib/api/index';
-    import AttackStepDrawer from '$lib/components/AttackStepDrawer.svelte';
-    import ActionNode from '$lib/components/flow/attack_node.svelte';
-    import {
-        SvelteFlow,
-        Position,
-        Controls,
-        Background,
-        BackgroundVariant,
-        type Node,
-        type Edge,
-        type NodeTypes
-    } from '@xyflow/svelte';
-    import dagre from '@dagrejs/dagre';
-    import '@xyflow/svelte/dist/style.css';
+	import { type FlowEdge, type AttackFlow, type AttackStep } from '$lib/api/index';
+	import AttackStepDrawer from '$lib/components/AttackStepDrawer.svelte';
+	import ActionNode from '$lib/components/flow/attack_node.svelte';
+	import {
+		SvelteFlow,
+		Position,
+		Controls,
+		Background,
+		BackgroundVariant,
+		type Node,
+		type Edge,
+		type NodeTypes
+	} from '@xyflow/svelte';
+	import dagre from '@dagrejs/dagre';
+	import '@xyflow/svelte/dist/style.css';
 	import { getCampaignState } from '$lib/components/CampaignState.svelte';
 	import { ranAPI } from '$lib/ran_api';
-    import { getContext } from 'svelte';
+	import { getContext } from 'svelte';
 
-    let campaignState = getCampaignState();
-    const theme = getContext<{ isDark: boolean }>('theme');
-    const dagreGraph = new dagre.graphlib.Graph();
-    dagreGraph.setDefaultEdgeLabel(() => ({}));
+	let campaignState = getCampaignState();
+	const theme = getContext<{ isDark: boolean }>('theme');
+	const dagreGraph = new dagre.graphlib.Graph();
+	dagreGraph.setDefaultEdgeLabel(() => ({}));
 
-    let nodes: Node[] = $state.raw([]);
-    let edges: Edge[] = $state.raw([]);
+	let nodes: Node[] = $state.raw([]);
+	let edges: Edge[] = $state.raw([]);
 
-    const nodeTypes: NodeTypes = {
-        actionNode: ActionNode
-    };
+	const nodeTypes: NodeTypes = {
+		actionNode: ActionNode
+	};
 
-    // const snapGrid = [25, 25];
-    const nodeWidth = 240; // values are manually read from rendered nodes
-    const nodeHeight = 95;
-    let selectedStep: AttackStep | null = $state(null);
+	// const snapGrid = [25, 25];
+	const nodeWidth = 240; // values are manually read from rendered nodes
+	const nodeHeight = 95;
+	let selectedStep: AttackStep | null = $state(null);
 
-    function convertStep(step: AttackStep): Node {
-        return {
-            id: step.id,
-            type: 'actionNode',
-            data: { label: step.TTP.name, step: step },
-            position: { x: 0, y: 0 } // will be replaced by the layout algorithm
-        };
-    }
+	function convertStep(step: AttackStep): Node {
+		return {
+			id: step.id,
+			type: 'actionNode',
+			data: { label: step.TTP.name, step: step },
+			position: { x: 0, y: 0 } // will be replaced by the layout algorithm
+		};
+	}
 
-    function convertEdge(edge: FlowEdge): Edge {
-        return {
-            id: edge.id,
-            type: 'default',
-            source: edge.sourceId,
-            target: edge.targetId,
-        };
-    }
+	function convertEdge(edge: FlowEdge): Edge {
+		return {
+			id: edge.id,
+			type: 'default',
+			source: edge.sourceId,
+			target: edge.targetId
+		};
+	}
 
-    function layOutElements(nodes: Node[], edges: Edge[], direction = 'TB') {
-        const isHorizontal = direction === 'LR';
-        dagreGraph.setGraph({ rankdir: direction });
+	function layOutElements(nodes: Node[], edges: Edge[], direction = 'TB') {
+		const isHorizontal = direction === 'LR';
+		dagreGraph.setGraph({ rankdir: direction });
 
-        nodes.forEach((node) => {
-            dagreGraph.setNode(node.id, {
-                ...node,
-                width: node.measured?.width ?? nodeWidth,
-                height: node.measured?.height ?? nodeHeight,
-            });
-        });
+		nodes.forEach((node) => {
+			dagreGraph.setNode(node.id, {
+				...node,
+				width: node.measured?.width ?? nodeWidth,
+				height: node.measured?.height ?? nodeHeight
+			});
+		});
 
-        edges.forEach((edge) => {
-            dagreGraph.setEdge(edge.source, edge.target);
-        });
+		edges.forEach((edge) => {
+			dagreGraph.setEdge(edge.source, edge.target);
+		});
 
-        dagre.layout(dagreGraph);
+		dagre.layout(dagreGraph);
 
-        nodes = nodes.map((node) => {
-            // set the position of the input/output ports
-            const nodeWithPosition = dagreGraph.node(node.id);
-            // We are shifting the dagre node position (anchor=center center) to the top left
-            // so it matches the React Flow node anchor point (top left).
-            const x = nodeWithPosition.x - (node.measured?.width ?? nodeWidth) / 2;
-            const y = nodeWithPosition.y - (node.measured?.height ?? nodeHeight) / 2;
-            return {
-                ...node,
-                position: { x, y },
-                sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
-                targetPosition: isHorizontal ? Position.Left : Position.Top
-            }
-        });
-        return { nodes, edges };
-    }
+		nodes = nodes.map((node) => {
+			// set the position of the input/output ports
+			const nodeWithPosition = dagreGraph.node(node.id);
+			// We are shifting the dagre node position (anchor=center center) to the top left
+			// so it matches the React Flow node anchor point (top left).
+			const x = nodeWithPosition.x - (node.measured?.width ?? nodeWidth) / 2;
+			const y = nodeWithPosition.y - (node.measured?.height ?? nodeHeight) / 2;
+			return {
+				...node,
+				position: { x, y },
+				sourcePosition: isHorizontal ? Position.Right : Position.Bottom,
+				targetPosition: isHorizontal ? Position.Left : Position.Top
+			};
+		});
+		return { nodes, edges };
+	}
 
-    ranAPI.GetFlow()
-        .then((result: AttackFlow) => {
-            console.log('Campaign flow:', result);
-            const { steps, edges: es } = result;
-            const laidOutElements = layOutElements(steps.map(convertStep), es.map(convertEdge), 'TB');
+	ranAPI
+		.GetFlow()
+		.then((result: AttackFlow) => {
+			console.log('Campaign flow:', result);
+			const { steps, edges: es } = result;
+			const laidOutElements = layOutElements(steps.map(convertStep), es.map(convertEdge), 'TB');
 
-            nodes = laidOutElements.nodes;
-            edges = laidOutElements.edges;
-        })
-        .catch((err) => {
-            console.error(err);
-        });
-
+			nodes = laidOutElements.nodes;
+			edges = laidOutElements.edges;
+		})
+		.catch((err) => {
+			console.error(err);
+		});
 </script>
 
 <div class="items-top mx-auto flex h-dvh w-full justify-center">
-    <!-- {#each nodes as node}
+	<!-- {#each nodes as node}
         <div class="border-primary-950-50 m-4 rounded-lg border-2 p-6 shadow-lg">
             {node.name}
         </div>
     {/each} -->
-    <!-- <Graph bind:selectedNodeId /> -->
+	<!-- <Graph bind:selectedNodeId /> -->
 
-    <SvelteFlow
-        bind:nodes
-        bind:edges
-        {nodeTypes}
-        fitView
-        colorMode={theme.isDark ? 'dark' : 'light'}
-        onnodeclick={(event) => {
-            console.log('on node click', event, event.node);
-            selectedStep = event.node.data.step as AttackStep;
-        }}
-        onpaneclick={(event) => {
-            console.log('on pane click', event);
-            selectedStep = null;
-        }}
-        onselectionclick={(event) => console.log('on selection click', event)}
-        minZoom={0.1}
-        maxZoom={2.5}
-    >
-        <Controls />
-        <Background variant={BackgroundVariant.Dots} />
-        <!-- <MiniMap /> -->
-    </SvelteFlow>
+	<SvelteFlow
+		bind:nodes
+		bind:edges
+		{nodeTypes}
+		fitView
+		colorMode={theme.isDark ? 'dark' : 'light'}
+		onnodeclick={(event) => {
+			console.log('on node click', event, event.node);
+			selectedStep = event.node.data.step as AttackStep;
+		}}
+		onpaneclick={(event) => {
+			console.log('on pane click', event);
+			selectedStep = null;
+		}}
+		onselectionclick={(event) => console.log('on selection click', event)}
+		minZoom={0.1}
+		maxZoom={2.5}
+	>
+		<Controls />
+		<Background variant={BackgroundVariant.Dots} />
+		<!-- <MiniMap /> -->
+	</SvelteFlow>
 </div>
 
 <AttackStepDrawer step={selectedStep} onclose={() => (selectedStep = null)} />
 
 <style>
-    :global(.svelte-flow__node) {
-        text-align: center;
-    }
+	:global(.svelte-flow__node) {
+		text-align: center;
+	}
 </style>

--- a/frontend/src/routes/flow/+page.svelte
+++ b/frontend/src/routes/flow/+page.svelte
@@ -14,11 +14,9 @@
 	} from '@xyflow/svelte';
 	import dagre from '@dagrejs/dagre';
 	import '@xyflow/svelte/dist/style.css';
-	import { getCampaignState } from '$lib/components/CampaignState.svelte';
 	import { ranAPI } from '$lib/ran_api';
 	import { getContext } from 'svelte';
 
-	let campaignState = getCampaignState();
 	const theme = getContext<{ isDark: boolean }>('theme');
 	const dagreGraph = new dagre.graphlib.Graph();
 	dagreGraph.setDefaultEdgeLabel(() => ({}));

--- a/frontend/src/routes/page.svelte.test.ts
+++ b/frontend/src/routes/page.svelte.test.ts
@@ -4,6 +4,5 @@ import { render, screen } from '@testing-library/svelte';
 import Page from './+page.svelte';
 
 describe('/+page.svelte', () => {
-	test('should render h1', () => {
-	});
+	test('should render h1', () => {});
 });

--- a/frontend/src/routes/page.svelte.test.ts
+++ b/frontend/src/routes/page.svelte.test.ts
@@ -1,6 +1,0 @@
-import { describe, test } from 'vitest';
-import '@testing-library/jest-dom/vitest';
-
-describe('/+page.svelte', () => {
-	test('should render h1', () => {});
-});

--- a/frontend/src/routes/page.svelte.test.ts
+++ b/frontend/src/routes/page.svelte.test.ts
@@ -1,7 +1,5 @@
-import { describe, test, expect } from 'vitest';
+import { describe, test } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/svelte';
-import Page from './+page.svelte';
 
 describe('/+page.svelte', () => {
 	test('should render h1', () => {});

--- a/frontend/src/types/cytoscape-fcose.d.ts
+++ b/frontend/src/types/cytoscape-fcose.d.ts
@@ -1,63 +1,63 @@
 // src/types/cytoscape-fcose.d.ts
-import cytoscape, { LayoutOptions, EdgeSingular, NodeSingular } from "cytoscape";
+import cytoscape, { LayoutOptions, EdgeSingular, NodeSingular } from 'cytoscape';
 
-declare module "cytoscape" {
-  /** Options for the "fcose" layout */
-  interface FCoSELayoutOptions extends LayoutOptions {
-    name: "fcose";
+declare module 'cytoscape' {
+	/** Options for the "fcose" layout */
+	interface FCoSELayoutOptions extends LayoutOptions {
+		name: 'fcose';
 
-    // General
-    quality?: "draft" | "default" | "proof";
-    randomize?: boolean;
-    animate?: boolean | "end";
-    animationDuration?: number;
-    animationEasing?: string;
-    fit?: boolean;
-    padding?: number;
-    nodeDimensionsIncludeLabels?: boolean;
-    uniformNodeDimensions?: boolean;
-    packComponents?: boolean;
+		// General
+		quality?: 'draft' | 'default' | 'proof';
+		randomize?: boolean;
+		animate?: boolean | 'end';
+		animationDuration?: number;
+		animationEasing?: string;
+		fit?: boolean;
+		padding?: number;
+		nodeDimensionsIncludeLabels?: boolean;
+		uniformNodeDimensions?: boolean;
+		packComponents?: boolean;
 
-    // Forces / physics (common in CoSE/ fCoSE)
-    nodeSeparation?: number;
-    idealEdgeLength?: number | ((edge: EdgeSingular) => number);
-    nodeRepulsion?: number | ((node: NodeSingular) => number);
-    edgeElasticity?: number | ((edge: EdgeSingular) => number);
-    nestingFactor?: number;
-    gravity?: number;
-    gravityRangeCompound?: number;
-    gravityCompound?: number;
-    gravityRange?: number;
+		// Forces / physics (common in CoSE/ fCoSE)
+		nodeSeparation?: number;
+		idealEdgeLength?: number | ((edge: EdgeSingular) => number);
+		nodeRepulsion?: number | ((node: NodeSingular) => number);
+		edgeElasticity?: number | ((edge: EdgeSingular) => number);
+		nestingFactor?: number;
+		gravity?: number;
+		gravityRangeCompound?: number;
+		gravityCompound?: number;
+		gravityRange?: number;
 
-    // Constraints & incremental
-    numIter?: number;
-    tile?: boolean;
-    initialEnergyOnIncremental?: number;
+		// Constraints & incremental
+		numIter?: number;
+		tile?: boolean;
+		initialEnergyOnIncremental?: number;
 
-    fixedNodeConstraint?: Array<{
-      nodeId: string;
-      position: { x: number; y: number };
-    }>;
+		fixedNodeConstraint?: Array<{
+			nodeId: string;
+			position: { x: number; y: number };
+		}>;
 
-    alignmentConstraint?: {
-      vertical?: string[][];
-      horizontal?: string[][];
-    };
+		alignmentConstraint?: {
+			vertical?: string[][];
+			horizontal?: string[][];
+		};
 
-    relativePlacementConstraint?: Array<{
-      top?: string;
-      bottom?: string;
-      left?: string;
-      right?: string;
-      gap?: number;
-    }>;
+		relativePlacementConstraint?: Array<{
+			top?: string;
+			bottom?: string;
+			left?: string;
+			right?: string;
+			gap?: number;
+		}>;
 
-    /** Allow any extra plugin-specific options you may use */
-    [key: string]: unknown;
-  }
+		/** Allow any extra plugin-specific options you may use */
+		[key: string]: unknown;
+	}
 }
 
-declare module "cytoscape-fcose" {
-  const register: (cy: typeof cytoscape) => void;
-  export default register;
+declare module 'cytoscape-fcose' {
+	const register: (cy: typeof cytoscape) => void;
+	export default register;
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,9 +14,9 @@
 	"include": [
 		"./src",
 		"./src/types/*.ts",
-		"./.sveltekit/ambient.d.ts",
-		"./.sveltekit/non-ambient.d.ts",
-		"./.sveltekit/types/**/$types.d.ts",
+		"./.svelte-kit/ambient.d.ts",
+		"./.svelte-kit/non-ambient.d.ts",
+		"./.svelte-kit/types/**/$types.d.ts",
 		"./vite.config.js",
 		"./vite.config.ts",
 		"./src/**/*.js",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -19,6 +19,8 @@
 		"./.svelte-kit/types/**/$types.d.ts",
 		"./vite.config.js",
 		"./vite.config.ts",
+		// registers the @testing-library/jest-dom matcher types for svelte-check
+		"./vitest-setup-client.ts",
 		"./src/**/*.js",
 		"./src/**/*.ts",
 		"./src/**/*.svelte",

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,7 +9,7 @@
 		"skipLibCheck": true,
 		"sourceMap": true,
 		"strict": true,
-		"moduleResolution": "bundler",
+		"moduleResolution": "bundler"
 	},
 	"include": [
 		"./src",

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,20 +1,25 @@
 import tailwindcss from '@tailwindcss/vite';
 import { svelteTesting } from '@testing-library/svelte/vite';
 import { sveltekit } from '@sveltejs/kit/vite';
-import Icons from 'unplugin-icons/vite'
+import Icons from 'unplugin-icons/vite';
 import { defineConfig } from 'vite';
 
 const viteHost = process.env.RAN_VITE_HOST ?? 'localhost';
 const requestedPort = Number.parseInt(process.env.RAN_VITE_PORT ?? '5173', 10);
-const vitePort = Number.isInteger(requestedPort) && requestedPort > 0 && requestedPort <= 65535
-	? requestedPort
-	: 5173;
+const vitePort =
+	Number.isInteger(requestedPort) && requestedPort > 0 && requestedPort <= 65535
+		? requestedPort
+		: 5173;
 
 export default defineConfig({
-	plugins: [tailwindcss(), sveltekit(), Icons({
-		compiler: 'svelte',
-		autoInstall: true,
-	})],
+	plugins: [
+		tailwindcss(),
+		sveltekit(),
+		Icons({
+			compiler: 'svelte',
+			autoInstall: true
+		})
+	],
 
 	server: {
 		host: viteHost,
@@ -31,25 +36,25 @@ export default defineConfig({
 	},
 
 	build: {
-		minify: 'esbuild',            // much lighter than terser
-		cssCodeSplit: true,           // ensure CSS isn’t bundled into a giant JS chunk
-		assetsInlineLimit: 0,         // avoid inlining large assets into JS (helps peak memory)
+		minify: 'esbuild', // much lighter than terser
+		cssCodeSplit: true, // ensure CSS isn’t bundled into a giant JS chunk
+		assetsInlineLimit: 0, // avoid inlining large assets into JS (helps peak memory)
 		// Smaller, more numerous chunks are usually easier on memory than one mega vendor chunk
 		rollupOptions: {
 			output: {
 				manualChunks(id) {
-				if (id.includes('node_modules')) {
-					// group by top-level package name: node_modules/<pkg>/...
-					const match = id.toString().split('node_modules/')[1];
-					if (!match) return;
-					const pkg = match.split('/')[0].startsWith('@')
-					? match.split('/').slice(0,2).join('/')
-					: match.split('/')[0];
-					return `vendor-${pkg}`;
+					if (id.includes('node_modules')) {
+						// group by top-level package name: node_modules/<pkg>/...
+						const match = id.toString().split('node_modules/')[1];
+						if (!match) return;
+						const pkg = match.split('/')[0].startsWith('@')
+							? match.split('/').slice(0, 2).join('/')
+							: match.split('/')[0];
+						return `vendor-${pkg}`;
+					}
 				}
-				},
 			}
-		},
+		}
 	},
 
 	test: {


### PR DESCRIPTION
Part 1 of #52. Gets `pnpm lint` to green and wires it into CI, so the baseline
cannot regress while the typing work is done separately.

## The issue missed a blocker

`pnpm lint` is `prettier --check . && eslint .`, and the prettier half was not
merely dirty, it was crashing. `prettier-plugin-tailwindcss@0.6.14` does not
forward `getVisitorKeys` to the svelte parser under `prettier@3.8.3`, so all 25
`.svelte` files threw `TypeError: getVisitorKeys is not a function`. Confirmed by
running the same file with the tailwind plugin dropped. Bumped to `0.8.1`.

No lint gate could ever have gone green without this, so it comes first.

## Result

| | before | after |
|---|---:|---:|
| eslint errors | 249 | **0** |
| eslint warnings | 0 | 171 |
| prettier crashes | 25 | 0 |
| prettier unformatted | 26 | 0 |
| svelte-check errors | 0 | 0 |
| tests | 136 pass | 135 pass |

The 171 warnings are the three rules deferred in #52, parked in
`eslint.config.js` with the issue link: `no-explicit-any` (102),
`svelte/require-each-key` (44), `svelte/prefer-svelte-reactivity` (25). Each
goes back to `error` as its area is cleaned up.

Test count drops by one because a scaffold stub that asserted nothing was
deleted, see below.

## Commits

1. `chore(frontend): unbreak prettier and format the tree` - the plugin bump plus
   `prettier --write` across 49 files. Pure formatting.
2. `fix(frontend): clear the behaviour-neutral eslint violations` - the ~78 errors
   with no runtime effect.
3. `ci(frontend): gate pnpm lint ...` - `make lint-frontend`, added to `make lint`
   and to the existing `test-and-build-frontend` CI job.
4. `ci(frontend): gate svelte-check too` - same for `make check-frontend`.
5. `test(frontend): drop the vacuous +page scaffold stub`.

## Things worth a look in review

**A real latent bug, found on the way.** `frontend/tsconfig.json` had a typo in
`include`: `./.sveltekit/...` instead of `./.svelte-kit/...`. TypeScript does not
merge `include` with the extended config (the file's own comment says so), so the
generated route types were never loaded. Fixing it made `resolve()` type-check and
immediately exposed a dead comparison in `+layout.svelte`
(`page.url.pathname === ''` can never be true) and 4 more lint hits.
svelte-check now covers 1230 files, up from 1226.

**Underscore-prefixed vars are not deletable.** Several unused locals are
deliberate `$effect` dependency trackers (`_track`, `_sys`, `_`). Deleting them
silently breaks reactivity, so `no-unused-vars` now carries `^_` ignore patterns
instead. In `armory.svelte` I replaced the `nodeState` tracker object with the
`void x` reads already used one line above it.

**One change that is not purely cosmetic.** `armory.svelte` had
`let armory = $state(new Map())` plus `$effect(() => { armory = campaign.armory })`,
which `svelte/prefer-writable-derived` flags. It is now
`$derived(campaign.armory)`. There is only one assignment in the file, so the
value is the same, but `$derived` resolves synchronously where the `$effect` ran
after render. That removes a one-frame stale armory rather than introducing one.

**One file-level suppression.** All 4 `href`s in `entitlement_info.svelte` are
external documentation URLs where `resolve()` would corrupt them. The anchors
span several lines, so the reported line sits inside the element tag where an
HTML comment cannot go, and `eslint-disable-next-line` cannot reach it. The
suppression is at file scope with that reasoning written down.

**The deleted stub was load-bearing by accident.** `src/routes/page.svelte.test.ts`
was the SvelteKit scaffold default: `test('should render h1', () => {})` with an
empty body, against a page containing no `<h1>` at all. Deleting it broke
`pnpm check` with 50 errors, because its `import '@testing-library/jest-dom/vitest'`
was the only thing feeding the jest-dom matcher types to svelte-check. The
runtime import has always been in `vitest-setup-client.ts`, but that file was
not in tsconfig's `include`, so the types arrived only via a test file that
happened to sit inside `src/`. `vitest-setup-client.ts` is now in `include`,
which is where that belongs.

## Gating

Both `make lint-frontend` and `make check-frontend` run in the existing
`test-and-build-frontend` job and are folded into `make lint`. svelte-check is
gated as well as eslint, since it is green today and was the thing that caught
the tsconfig bug. It would have rotted the same way lint did.

## Not in this PR

The three parked rules, per the split recommended in #52. Agreed approach for the
`any` follow-up is hand-written ambient declarations for
`cytoscape-expand-collapse` and `cytoscape-elk`, extending the existing
`src/types/cytoscape-fcose.d.ts`, so nothing needs a disable.

## Verified

`pnpm lint`, `pnpm check`, `pnpm test` (135 pass), `pnpm build`,
`make lint-frontend` and `make check-frontend` all pass locally, and both CI jobs
are green.

https://claude.ai/code/session_01JqYopyBtJ7s23Xq3wV6fWS
