### PR TITLE
fix(armory): read local IPs from interfaces, fall back to hostname

### DIFF
--- a/armory/TTPs/Discovery/get_local_ip_address.yaml
+++ b/armory/TTPs/Discovery/get_local_ip_address.yaml
@@ -1,15 +1,25 @@
 name: Get local IP address
-description: Retrieve the IP address of the system
+description: >
+  Read the IP addresses assigned to the system's own network interfaces.
+  Linux-only. The primary procedure reads the local interface table via
+  iproute2, which never triggers DNS and so cannot hang inside a Kubernetes
+  pod with a slow or unreachable resolver. `hostname -i` is kept as a backup
+  for systems without iproute2, at the cost of reintroducing that DNS
+  dependency.
 tactic: Discovery
 techniques: ["System Network Configuration Discovery", T1016]
 preconditions:
   kind: System
   accessLevel: user-exec
 procedures:
+  # Order is load-bearing: the runtime defaults to procedures[0] and a
+  # `NextProcedure` retry walks the list by index, so `ip` runs first and
+  # `hostname` is only reached as a fallback.
+  - key: ip
+    tool: ip
+    command: ip -o -4 addr show scope global | awk '{print $4}' | cut -d/ -f1
   - key: hostname
     tool: hostname
-    precondition:
-      accessLevel: user-exec
     command: hostname -i
 effects:
   - sys.ip

--- a/crates/armory/src/armory.rs
+++ b/crates/armory/src/armory.rs
@@ -775,4 +775,39 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn local_ip_discovery_prefers_interfaces_over_hostname() {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../armory/TTPs");
+        let armory = Armory::load_from_dir(path).expect("repository armory should load");
+
+        let ttp = armory
+            .get_ttp("get-local-ip-address")
+            .expect("local IP discovery TTP");
+        assert_eq!(ttp.tactic, "Discovery");
+        assert!(ttp.effects.iter().any(|e| e == "sys.ip"));
+
+        // Order is the fallback mechanism: the runtime defaults to
+        // `procedures[0]` and a `NextProcedure` retry indexes into the list, so
+        // the interface read must come first and `hostname` second.
+        assert_eq!(ttp.procedures.len(), 2);
+
+        let primary = &ttp.procedures[0];
+        assert_eq!(primary.id, "ip");
+        assert_eq!(primary.tool.as_deref(), Some("ip"));
+        assert_eq!(
+            primary.command,
+            "ip -o -4 addr show scope global | awk \'{print $4}\' | cut -d/ -f1"
+        );
+        // The primary path must not resolve the hostname - that is what hangs
+        // in a pod with an unreachable DNS resolver.
+        assert!(!primary.command.contains("hostname"));
+        // `$4` is an awk field reference, not a Ran parameter placeholder.
+        assert!(!primary.command.contains("${"));
+
+        let fallback = &ttp.procedures[1];
+        assert_eq!(fallback.id, "hostname");
+        assert_eq!(fallback.tool.as_deref(), Some("hostname"));
+        assert_eq!(fallback.command, "hostname -i");
+    }
 }

--- a/crates/campaign/src/output_parsers/sys.rs
+++ b/crates/campaign/src/output_parsers/sys.rs
@@ -626,6 +626,46 @@ mod tests {
     }
 
     #[test]
+    fn parse_sys_ip_parses_multiple_interface_addresses() {
+        // stdout of `ip -o -4 addr show scope global | awk '{print $4}' | cut -d/ -f1`
+        // on a node with a primary NIC and a CNI bridge.
+        let stdout = "10.128.0.4\n172.17.0.1\n";
+        let result = parse_sys_ip(stdout, "", &HashMap::new());
+
+        let ParserOutput::Success(updates, detail) = result else {
+            panic!("expected Success, got {result:?}");
+        };
+        assert_eq!(updates.ips, vec!["10.128.0.4", "172.17.0.1"]);
+        assert!(
+            detail.contains("2"),
+            "detail should report the count: {detail}"
+        );
+    }
+
+    #[test]
+    fn parse_sys_ip_deduplicates_repeated_addresses() {
+        let result = parse_sys_ip("10.128.0.4\n10.128.0.4\n", "", &HashMap::new());
+
+        let ParserOutput::Success(updates, _) = result else {
+            panic!("expected Success");
+        };
+        assert_eq!(updates.ips, vec!["10.128.0.4"]);
+    }
+
+    #[test]
+    fn parse_sys_ip_on_empty_output_yields_no_ips() {
+        // A host with no global-scope IPv4 address produces empty stdout. The
+        // parser reports no IPs rather than UnknownFormat; the effect layer is
+        // what classifies empty stdout as a KnownFailure.
+        let result = parse_sys_ip("", "", &HashMap::new());
+
+        let ParserOutput::Success(updates, _) = result else {
+            panic!("expected Success");
+        };
+        assert!(updates.ips.is_empty());
+    }
+
+    #[test]
     fn parse_process_line_parses_standard_ps_line() {
         // Format: user pid ppid cpu stime tty time cmd...
         // (ps -eo user,pid,ppid,c,stime,tty,time,cmd)

--- a/crates/campaign/src/ttp_applicability.rs
+++ b/crates/campaign/src/ttp_applicability.rs
@@ -1459,6 +1459,56 @@ mod tests {
     }
 
     #[test]
+    fn fallback_procedure_keeps_ttp_runnable_when_primary_tool_is_absent() {
+        // Mirrors get-local-ip-address: `ip` primary, `hostname` fallback.
+        let ttp = Ttp {
+            status: "enabled".to_string(),
+            procedures: vec![
+                armory::Procedure {
+                    tool: Some("ip".to_string()),
+                    ..armory::Procedure::new("ip", "ip -o -4 addr show scope global")
+                },
+                armory::Procedure {
+                    tool: Some("hostname".to_string()),
+                    ..armory::Procedure::new("hostname", "hostname -i")
+                },
+            ],
+            ..Ttp::new("get-local-ip-address", "Get local IP address", "Discovery")
+        };
+
+        // iproute2 missing but hostname present: readiness is the max over
+        // procedures, so the fallback keeps the action on the table.
+        let mut c = empty_campaign();
+        let mut pod = Pod::new("nginx", "default");
+        pod.system
+            .binaries
+            .insert("ip".to_string(), BinaryPresence::Absent);
+        pod.system.binaries.insert(
+            "hostname".to_string(),
+            BinaryPresence::Present("/bin/hostname".into()),
+        );
+        let id = pod.entity_id().0;
+        c.entities.insert_typed(pod);
+
+        let tc = resolve_target_context(&c, &id).unwrap();
+        assert!(ttp_tool_satisfied(&ttp, &c, &tc));
+
+        // Both absent: nothing left to fall back to.
+        let mut c = empty_campaign();
+        let mut pod = Pod::new("nginx", "default");
+        for tool in ["ip", "hostname"] {
+            pod.system
+                .binaries
+                .insert(tool.to_string(), BinaryPresence::Absent);
+        }
+        let id = pod.entity_id().0;
+        c.entities.insert_typed(pod);
+
+        let tc = resolve_target_context(&c, &id).unwrap();
+        assert!(!ttp_tool_satisfied(&ttp, &c, &tc));
+    }
+
+    #[test]
     fn tool_satisfied_passes_for_non_system_target() {
         // A ServiceAccount has no binary map to assess → never blocked on tools.
         let c = campaign_with_sa("get", "serviceaccounts");


### PR DESCRIPTION
## Problem

`get-local-ip-address` ran `hostname -i`, which resolves the hostname through DNS. Inside a Kubernetes pod with a slow or unreachable resolver that can hang, which is bad in a workshop setting. We want local interface addresses, not hostname resolution.

## Change

The TTP now leads with an interface read and keeps `hostname -i` as a backup:

```
ip -o -4 addr show scope global | awk '{print $4}' | cut -d/ -f1
```

Procedure order is load-bearing, and both dispatch paths key off it:

- `select_procedure` takes `procedures.first()` when no procedure is named, so `ip` is the default.
- `retry_procedure_id_with_armory` does `procedures.get(attempt)`, so a step with `retry: NextProcedure` falls through to `hostname` on its own.
- `best_tool_readiness` is the max over procedures, so a target missing iproute2 but carrying `hostname` still keeps the action applicable.

The declared tool moved `hostname` to `ip`. `awk` and `cut` are not gated: `Procedure.tool` holds a single binary, and `ip` is the dependency that actually varies (iproute2 is absent from distroless and some slim images) while awk/cut are busybox/coreutils staples.

Also dropped the procedure-level `precondition:` block. `RawProcedure` has no such field, so it was silently discarded at load; the top-level `preconditions.accessLevel: user-exec` already carried that requirement.

## Tests

- `local_ip_discovery_prefers_interfaces_over_hostname` loads the real repo armory and asserts both procedures, their order, and the exact commands.
- `fallback_procedure_keeps_ttp_runnable_when_primary_tool_is_absent` covers `ip` absent + `hostname` present staying runnable, and both absent not.
- Three `parse_sys_ip` tests: newline-separated output parsing into multiple `sys.ip` facts, dedupe, and empty output.

`cargo test -p armory` (24) and `cargo test -p campaign` (491) pass; fmt, clippy `-D warnings`, and `git diff --check` are clean.

## Known limits

Worth reviewing rather than assuming away:

- **This is not real OS scoping.** The armory schema has no `os` precondition and no per-platform variants (`requires` supports only kind, rbacPermissions, accessLevel, activeSession, exists, c2.has-listener, c2.has-tool, has-token, related). Scoping here is indirect, via the binary gate. Adding the `hostname` fallback weakens it further: Windows has `hostname.exe`, so the TTP can be offered on a Windows target where `hostname -i` is not a valid invocation.
- **The hang is still reachable.** `NextProcedure` retry only helps when `ip` fails fast. If `ip` is missing and DNS is unreachable, the fallback is the original hang.

Both are fine for Linux targets, which the description now states. Hard OS gating would be a schema addition and belongs in its own change.

https://claude.ai/code/session_012RnFv8onoqKZr9VKe1tdXw