### PR TITLE
refactor(frontend): type the cytoscape modules and gate them

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -52,6 +52,24 @@ export default ts.config(
 		}
 	},
 	{
+		// The cytoscape modules are fully typed (#52 follow-up): the plugins have
+		// hand-written declarations in src/types, so `any` is an error here even
+		// while the rest of the tree still carries it as a warning. Adding a file
+		// to this list means committing to keeping it clean.
+		files: [
+			'src/types/**/*.d.ts',
+			'src/routes/components/graph.svelte',
+			'src/routes/components/graph_edges.ts',
+			'src/routes/components/graph_edges.svelte.test.ts',
+			'src/routes/components/graph_style.ts',
+			'src/routes/components/graph_node_selector.svelte',
+			'src/routes/components/elk_layout.ts'
+		],
+		rules: {
+			'@typescript-eslint/no-explicit-any': 'error'
+		}
+	},
+	{
 		files: ['**/*.svelte', '**/*.svelte.ts', '**/*.svelte.js'],
 		ignores: ['eslint.config.js', 'svelte.config.js'],
 

--- a/frontend/src/routes/components/GraphLayoutPlayground.svelte
+++ b/frontend/src/routes/components/GraphLayoutPlayground.svelte
@@ -31,8 +31,7 @@
 		{ key: 'layerSpacing', label: 'Layer spacing', min: 0, max: 400, step: 5, unit: 'px' },
 		{ key: 'nodeSpacing', label: 'Node spacing', min: 0, max: 150, step: 5, unit: 'px' },
 		{ key: 'edgeNodeSpacing', label: 'Edge-node spacing', min: 0, max: 150, step: 5, unit: 'px' },
-		{ key: 'aspectRatio', label: 'Aspect ratio', min: 0, max: 5, step: 0.1, unit: '' },
-		{ key: 'usesStraightness', label: '"uses" straightness', min: 0, max: 10, step: 1, unit: '' }
+		{ key: 'aspectRatio', label: 'Aspect ratio', min: 0, max: 5, step: 0.1, unit: '' }
 	];
 
 	const compoundSliders: Slider[] = [

--- a/frontend/src/routes/components/elk_layout.ts
+++ b/frontend/src/routes/components/elk_layout.ts
@@ -1,5 +1,4 @@
 import type cytoscape from 'cytoscape';
-import { INFORMATIONAL_EDGES } from './edge_categories';
 
 /** Rejects positions with non-finite coordinates or extreme values. */
 export function isValidPosition(pos: unknown): pos is { x: number; y: number } {
@@ -92,8 +91,6 @@ export type LayoutParams = {
 	compoundEdgeLength: number; // stress target edge length within namespace compounds
 	compoundPadding: number; // padding inside namespace compound nodes
 	stressIterations: number; // max iterations of stress algorithm inside compounds
-	// Edge behaviour
-	usesStraightness: number; // 0-10: how hard ELK tries to align "uses" edge endpoints vertically
 	// Animation
 	animationDuration: number; // ms; 0 = instant
 	// Strategies
@@ -109,7 +106,6 @@ export const DEFAULT_LAYOUT_PARAMS: LayoutParams = {
 	compoundEdgeLength: 32,
 	compoundPadding: 8,
 	stressIterations: 300,
-	usesStraightness: 3,
 	animationDuration: 250,
 	layeringStrategy: 'NETWORK_SIMPLEX',
 	nodePlacementStrategy: 'BRANDES_KOEPF'
@@ -130,7 +126,7 @@ function elkPos(x: number, y: number): string {
 export function createElkLayout(
 	positions: Record<string, { x: number; y: number }> = {},
 	params: LayoutParams = DEFAULT_LAYOUT_PARAMS
-): cytoscape.LayoutOptions & Record<string, unknown> {
+): cytoscape.ElkLayoutOptions {
 	const p = params.compoundPadding;
 	const compoundPad = `[top=${p},left=${p},bottom=${p},right=${p}]`;
 
@@ -192,17 +188,6 @@ export function createElkLayout(
 			}
 
 			return opts;
-		},
-
-		edgeLayoutOptions: (edge: cytoscape.EdgeSingular) => {
-			const name: string = edge.data('name');
-			if (name === 'uses') {
-				return { 'elk.layered.priority.straightness': String(params.usesStraightness) };
-			}
-			if (INFORMATIONAL_EDGES.has(name)) {
-				return undefined;
-			}
-			return {};
 		}
 	};
 }

--- a/frontend/src/routes/components/graph.svelte
+++ b/frontend/src/routes/components/graph.svelte
@@ -47,6 +47,14 @@
 		data: Node & { scenarioProvided: boolean };
 		position?: { x: number; y: number };
 	};
+	type CyEdge = {
+		data: Edge & {
+			source: string;
+			target: string;
+			scenarioProvided: boolean;
+			informational: boolean;
+		};
+	};
 	type Pos = { x: number; y: number };
 	type PosMap = Record<string, Pos>;
 	type ExpansionSnapshot = { right: number; visibleNodeIds: string[] };
@@ -57,8 +65,10 @@
 		selectedObject = $bindable()
 	}: GraphProps = $props();
 
-	let nodes = $state([]);
-	let edges = $state([]);
+	// The expand-collapse plugin API, handed from the mount to the update effect.
+	let expandCollapseApi: cytoscape.ExpandCollapseApi | null = null;
+	let nodes: CyNode[] = $state([]);
+	let edges: CyEdge[] = $state([]);
 	let searchOpen = $state(false);
 
 	const FILTER_NS_KEY = '_hiddenNamespaces';
@@ -118,7 +128,7 @@
 		if (!cy || cy.nodes().length === 0) return;
 		const currentPan = cy.pan();
 		const currentZoom = cy.zoom();
-		const l = cy.elements(':visible').layout(createElkLayout(positions, layoutParams) as any);
+		const l = cy.elements(':visible').layout(createElkLayout(positions, layoutParams));
 		l.one('layoutstop', () => {
 			cy.pan(currentPan);
 			cy.zoom(currentZoom);
@@ -195,7 +205,12 @@
 				nodes: nodes,
 				edges: edges
 			},
-			style: getGraphStyle(theme.isDark),
+			// Our style table declares property values as plain strings, where
+			// cytoscape's StylesheetJson wants literal unions ('text-wrap' must be
+			// 'none' | 'wrap' | 'ellipsis'). Satisfying that needs `as const` across
+			// the whole table, so the widening is asserted away here instead. A
+			// precise type, not any: a bad selector or style key still fails to build.
+			style: getGraphStyle(theme.isDark) as cytoscape.StylesheetJson,
 			layout: { name: 'preset' },
 			zoom: zoom,
 			wheelSensitivity: 0.1
@@ -205,9 +220,9 @@
 		}
 
 		// Initialize expand-collapse extension
-		let api;
+		let api: cytoscape.ExpandCollapseApi | null;
 		try {
-			api = (cy as any).expandCollapse({
+			api = cy.expandCollapse({
 				layoutBy: null,
 				fisheye: false,
 				animate: true,
@@ -228,10 +243,8 @@
 			api = null;
 		}
 
-		// Make API available for the graph update effect (expand/re-collapse on update)
-		if (browser) {
-			(window as any).cyExpandCollapseAPI = api;
-		}
+		// Hand the API to the graph update effect (expand/re-collapse on update)
+		expandCollapseApi = api;
 
 		cy.on('expandcollapse.aftercollapse', (event) => {
 			handleAfterCollapse(event.target);
@@ -340,7 +353,7 @@
 					// would not be in cyNodeIdSet and cy.add() would try to re-add them, causing
 					// "element already exists" or "invalid ID" errors from the plugin's meta-nodes.
 					const collapsedNodes: string[] = [];
-					const ecApi = (window as any).cyExpandCollapseAPI;
+					const ecApi = expandCollapseApi;
 					let addedNodeIds = new Set<string>();
 					const recollapseNodes = () => {
 						if (!ecApi || collapsedNodes.length === 0) return;
@@ -350,7 +363,7 @@
 								// The collapse plugin restores children by applying the parent's
 								// later movement delta. Seed newly added children at their parent
 								// so they follow that delta instead of restoring from (0, 0).
-								node.children().forEach((child: any) => {
+								node.children().forEach((child) => {
 									if (!addedNodeIds.has(child.id())) return;
 									const position = node.position();
 									child.position(position);
@@ -388,7 +401,7 @@
 					if (ecApi) {
 						isRestoringCollapsedState = true;
 						try {
-							cy.nodes('.cy-expand-collapse-collapsed-node').forEach((n: any) => {
+							cy.nodes('.cy-expand-collapse-collapsed-node').forEach((n) => {
 								collapsedNodes.push(n.id());
 								try {
 									ecApi.expand(n);
@@ -403,38 +416,38 @@
 
 					// Snapshot element IDs AFTER expansion so restored children are included
 					const cyNodeIdSet = new Set<string>();
-					cy.nodes().forEach((n: any) => {
+					cy.nodes().forEach((n) => {
 						cyNodeIdSet.add(n.id());
 					});
 					const cyEdgeIdSet = new Set<string>();
-					cy.edges().forEach((e: any) => {
+					cy.edges().forEach((e) => {
 						cyEdgeIdSet.add(e.id());
 					});
 
 					// Compute diffs: what to add, what to remove (guard against empty IDs)
 					const newEdgeIds = new Set<string>(
-						edges.filter((e: any) => e.data.id).map((e: any) => e.data.id as string)
+						edges.filter((e) => e.data.id).map((e) => e.data.id as string)
 					);
 					const nodesToAdd = nodes.filter(
-						(n: any) => n.data.id && !cyNodeIdSet.has(n.data.id as string)
+						(n) => n.data.id && !cyNodeIdSet.has(n.data.id as string)
 					);
-					addedNodeIds = new Set(nodesToAdd.map((node: any) => node.data.id as string));
+					addedNodeIds = new Set(nodesToAdd.map((node) => node.data.id as string));
 					const edgesToAdd = edges.filter(
-						(e: any) => e.data.id && !cyEdgeIdSet.has(e.data.id as string)
+						(e) => e.data.id && !cyEdgeIdSet.has(e.data.id as string)
 					);
 
 					// Remove elements no longer in the graph
 					cy.nodes()
-						.filter((n: any) => n.id() && !currentNodeIds.has(n.id()))
+						.filter((n) => n.id() !== '' && !currentNodeIds.has(n.id()))
 						.remove();
 					cy.edges()
-						.filter((e: any) => e.id() && !newEdgeIds.has(e.id()))
+						.filter((e) => e.id() !== '' && !newEdgeIds.has(e.id()))
 						.remove();
 
 					// Update data for existing nodes (e.g. compromised/isRunning status changes)
 					nodes
-						.filter((n: any) => n.data.id && cyNodeIdSet.has(n.data.id as string))
-						.forEach((n: any) => {
+						.filter((n) => n.data.id && cyNodeIdSet.has(n.data.id as string))
+						.forEach((n) => {
 							cy.getElementById(n.data.id).data(n.data);
 						});
 
@@ -443,18 +456,18 @@
 					// target and name stay the same), so without this refresh the
 					// edge[?broken] restyle would not apply until a full remount.
 					edges
-						.filter((e: any) => e.data.id && cyEdgeIdSet.has(e.data.id as string))
-						.forEach((e: any) => {
+						.filter((e) => e.data.id && cyEdgeIdSet.has(e.data.id as string))
+						.forEach((e) => {
 							cy.getElementById(e.data.id).data(e.data);
 						});
 
 					// Pre-position new nodes near their connected existing nodes so they don't spawn randomly
 					if (nodesToAdd.length > 0) {
-						const addingIds = new Set<string>(nodesToAdd.map((n: any) => n.data.id as string));
-						const nodeDefinitions = new Map<string, any>(
-							nodes.map((node: any) => [node.data.id as string, node])
+						const addingIds = new Set<string>(nodesToAdd.map((n) => n.data.id as string));
+						const nodeDefinitions = new Map<string, CyNode>(
+							nodes.map((node) => [node.data.id as string, node])
 						);
-						nodesToAdd.forEach((newNode: any, index: number) => {
+						nodesToAdd.forEach((newNode, index) => {
 							if (newNode.position) return; // already has a saved position
 							const nodeId = newNode.data.id as string;
 
@@ -482,7 +495,7 @@
 							if (newNode.position) return;
 
 							const neighborPositions: { x: number; y: number }[] = [];
-							edges.forEach((edge: any) => {
+							edges.forEach((edge) => {
 								const src = edge.data.source as string;
 								const tgt = edge.data.target as string;
 								const neighborId = src === nodeId ? tgt : tgt === nodeId ? src : null;
@@ -503,9 +516,9 @@
 							}
 						});
 						// Ensure compound/parent nodes are added before their children
-						nodesToAdd.sort((a: any, b: any) => {
-							const aIsParent = nodes.some((n: any) => n.data.parent === a.data.id);
-							const bIsParent = nodes.some((n: any) => n.data.parent === b.data.id);
+						nodesToAdd.sort((a, b) => {
+							const aIsParent = nodes.some((n) => n.data.parent === a.data.id);
+							const bIsParent = nodes.some((n) => n.data.parent === b.data.id);
 							if (aIsParent && !bIsParent) return -1;
 							if (!aIsParent && bIsParent) return 1;
 							return 0;
@@ -514,7 +527,7 @@
 
 						// Sync pre-computed positions into the map and onto the live element so
 						// elk.position hints reflect the pre-positioned location on next layout run.
-						nodesToAdd.forEach((newNode: any) => {
+						nodesToAdd.forEach((newNode) => {
 							if (newNode.position) {
 								const id = newNode.data.id as string;
 								positions[id] = newNode.position;
@@ -561,7 +574,7 @@
 							positions,
 							untrack(() => layoutParams)
 						);
-						const l = cy.elements(':visible').layout(layoutOptions as any);
+						const l = cy.elements(':visible').layout(layoutOptions);
 
 						l.one('layoutstop', () => {
 							if (isInitialLoad) {
@@ -621,7 +634,7 @@
 	function saveCollapsedNodes() {
 		if (!browser || !cy) return;
 		const ids: string[] = [];
-		cy.nodes('.cy-expand-collapse-collapsed-node').forEach((n: any) => {
+		cy.nodes('.cy-expand-collapse-collapsed-node').forEach((n) => {
 			ids.push(n.id());
 		});
 		sessionStorage.setItem(COLLAPSED_KEY, JSON.stringify(ids));
@@ -724,7 +737,7 @@
 	 * Keep the selected element and its immediate graph context prominent.
 	 * Compound ancestors remain visible as quiet orientation boundaries.
 	 */
-	function focusSelection(element: any) {
+	function focusSelection(element: cytoscape.NodeSingular | cytoscape.EdgeSingular) {
 		if (!cy) return;
 		const visible = cy.elements(':visible');
 		let context: cytoscape.CollectionReturnValue;
@@ -763,7 +776,7 @@
 		context.removeClass('context-dimmed');
 	}
 
-	function toCyNode(n: Node, nodePos: Record<string, any>): CyNode {
+	function toCyNode(n: Node, nodePos: PosMap): CyNode {
 		let cyNode: CyNode = {
 			id: n.id,
 			label: n.name,
@@ -788,7 +801,7 @@
 		return cyNode;
 	}
 
-	function toCyEdge(e: Edge) {
+	function toCyEdge(e: Edge): CyEdge {
 		return {
 			data: {
 				source: e.sourceId,
@@ -816,7 +829,7 @@
 		searchOpen = true;
 	}
 
-	function handleAfterCollapse(node: any) {
+	function handleAfterCollapse(node: cytoscape.NodeSingular) {
 		// After the expand-collapse plugin re-points every child edge at the
 		// collapsed compound, merge parallel edges sharing the same directed pair
 		// into one meta-edge so the node shows a single edge per relation to each
@@ -831,20 +844,22 @@
 	 */
 	function applyNamespaceFilters(cy: cytoscape.Core, hidden: Set<string>) {
 		// Step 1: restore elements previously hidden by this filter
-		cy.elements('.namespace-filtered').forEach((el: any) => {
-			el.removeClass('namespace-filtered');
-			if (el.isNode()) {
-				// Don't re-show if it's a child of a collapsed compound node
-				const parent = el.parent();
-				const isCollapsedChild =
-					parent.length > 0 && parent.hasClass('cy-expand-collapse-collapsed-node');
-				if (!isCollapsedChild) {
+		cy.elements('.namespace-filtered').forEach(
+			(el: cytoscape.NodeSingular | cytoscape.EdgeSingular) => {
+				el.removeClass('namespace-filtered');
+				if (el.isNode()) {
+					// Don't re-show if it's a child of a collapsed compound node
+					const parent = el.parent();
+					const isCollapsedChild =
+						parent.length > 0 && parent[0].hasClass('cy-expand-collapse-collapsed-node');
+					if (!isCollapsedChild) {
+						el.show();
+					}
+				} else if (!el.data('isMetaEdge') && !el.hasClass(COLLAPSED_EDGE_CLASS)) {
 					el.show();
 				}
-			} else if (!el.data('isMetaEdge') && !el.hasClass(COLLAPSED_EDGE_CLASS)) {
-				el.show();
 			}
-		});
+		);
 
 		if (hidden.size === 0) {
 			// No filter - re-apply informational edge logic and return
@@ -855,7 +870,7 @@
 		// Step 2: collect node IDs that belong to filtered namespaces
 		const filteredNodeIds = new Set<string>();
 		hidden.forEach((nsName) => {
-			cy.nodes().forEach((n: any) => {
+			cy.nodes().forEach((n) => {
 				// Match both expanded compound nodes (isParent) and collapsed ones
 				// (cy-expand-collapse-collapsed-node class). When collapsed, isParent()
 				// returns false because the plugin has removed children from the graph.
@@ -867,7 +882,9 @@
 					// descendants() is empty for collapsed nodes (children are removed by the
 					// plugin), so this is a no-op for them - which is correct: hiding the
 					// collapsed compound already hides everything inside it.
-					n.descendants().forEach((d: any) => filteredNodeIds.add(d.id()));
+					n.descendants().forEach((d) => {
+						filteredNodeIds.add(d.id());
+					});
 				}
 			});
 		});
@@ -877,12 +894,12 @@
 			const n = cy.getElementById(id);
 			if (n.length > 0) {
 				n.addClass('namespace-filtered');
-				(n as any).hide();
+				n.hide();
 			}
 		});
 
 		// Step 4: hide edges touching filtered nodes
-		cy.edges().forEach((e: any) => {
+		cy.edges().forEach((e) => {
 			if (e.data('isMetaEdge')) return;
 			if (filteredNodeIds.has(e.source().id()) || filteredNodeIds.has(e.target().id())) {
 				e.addClass('namespace-filtered');
@@ -894,7 +911,7 @@
 		hideRedundantInformationalEdges(cy);
 	}
 
-	function handleAfterExpand(node: any) {
+	function handleAfterExpand(node: cytoscape.NodeSingular) {
 		// Remove our custom meta-edges for this node and restore the original
 		// edges we hid on collapse (the plugin restores its own internal state).
 		restoreConsolidatedEdges(cy, node);
@@ -904,15 +921,15 @@
 		applyCompromisedStyle(cy);
 	}
 
-	function captureExpansionSnapshot(node: any) {
+	function captureExpansionSnapshot(node: cytoscape.NodeSingular) {
 		const bounds = node.boundingBox();
 		expansionSnapshots.set(node.id(), {
 			right: bounds.x2,
-			visibleNodeIds: cy.nodes(':visible').map((n: any) => n.id())
+			visibleNodeIds: cy.nodes(':visible').map((n) => n.id())
 		});
 	}
 
-	function shiftNodesForExpansion(node: any) {
+	function shiftNodesForExpansion(node: cytoscape.NodeSingular) {
 		const snapshot = expansionSnapshots.get(node.id());
 		expansionSnapshots.delete(node.id());
 		if (!snapshot) return;
@@ -924,19 +941,24 @@
 		const candidates = snapshot.visibleNodeIds
 			.map((id) => cy.getElementById(id))
 			.filter(
-				(candidate: any) =>
+				(candidate) =>
 					candidate.length > 0 &&
 					candidate.visible() &&
 					candidate.id() !== node.id() &&
 					candidate.boundingBox().x1 >= snapshot.right
 			);
-		const candidateIds = new Set(candidates.map((candidate: any) => candidate.id()));
-		const nodesToShift = candidates.filter((candidate: any) =>
-			candidate.ancestors().every((ancestor: any) => !candidateIds.has(ancestor.id()))
+		const candidateIds = new Set(candidates.map((candidate) => candidate.id()));
+		// Shift only the outermost candidates: an ancestor that is shifting too
+		// already carries its descendants, so moving both would double the offset.
+		// filter() is used rather than every() because cytoscape types every()'s
+		// callback as CollectionArgument, which has no id().
+		const nodesToShift = candidates.filter(
+			(candidate) =>
+				candidate.ancestors().filter((ancestor) => candidateIds.has(ancestor.id())).length === 0
 		);
 
 		cy.batch(() => {
-			nodesToShift.forEach((candidate: any) => {
+			nodesToShift.forEach((candidate) => {
 				const position = candidate.position();
 				candidate.position({ x: position.x + shift, y: position.y });
 			});

--- a/frontend/src/routes/components/graph_edges.svelte.test.ts
+++ b/frontend/src/routes/components/graph_edges.svelte.test.ts
@@ -18,20 +18,20 @@ const COLLAPSED_NODE_CLASS = 'cy-expand-collapse-collapsed-node';
 // re-pointed at the collapsed compound, and the compound carrying the collapsed
 // class - which is exactly the input our helpers consume.
 
-function mountCy(elements: any[]) {
+function mountCy(elements: cytoscape.ElementDefinition[]) {
 	return cytoscape({ headless: true, styleEnabled: true, elements });
 }
 
 /** Mark a compound as collapsed, mirroring the plugin's class. */
-function markCollapsed(cy: any, id: string) {
+function markCollapsed(cy: cytoscape.Core, id: string) {
 	cy.getElementById(id).addClass(COLLAPSED_NODE_CLASS);
 }
 
-function visibleEdges(cy: any): string[] {
+function visibleEdges(cy: cytoscape.Core): string[] {
 	return cy
 		.edges()
-		.filter((e: any) => e.visible())
-		.map((e: any) => `${e.source().id()}->${e.target().id()} [${e.id()}]`)
+		.filter((e) => e.visible())
+		.map((e: cytoscape.EdgeSingular) => `${e.source().id()}->${e.target().id()} [${e.id()}]`)
 		.sort();
 }
 

--- a/frontend/src/routes/components/graph_edges.ts
+++ b/frontend/src/routes/components/graph_edges.ts
@@ -16,18 +16,18 @@ export const COLLAPSED_EDGE_CLASS = 'collapsed-consolidated';
  * into a single meta-edge per directed pair so the collapsed node shows one edge
  * per relation to each external neighbour instead of one edge per hidden child.
  */
-export function consolidateCollapsedEdges(cy: cytoscape.Core, node: any) {
+export function consolidateCollapsedEdges(cy: cytoscape.Core, node: cytoscape.NodeSingular) {
 	// Consider all VISIBLE connected edges. This includes meta-edges produced by
 	// already-collapsed descendants (e.g. collapsed Deployments inside a Namespace),
 	// so their groups merge upward into this node's meta-edge. It is also naturally
 	// idempotent: after consolidation the underlying edges are hidden, so a repeat
 	// call sees only the single visible meta-edge per pair (group size 1 → skipped).
-	const connectedEdges = node.connectedEdges().filter((e: any) => e.visible());
+	const connectedEdges = node.connectedEdges().filter((e) => e.visible());
 
 	// Group by directed source->target pair
-	const edgeGroups = new Map<string, any[]>();
+	const edgeGroups = new Map<string, cytoscape.EdgeSingular[]>();
 
-	connectedEdges.forEach((edge: any) => {
+	connectedEdges.forEach((edge) => {
 		const sourceId = edge.source().id();
 		const targetId = edge.target().id();
 		if (sourceId === targetId) return; // skip self-loops
@@ -55,19 +55,19 @@ export function consolidateCollapsedEdges(cy: cytoscape.Core, node: any) {
 		// Hide all edges in this group. Tag them so later visibility passes
 		// (hideRedundantInformationalEdges) know they were hidden by collapse
 		// and must not re-show them.
-		edges.forEach((e: any) => {
+		edges.forEach((e) => {
 			e.addClass(COLLAPSED_EDGE_CLASS);
 			e.hide();
 		});
 
 		// Build a descriptive label from unique edge names
-		const uniqueNames = [...new Set(edges.map((e: any) => e.data('name')))].filter(Boolean);
+		const uniqueNames = [...new Set(edges.map((e) => e.data('name')))].filter(Boolean);
 		const label = uniqueNames.length === 1 ? uniqueNames[0] : `${edges.length} relations`;
 
 		// Inherit the informational styling (subdued gray/dotted) only when every
 		// consolidated edge was informational. If any underlying edge is actionable,
 		// the group represents a meaningful relation and should look actionable.
-		const informational = edges.every((e: any) => Boolean(e.data('informational')));
+		const informational = edges.every((e) => Boolean(e.data('informational')));
 
 		cy.add({
 			group: 'edges',
@@ -77,7 +77,7 @@ export function consolidateCollapsedEdges(cy: cytoscape.Core, node: any) {
 				target: targetId,
 				name: label,
 				informational,
-				collapsedEdges: edges.map((e: any) => e.id()),
+				collapsedEdges: edges.map((e) => e.id()),
 				isMetaEdge: true
 			}
 		});
@@ -89,8 +89,8 @@ export function consolidateCollapsedEdges(cy: cytoscape.Core, node: any) {
  * remove our custom meta-edges touching this node and restore the original edges
  * we hid, clearing the collapse marker so normal visibility logic applies again.
  */
-export function restoreConsolidatedEdges(cy: cytoscape.Core, node: any) {
-	cy.edges('[?isMetaEdge]').forEach((metaEdge: any) => {
+export function restoreConsolidatedEdges(cy: cytoscape.Core, node: cytoscape.NodeSingular) {
+	cy.edges('[?isMetaEdge]').forEach((metaEdge) => {
 		const source = metaEdge.source().id();
 		const target = metaEdge.target().id();
 
@@ -101,8 +101,8 @@ export function restoreConsolidatedEdges(cy: cytoscape.Core, node: any) {
 			collapsedEdgeIds.forEach((edgeId: string) => {
 				const edge = cy.getElementById(edgeId);
 				if (edge.length > 0) {
-					(edge as any).removeClass(COLLAPSED_EDGE_CLASS);
-					(edge as any).show();
+					edge.removeClass(COLLAPSED_EDGE_CLASS);
+					edge.show();
 				}
 			});
 
@@ -121,7 +121,7 @@ export function restoreConsolidatedEdges(cy: cytoscape.Core, node: any) {
  * per external neighbour. Safe to call repeatedly.
  */
 export function reconcileCollapsedEdges(cy: cytoscape.Core) {
-	cy.nodes('.cy-expand-collapse-collapsed-node').forEach((node: any) => {
+	cy.nodes('.cy-expand-collapse-collapsed-node').forEach((node) => {
 		consolidateCollapsedEdges(cy, node);
 	});
 }
@@ -140,7 +140,7 @@ export function hideRedundantInformationalEdges(cy: cytoscape.Core) {
 	// Collect directed node-pairs that have any non-filtered edge (keyed by pair + edge name)
 	const pairEdgeNames = new Map<string, Set<string>>();
 
-	cy.edges().forEach((e: any) => {
+	cy.edges().forEach((e) => {
 		if (e.hasClass('namespace-filtered') || e.hasClass(COLLAPSED_EDGE_CLASS)) return;
 		const pair = `${e.source().id()}->${e.target().id()}`;
 		if (!e.data('informational')) {
@@ -153,7 +153,7 @@ export function hideRedundantInformationalEdges(cy: cytoscape.Core) {
 
 	// Hide informational edges whose directed pair has an actionable edge.
 	// For "runs-on", hide when ANY other edge exists for the same pair.
-	cy.edges('[?informational]').forEach((e: any) => {
+	cy.edges('[?informational]').forEach((e) => {
 		if (e.hasClass('namespace-filtered')) return; // don't touch namespace-filtered edges
 		// Edges hidden by a compound collapse are represented by a meta-edge; leave
 		// them hidden so collapsing doesn't get undone by this pass.

--- a/frontend/src/routes/components/graph_node_selector.svelte
+++ b/frontend/src/routes/components/graph_node_selector.svelte
@@ -5,7 +5,7 @@
 	type CyNode = {
 		id: string;
 		label: string;
-		data: any;
+		data: cytoscape.NodeDataDefinition;
 		position?: { x: number; y: number };
 	};
 

--- a/frontend/src/routes/components/graph_style.ts
+++ b/frontend/src/routes/components/graph_style.ts
@@ -76,7 +76,20 @@ function mapKindIcons(obj: Record<string, string>) {
 	});
 }
 
-export function getGraphStyle(isDark: boolean = false) {
+/**
+ * One block of the graph stylesheet. Precise about the block shape while
+ * staying loose about property values: cytoscape's own StylesheetJson types
+ * every style property as a literal union, which a plain object-literal table
+ * cannot satisfy without `as const` throughout. The cast to StylesheetJson
+ * happens once, where the stylesheet is handed to cytoscape.
+ */
+export type GraphStylesheetBlock = {
+	selector: string;
+	// undefined appears where a property is set through a conditional spread.
+	style: Record<string, string | number | string[] | number[] | undefined>;
+};
+
+export function getGraphStyle(isDark: boolean = false): GraphStylesheetBlock[] {
 	// Cytoscape does not accept the Mona theme's native oklch() color value.
 	const primary = '#600FED';
 	const textColor = isDark ? 'white' : 'black';
@@ -480,7 +493,7 @@ export function getGraphStyle(isDark: boolean = false) {
 			}
 		}
 	];
-	return [...mapKindIcons(KIND_SVG_MAP), ...graph_style] as any;
+	return [...mapKindIcons(KIND_SVG_MAP), ...graph_style];
 }
 
 const redTintSvg =

--- a/frontend/src/types/cytoscape-augment.d.ts
+++ b/frontend/src/types/cytoscape-augment.d.ts
@@ -1,0 +1,36 @@
+// src/types/cytoscape-augment.d.ts
+//
+// Gaps in cytoscape's own bundled index.d.ts. These are documented, shipped API
+// that the type definitions simply omit, so they are declared here rather than
+// worked around with casts. Verified against cytoscape 3.33.2; re-check on a
+// major bump in case upstream has since typed them.
+//
+// `show()` / `hide()` are the documented display shortcuts (equivalent to
+// setting the `display` style to `element` / `none`). They exist on singulars
+// and collections alike but appear nowhere in the bundled declarations. The
+// declarations are repeated per interface rather than shared through a base,
+// because an interface extending one without adding members is itself a lint
+// error.
+import 'cytoscape';
+
+declare module 'cytoscape' {
+	interface NodeSingular {
+		show(): this;
+		hide(): this;
+	}
+
+	interface EdgeSingular {
+		show(): this;
+		hide(): this;
+	}
+
+	interface NodeCollection {
+		show(): this;
+		hide(): this;
+	}
+
+	interface EdgeCollection {
+		show(): this;
+		hide(): this;
+	}
+}

--- a/frontend/src/types/cytoscape-elk.d.ts
+++ b/frontend/src/types/cytoscape-elk.d.ts
@@ -1,0 +1,69 @@
+// src/types/cytoscape-elk.d.ts
+//
+// cytoscape-elk ships no type declarations. These are written from the plugin
+// source (node_modules/cytoscape-elk/src/defaults.js for the options,
+// src/layout.js for how they are consumed). Hand-written types drift from the
+// library, so on a version bump re-read those files before trusting this one.
+import cytoscape, { NodeSingular, Position } from 'cytoscape';
+
+declare module 'cytoscape' {
+	/**
+	 * Layout options for ELK's own algorithms, passed straight through as ELK
+	 * `layoutOptions`. Keys are ELK identifiers and must be quoted, in either
+	 * the short (`elk.direction`) or fully qualified
+	 * (`org.eclipse.elk.hierarchyHandling`) form, and ELK reads every value as
+	 * a string. See https://www.eclipse.org/elk/reference.html
+	 */
+	interface ElkOptions {
+		/** The ELK algorithm to run. Effectively mandatory. */
+		'elk.algorithm'?:
+			| 'box'
+			| 'disco'
+			| 'force'
+			| 'layered'
+			| 'mrtree'
+			| 'radial'
+			| 'random'
+			| 'stress';
+		[option: string]: string | undefined;
+	}
+
+	/** Options for the "elk" layout. */
+	interface ElkLayoutOptions extends cytoscape.BaseLayoutOptions {
+		name: 'elk';
+
+		/** Include label dimensions when measuring nodes. */
+		nodeDimensionsIncludeLabels?: boolean;
+		fit?: boolean;
+		/** Padding applied when `fit` is true. */
+		padding?: number;
+
+		animate?: boolean;
+		/** Nodes returning false jump straight to their final position. */
+		animateFilter?: (node: NodeSingular, index: number) => boolean;
+		animationDuration?: number;
+		animationEasing?: string;
+
+		/** Applies a transform to each final node position. */
+		transform?: (node: NodeSingular, position: Position) => Position;
+		ready?: () => void;
+		stop?: () => void;
+
+		/** Per-node ELK options, merged over `elk` for that node. */
+		nodeLayoutOptions?: ElkOptions | ((node: NodeSingular) => Record<string, string> | ElkOptions);
+
+		/** Options handed to ELK for the graph as a whole. */
+		elk?: ElkOptions;
+
+		/**
+		 * Edges with a non-nil priority are skipped when greedy edge cycle
+		 * breaking is enabled.
+		 */
+		priority?: (edge: cytoscape.EdgeSingular) => number | null;
+	}
+}
+
+declare module 'cytoscape-elk' {
+	const register: (cy: typeof cytoscape) => void;
+	export default register;
+}

--- a/frontend/src/types/cytoscape-expand-collapse.d.ts
+++ b/frontend/src/types/cytoscape-expand-collapse.d.ts
@@ -1,0 +1,112 @@
+// src/types/cytoscape-expand-collapse.d.ts
+//
+// cytoscape-expand-collapse ships no type declarations. These are written from
+// the plugin source (node_modules/cytoscape-expand-collapse/src/index.js): the
+// options block is its documented defaults object, and the methods are the
+// `api.*` assignments in createExtensionAPI. Hand-written types drift from the
+// library, so on a version bump re-read that file before trusting this one.
+import cytoscape, { NodeCollection, NodeSingular, EdgeCollection } from 'cytoscape';
+
+declare module 'cytoscape' {
+	/**
+	 * Options accepted by `cy.expandCollapse()`. Every field is optional; the
+	 * plugin merges what it is given over its own defaults.
+	 */
+	interface ExpandCollapseOptions {
+		/** Layout to re-run after an expand or collapse. `null` disables it. */
+		layoutBy?: cytoscape.LayoutOptions | (() => void) | null;
+		/** Fisheye view around the node being expanded or collapsed. */
+		fisheye?: boolean | (() => boolean);
+		animate?: boolean | (() => boolean);
+		animationDuration?: number;
+		/** Called once the extension has initialised. */
+		ready?: () => void;
+		/** Register operations with the undo-redo extension, when present. */
+		undoable?: boolean;
+
+		/** The clickable plus/minus cue drawn on collapsible nodes. */
+		cueEnabled?: boolean;
+		expandCollapseCuePosition?:
+			| 'top-left'
+			| 'top-right'
+			| 'bottom-left'
+			| 'bottom-right'
+			| ((node: NodeSingular) => { x: number; y: number });
+		expandCollapseCueSize?: number;
+		expandCollapseCueLineSize?: number;
+		/** Custom cue artwork. Undefined draws the built-in icon. */
+		expandCueImage?: string;
+		collapseCueImage?: string;
+		expandCollapseCueSensitivity?: number;
+
+		/** `edge.data()` field naming the edge type, used to group edges. */
+		edgeTypeInfo?: string | ((edge: cytoscape.EdgeSingular) => string);
+		groupEdgesOfSameTypeOnCollapse?: boolean;
+		allowNestedEdgeCollapse?: boolean;
+		/** z-index of the canvas the cues are drawn on. */
+		zIndex?: number;
+	}
+
+	/** Per-call overrides. The plugin accepts the same shape as the initialiser. */
+	type ExpandCollapseCallOptions = ExpandCollapseOptions;
+
+	/** The object returned by `cy.expandCollapse(options)`. */
+	interface ExpandCollapseApi {
+		setOptions(options: ExpandCollapseOptions): void;
+		extendOptions(options: ExpandCollapseOptions): void;
+		setOption<K extends keyof ExpandCollapseOptions>(
+			name: K,
+			value: ExpandCollapseOptions[K]
+		): void;
+
+		collapse(eles: NodeCollection | NodeSingular, options?: ExpandCollapseCallOptions): void;
+		collapseRecursively(
+			eles: NodeCollection | NodeSingular,
+			options?: ExpandCollapseCallOptions
+		): void;
+		expand(eles: NodeCollection | NodeSingular, options?: ExpandCollapseCallOptions): void;
+		expandRecursively(
+			eles: NodeCollection | NodeSingular,
+			options?: ExpandCollapseCallOptions
+		): void;
+		collapseAll(options?: ExpandCollapseCallOptions): void;
+		expandAll(options?: ExpandCollapseCallOptions): void;
+
+		isExpandable(node: NodeSingular): boolean;
+		isCollapsible(node: NodeSingular): boolean;
+		collapsibleNodes(nodes?: NodeCollection): NodeCollection;
+		expandableNodes(nodes?: NodeCollection): NodeCollection;
+
+		getCollapsedChildren(node: NodeSingular): cytoscape.Collection;
+		getCollapsedChildrenRecursively(node: NodeSingular): cytoscape.Collection;
+		getAllCollapsedChildrenRecursively(): cytoscape.Collection;
+		getParent(nodeId: string): NodeSingular | undefined;
+
+		clearVisualCue(node: NodeSingular): void;
+		disableCue(): void;
+		enableCue(): void;
+
+		collapseEdges(edges: EdgeCollection, options?: ExpandCollapseCallOptions): void;
+		expandEdges(edges: EdgeCollection): void;
+		collapseEdgesBetweenNodes(nodes: NodeCollection, options?: ExpandCollapseCallOptions): void;
+		expandEdgesBetweenNodes(nodes: NodeCollection): void;
+		collapseAllEdges(options?: ExpandCollapseCallOptions): void;
+		expandAllEdges(): void;
+
+		loadJson(json: string): void;
+		saveJson(eles: cytoscape.Collection, filename: string): void;
+	}
+
+	interface Core {
+		/**
+		 * Initialise the extension, or pass the literal string `'get'` to
+		 * retrieve the API of an already-initialised instance.
+		 */
+		expandCollapse(options: ExpandCollapseOptions | 'get'): ExpandCollapseApi;
+	}
+}
+
+declare module 'cytoscape-expand-collapse' {
+	const register: (cy: typeof cytoscape) => void;
+	export default register;
+}


### PR DESCRIPTION
Part 2 of #52. Types the cytoscape modules and gates them, following the green
baseline landed in #74.

## Result

All 70 `no-explicit-any` violations in the cytoscape modules are gone, and the
rule is now an **error** (not a warning) for those files, so the area cannot
regress.

| | before | after |
|---|---:|---:|
| `no-explicit-any`, cytoscape modules | 70 | **0** |
| `no-explicit-any`, rest of the tree | 32 | 32 (unchanged, part 3) |
| svelte-check errors | 0 | 0 |
| tests | 135 pass | 135 pass |

Per-file: `graph.svelte` 48 to 0, `graph_edges.ts` 15 to 0,
`graph_edges.svelte.test.ts` 5 to 0, plus one each in `graph_style.ts` and
`graph_node_selector.svelte`.

## Three new declaration files

- **`cytoscape-expand-collapse.d.ts`** - the plugin ships no types. The options
  interface is transcribed from its defaults block and the 28 API methods from
  the `api.*` assignments in `createExtensionAPI`. `cy.expandCollapse()` is
  declared on `Core`, so the `(cy as any)` at the init site is gone.
- **`cytoscape-elk.d.ts`** - same story, read from the plugin's `defaults.js`
  and `layout.js`. `createElkLayout` now returns `cytoscape.ElkLayoutOptions`
  and the two `as any` casts on `cy.layout(...)` are gone.
- **`cytoscape-augment.d.ts`** - `show()` and `hide()` are documented, shipped
  cytoscape API that its own `index.d.ts` omits entirely. Verified against
  cytoscape 3.33.2 at runtime before declaring them.

Each file says where its contents were read from, because hand-written plugin
types drift; a version bump should re-read the source.

## A dead layout option, found by the typing

The `as any` on the layout call was hiding it: `createElkLayout` passed an
`edgeLayoutOptions` callback that **cytoscape-elk never reads**. The string
appears nowhere in the package, and the layout consumes exactly two hooks,
`options.nodeLayoutOptions` and `options.elk`. There is no per-edge options hook
at all.

So the `"uses" straightness` slider in GraphLayoutPlayground, range 0-10, was a
live UI control wired to nothing, and the `INFORMATIONAL_EDGES` branch beside it
was equally inert. Both are deleted along with the `usesStraightness` param.
The rendered layout is byte-identical, because none of it ever ran. Restoring
the feature needs a plugin with a per-edge options hook, which this one does not
have.

## Other things the types surfaced

- **`.filter((n) => n.id() && ...)`** leaked `string | boolean` out of a
  predicate, because `id()` returns `''` for an unset id. Now an explicit
  comparison.
- **`SingularElementReturnValue` is an intersection, not a union**
  (`EdgeSingular & NodeSingular`), so an `isNode()` guard narrows the else branch
  to `never`. Two call sites were silently unreachable-typed; both now take the
  union.
- **`forEach` returning `Set.add`'s value** rather than void.
- **`parent.hasClass(...)`** called on a `NodeCollection`, where `hasClass` is a
  singular method. The existing length guard already proves the index is safe.
- **The expand-collapse API was being passed through `window`** between the mount
  and the update effect, in the same component. It is a component-scoped variable
  now, which removes two more casts.

## Casts that remain, and why

Two, both to precise types rather than `any`, each with the reasoning in a
comment:

- `getGraphStyle(...) as cytoscape.StylesheetJson` at the one point the
  stylesheet is handed to cytoscape. Cytoscape types every style property as a
  literal union (`'text-wrap'` must be `'none' | 'wrap' | 'ellipsis'`), which a
  480-line plain object table cannot satisfy without `as const` throughout. The
  function's own return type is now an explicit `GraphStylesheetBlock[]` instead
  of `any`, so a bad selector or style key still fails the build.
- `.map((e: cytoscape.EdgeSingular) => ...)` in one test helper, because
  cytoscape types `Collection.map`'s callback as `SingularElementArgument`,
  dropping the edge-only accessors.

One call site was rewritten rather than cast: cytoscape types `every()`/`some()`
with `CollectionArgument` where `filter()`/`map()` correctly use the element
type, so the `ancestors().every(...)` check uses `filter().length === 0`.

## Gating

`@typescript-eslint/no-explicit-any` is `error` for `src/types/**` and the six
cytoscape modules, while staying a warning elsewhere until part 3. I verified
the gate bites by planting an `any` in a listed file and confirming it fails.

## Not in this PR

The 32 remaining `any` outside the graph modules (API payloads in `ran_api.ts`
and `CampaignState`, `Record<string, any>` arg contexts, `showSaveFilePicker`).
Those need domain and API types, not cytoscape types, so they are their own
change. `svelte/require-each-key` (44) and `svelte/prefer-svelte-reactivity`
(25) remain parked.

## Verified

`pnpm lint` (0 errors), `pnpm check` (0 errors, 1233 files), `pnpm test`
(135 pass) and `pnpm build` all pass locally.

https://claude.ai/code/session_01JqYopyBtJ7s23Xq3wV6fWS
